### PR TITLE
feat: Remove web_search toggle from BaseToolMenu

### DIFF
--- a/frontend/src/components/menus/BaseToolMenu.tsx
+++ b/frontend/src/components/menus/BaseToolMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Plus, Globe, ShieldCheck, ShieldOff } from "lucide-react";
+import { Plus, ShieldCheck, ShieldOff } from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -18,8 +18,6 @@ export function BaseToolMenu() {
 	const {
 		agent,
 		setAgent,
-		webSearchCheck,
-		setWebSearchCheck,
 		piiAnalyzeCheck,
 		setPiiAnalyzeCheck,
 		piiAnonymizeCheck,
@@ -30,23 +28,6 @@ export function BaseToolMenu() {
 	useEffect(() => {
 		setAgent({ ...agent, tools: [...agent.tools, ...DEFAULT_AGENT_TOOLS] });
 	}, []);
-
-	useEffect(() => {
-		localStorage.setItem("enso:tool:search", JSON.stringify(webSearchCheck));
-		if (webSearchCheck) {
-			setAgent({
-				...agent,
-				tools: [...new Set([...agent.tools, ...DEFAULT_AGENT_TOOLS])],
-			});
-		} else {
-			setAgent({
-				...agent,
-				tools: agent.tools.filter(
-					(tool: string) => !DEFAULT_AGENT_TOOLS.includes(tool),
-				),
-			});
-		}
-	}, [webSearchCheck]);
 
 	return (
 		<DropdownMenu open={open}>
@@ -68,14 +49,9 @@ export function BaseToolMenu() {
 			>
 				<DropdownMenuGroup>
 					<ImageUpload />
-					<DropdownMenuSeparator className="h-px bg-muted-foreground/30" />
-					<DropdownMenuItem
-						onClick={() => setWebSearchCheck(!webSearchCheck)}
-						className="flex items-center gap-3 cursor-pointer text-base rounded-lg"
-					>
-						<Globe className="h-12 w-12" />
-						<span>Web Search {webSearchCheck ? "✅" : "🚫"}</span>
-					</DropdownMenuItem>
+					{localStorage.getItem("enso:checkbox:pii_analyze") && (
+						<DropdownMenuSeparator className="h-px bg-muted-foreground/30" />
+					)}
 					{localStorage.getItem("enso:checkbox:pii_analyze") && (
 						<DropdownMenuItem
 							onClick={() => setPiiAnalyzeCheck(!piiAnalyzeCheck)}


### PR DESCRIPTION
## Summary
- Removed the Web Search toggle menu item from the BaseToolMenu component
- Removed associated state management and effects for `webSearchCheck`
- Cleaned up the Globe icon import (no longer needed)
- Improved menu separator logic to only display when PII options are present

## Changes
- **File Modified:** `frontend/src/components/menus/BaseToolMenu.tsx`
  - Removed `webSearchCheck` state management
  - Removed `useEffect` hook for web_search tool toggling
  - Removed Web Search dropdown menu item
  - Fixed separator display logic

## Impact
- The `web_search` tool remains in `DEFAULT_AGENT_TOOLS` and is still automatically added to agent configurations
- Users can no longer toggle web_search on/off through the UI
- Net reduction of 24 lines of code

## Closes
Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)