### PR TITLE
FROM bug/538-fetch-threads-directly TO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.0.2
 
 ### Fixed
+  - bug/538-fetch-threads-directly (2025-12-02)
   - bug/536-error-search-threads-files (2025-12-01)
   - bug/518-on-new-token-is-broken (2025-11-29)
   - bug/516-fix-google-stop-reason-stream (2025-11-21)

--- a/backend/src/repos/thread_repo.py
+++ b/backend/src/repos/thread_repo.py
@@ -27,7 +27,16 @@ class ThreadRepo(BaseRepo):
             pass
         super().__init__(user_id=user_id, store=store, entity_type="threads")
         
-
+    def _format(self, item: SearchItem) -> ThreadSnapshot:
+        return ThreadSnapshot(
+            id=item.key,
+            messages=item.value.get("messages", []),
+            files=item.value.get("files", []),
+            todos=item.value.get("todos", []),
+            score=getattr(item, "score", None),
+            updated_at=getattr(item, "updated_at", None),
+        )
+        
     async def search(
         self,
         search_filter: SearchFilter,
@@ -102,7 +111,8 @@ class ThreadRepo(BaseRepo):
         
         
     async def get(self, thread_id: str) -> dict:
-        return await self._get(thread_id)
+        item = await self._get(thread_id)
+        return self._format(item)
         
     async def delete(self, thread_id: str) -> bool:
         try:

--- a/backend/src/routes/v0/thread.py
+++ b/backend/src/routes/v0/thread.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, Body, HTTPException, Depends, status
 from fastapi.responses import Response
 from langgraph.store.base import BaseStore
+from src.schemas.entities.store import ThreadSnapshot
 from src.contexts.service import ServiceContext
 from src.schemas.entities import SearchFilter, ThreadSemanticSearchRequest
 from src.utils.logger import logger
@@ -31,9 +32,14 @@ async def search_threads(
                 checkpoints = await service_context.checkpoint_service.list_checkpoints(
                     thread_id=search_filter.filter["thread_id"]
                 )
-                # if not checkpoints:
-                #     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Checkpoints not found")
+                thread: ThreadSnapshot = await service_context.thread_service.get(
+                    search_filter.filter["thread_id"]
+                )
+                if thread:
+                    checkpoints[0]['metadata']['files'] = thread.files
+                    checkpoints[0]['metadata']['todos'] = thread.todos
                 return {"checkpoints": checkpoints}
+                
 
             threads = await service_context.thread_service.search(search_filter)
             return {"threads": threads}

--- a/backend/src/schemas/entities/store.py
+++ b/backend/src/schemas/entities/store.py
@@ -36,7 +36,9 @@ class Project(BaseEntity):
 
 class ThreadSnapshot(BaseModel):
     id: str
-    messages: list[BaseMessage]
+    messages: list[Union[BaseMessage, dict]]
     files: Optional[Any] = None
-    score: float
+    todos: Optional[Any] = None
+    score: float | None = None
+    metadata: Optional[dict] = None
     updated_at: datetime

--- a/backend/src/services/checkpoint.py
+++ b/backend/src/services/checkpoint.py
@@ -44,7 +44,7 @@ class CheckpointService:
         return checkpoints
 
     @retry_db_operation(tries=3, delay=1, backoff=2, exceptions=(Exception,))
-    async def list_checkpoints(self, thread_id: str, limit: int = 20) -> list[StateSnapshot]:
+    async def list_checkpoints(self, thread_id: str, limit: int = 3) -> list[StateSnapshot]:
         try:
             config = RunnableConfig(configurable={"thread_id": thread_id})
             checkpoints = []


### PR DESCRIPTION
- init
- Fixes but prolly should reset caht wiwndow
Closes #538


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread fetching to retrieve threads directly.

* **New Features**
  * Enhanced thread search results with enriched metadata, now including associated files and todos.

* **Changes**
  * Adjusted default checkpoint retrieval limit from 20 to 3 per thread query.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->