### PR TITLE
FROM feat/582-ttft-counter TO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.0.2-rc121
 
 ### Changed
+  - feat/578-api-token-support (2025-12-14)
 
 ### Fixed
   - bug/575-api-docs-not-showing-in-docker (2025-12-14)

--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -205,11 +205,13 @@ export const Message = memo(
 									"Unknown model"}
 							</button>
 
-							{isLatest && streamingRate?.rate && (
+							{isLatest && streamingRate && (
 								<span
 									className={`text-sm text-muted-foreground/70 ${loading ? "animate-pulse" : ""}`}
 								>
-									{streamingRate.rate} tok/s • {streamingRate.count} tokens
+									{streamingRate.ttft !== null && `TTFT: ${streamingRate.ttft}ms`}
+									{streamingRate.ttft !== null && streamingRate.rate && " • "}
+									{streamingRate.rate && `${streamingRate.rate} chars/s • ${streamingRate.count.toLocaleString()} characters`}
 								</span>
 							)}
 						</div>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -250,22 +250,20 @@ export default function useChat(): ChatContextType {
 		setStreamingRate(null);
 	};
 
-	// Helper to update loading message with current metrics
-	const updateLoadingMessageWithMetrics = (
-		metrics: { ttft: number | null; rate: number | null } | null,
+	// Helper to update loading message with TTFT (only TTFT, not rate)
+	const updateLoadingMessageWithTTFT = (
+		ttft: number | null,
 		additionalText?: string,
 	) => {
-		if (!metrics) {
-			if (additionalText) setLoadingMessage(additionalText);
-			return;
-		}
-
 		const parts: string[] = [];
-		if (metrics.ttft !== null) parts.push(`TTFT: ${metrics.ttft}ms`);
-		if (metrics.rate !== null) parts.push(`${metrics.rate} chars/s`);
+		if (ttft !== null) parts.push(`TTFT: ${ttft}ms`);
 		if (additionalText) parts.push(additionalText);
 
-		setLoadingMessage(parts.join(" • "));
+		if (parts.length > 0) {
+			setLoadingMessage(parts.join(" • "));
+		} else if (additionalText) {
+			setLoadingMessage(additionalText);
+		}
 	};
 
 	const handleMessages = (payload: any, history: any[]) => {
@@ -358,8 +356,8 @@ export default function useChat(): ChatContextType {
 							rate: null,
 						};
 
-						// Update loading message to show TTFT immediately
-						updateLoadingMessageWithMetrics(newMetrics);
+						// Update loading message to show TTFT only (not rate)
+						updateLoadingMessageWithTTFT(ttft);
 
 						return newMetrics;
 					});
@@ -378,8 +376,10 @@ export default function useChat(): ChatContextType {
 							rate,
 						};
 
-						// Update loading message with streaming metrics
-						updateLoadingMessageWithMetrics(newMetrics);
+						// Keep TTFT in loading message (don't add rate here)
+						if (prev?.ttft !== null) {
+							updateLoadingMessageWithTTFT(prev.ttft);
+						}
 
 						return newMetrics;
 					});
@@ -395,16 +395,17 @@ export default function useChat(): ChatContextType {
 			// Handle Final Response & Tool Response
 			streamHandler.processResponse(response, expectedContent, existingIndex);
 
-			// Update loading message, preserving TTFT if available
+			// Update loading message, preserving TTFT (not rate)
 			setStreamingRate((prev: any) => {
 				if (streamHandler.toolNameRef.current) {
-					updateLoadingMessageWithMetrics(
-						prev,
+					// Show TTFT + tool name
+					updateLoadingMessageWithTTFT(
+						prev?.ttft ?? null,
 						`Calling ${streamHandler.toolNameRef.current} tool...`,
 					);
-				} else if (prev) {
-					// No tool call, just update with current metrics
-					updateLoadingMessageWithMetrics(prev);
+				} else if (prev?.ttft !== null) {
+					// No tool call, just show TTFT
+					updateLoadingMessageWithTTFT(prev.ttft);
 				}
 				return prev;
 			});

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -47,9 +47,11 @@ export type ChatContextType = {
 	};
 	setArcade: (arcade: { tools: string[]; toolkit: string[] }) => void;
 	streamingRate: {
-		count: number;
-		startTime: number;
+		submitTime: number | null;
+		firstTokenTime: number | null;
+		ttft: number | null;
 		rate: number | null;
+		count: number;
 	} | null;
 	filesMap: Map<string, any>;
 	setFilesMap: (map: Map<string, any>) => void;
@@ -86,9 +88,11 @@ export default function useChat(): ChatContextType {
 	const [controller, setController] = useState<AbortController | null>(null);
 
 	const [streamingRate, setStreamingRate] = useState<{
-		count: number;
-		startTime: number;
+		submitTime: number | null;
+		firstTokenTime: number | null;
+		ttft: number | null;
 		rate: number | null;
+		count: number;
 	} | null>(null);
 
 	const [arcade, setArcade] = useState({
@@ -105,6 +109,7 @@ export default function useChat(): ChatContextType {
 			controller.abort();
 			setController(null);
 		}
+		setStreamingRate(null);
 	};
 
 	const sseHandler = (payload: any, messages: any[]) => {
@@ -191,6 +196,14 @@ export default function useChat(): ChatContextType {
 	const handleSubmit = async (argQuery?: string, images: File[] = []) => {
 		setLoadingMessage("Request submitted...");
 		setLoading(true);
+		// Initialize metrics state with submit timestamp
+		setStreamingRate({
+			submitTime: Date.now(),
+			firstTokenTime: null,
+			ttft: null,
+			rate: null,
+			count: 0,
+		});
 		const { controller } = await handleSSE(argQuery || query, images);
 		setController(controller);
 		setQuery("");
@@ -234,6 +247,7 @@ export default function useChat(): ChatContextType {
 		setFilesMap(new Map());
 		setTodos([]);
 		setViewMode("chat");
+		setStreamingRate(null);
 	};
 
 	const handleMessages = (payload: any, history: any[]) => {
@@ -292,27 +306,38 @@ export default function useChat(): ChatContextType {
 			);
 
 			// Update streaming rate
+			// Note: count represents character count (not actual tokens)
 			if (
 				expectedContent &&
 				(!response.tool_call_chunks || response.tool_call_chunks.length === 0)
 			) {
 				if (existingIndex === -1) {
-					setStreamingRate({
-						count: expectedContent.length,
-						startTime: Date.now(),
-						rate: null,
-					});
-				} else {
+					// First chunk - calculate TTFT
 					setStreamingRate((prev: any) => {
 						const now = Date.now();
-						const startTime = prev?.startTime || now;
-						const newCount = (prev?.count || 0) + expectedContent.length;
-						const elapsed = (now - startTime) / 1000;
+						const submitTime = prev?.submitTime || now;
+						const ttft = now - submitTime;
 
 						return {
+							submitTime,
+							firstTokenTime: now,
+							ttft,
+							count: expectedContent.length,
+							rate: null,
+						};
+					});
+				} else {
+					// Subsequent chunks - update count and rate
+					setStreamingRate((prev: any) => {
+						const now = Date.now();
+						const firstTokenTime = prev?.firstTokenTime || now;
+						const newCount = (prev?.count || 0) + expectedContent.length;
+						const elapsed = (now - firstTokenTime) / 1000;
+
+						return {
+							...prev,
 							count: newCount,
-							startTime,
-							rate: elapsed > 0.1 ? Math.round(newCount / elapsed / 4) : null,
+							rate: elapsed > 0.1 ? Math.round(newCount / elapsed) : null,
 						};
 					});
 				}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -307,22 +307,39 @@ export default function useChat(): ChatContextType {
 
 			// Update streaming rate
 			// Note: count represents character count (not actual tokens)
-			if (
-				expectedContent &&
-				(!response.tool_call_chunks || response.tool_call_chunks.length === 0)
-			) {
+			// Track metrics for both content and tool calls to measure TTFT accurately
+			const hasContent = expectedContent && expectedContent.length > 0;
+			const hasToolCalls = response.tool_call_chunks && response.tool_call_chunks.length > 0;
+
+			// Calculate character count from both content and tool calls
+			let chunkCharCount = 0;
+			if (hasContent) {
+				chunkCharCount += expectedContent.length;
+			}
+			if (hasToolCalls) {
+				// Count characters from tool call chunks
+				response.tool_call_chunks.forEach((chunk: any) => {
+					if (chunk.name) chunkCharCount += chunk.name.length;
+					if (chunk.args) chunkCharCount += JSON.stringify(chunk.args).length;
+				});
+			}
+
+			if (chunkCharCount > 0) {
 				if (existingIndex === -1) {
-					// First chunk - calculate TTFT
+					// First chunk - calculate TTFT (from submit to first response, whether tool call or content)
 					setStreamingRate((prev: any) => {
 						const now = Date.now();
 						const submitTime = prev?.submitTime || now;
 						const ttft = now - submitTime;
 
+						// Update loading message to show TTFT
+						setLoadingMessage(`TTFT: ${ttft}ms`);
+
 						return {
 							submitTime,
 							firstTokenTime: now,
 							ttft,
-							count: expectedContent.length,
+							count: chunkCharCount,
 							rate: null,
 						};
 					});
@@ -331,13 +348,19 @@ export default function useChat(): ChatContextType {
 					setStreamingRate((prev: any) => {
 						const now = Date.now();
 						const firstTokenTime = prev?.firstTokenTime || now;
-						const newCount = (prev?.count || 0) + expectedContent.length;
+						const newCount = (prev?.count || 0) + chunkCharCount;
 						const elapsed = (now - firstTokenTime) / 1000;
+						const rate = elapsed > 0.1 ? Math.round(newCount / elapsed) : null;
+
+						// Update loading message with streaming metrics
+						if (rate && prev?.ttft) {
+							setLoadingMessage(`TTFT: ${prev.ttft}ms • ${rate} chars/s`);
+						}
 
 						return {
 							...prev,
 							count: newCount,
-							rate: elapsed > 0.1 ? Math.round(newCount / elapsed) : null,
+							rate,
 						};
 					});
 				}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -250,6 +250,24 @@ export default function useChat(): ChatContextType {
 		setStreamingRate(null);
 	};
 
+	// Helper to update loading message with current metrics
+	const updateLoadingMessageWithMetrics = (
+		metrics: { ttft: number | null; rate: number | null } | null,
+		additionalText?: string,
+	) => {
+		if (!metrics) {
+			if (additionalText) setLoadingMessage(additionalText);
+			return;
+		}
+
+		const parts: string[] = [];
+		if (metrics.ttft !== null) parts.push(`TTFT: ${metrics.ttft}ms`);
+		if (metrics.rate !== null) parts.push(`${metrics.rate} chars/s`);
+		if (additionalText) parts.push(additionalText);
+
+		setLoadingMessage(parts.join(" • "));
+	};
+
 	const handleMessages = (payload: any, history: any[]) => {
 		// console.log(payload);
 		const streamMode = payload[0];
@@ -327,41 +345,43 @@ export default function useChat(): ChatContextType {
 			if (chunkCharCount > 0) {
 				if (existingIndex === -1) {
 					// First chunk - calculate TTFT (from submit to first response, whether tool call or content)
+					const now = Date.now();
 					setStreamingRate((prev: any) => {
-						const now = Date.now();
 						const submitTime = prev?.submitTime || now;
 						const ttft = now - submitTime;
 
-						// Update loading message to show TTFT
-						setLoadingMessage(`TTFT: ${ttft}ms`);
-
-						return {
+						const newMetrics = {
 							submitTime,
 							firstTokenTime: now,
 							ttft,
 							count: chunkCharCount,
 							rate: null,
 						};
+
+						// Update loading message to show TTFT immediately
+						updateLoadingMessageWithMetrics(newMetrics);
+
+						return newMetrics;
 					});
 				} else {
 					// Subsequent chunks - update count and rate
+					const now = Date.now();
 					setStreamingRate((prev: any) => {
-						const now = Date.now();
 						const firstTokenTime = prev?.firstTokenTime || now;
 						const newCount = (prev?.count || 0) + chunkCharCount;
 						const elapsed = (now - firstTokenTime) / 1000;
 						const rate = elapsed > 0.1 ? Math.round(newCount / elapsed) : null;
 
-						// Update loading message with streaming metrics
-						if (rate && prev?.ttft) {
-							setLoadingMessage(`TTFT: ${prev.ttft}ms • ${rate} chars/s`);
-						}
-
-						return {
+						const newMetrics = {
 							...prev,
 							count: newCount,
 							rate,
 						};
+
+						// Update loading message with streaming metrics
+						updateLoadingMessageWithMetrics(newMetrics);
+
+						return newMetrics;
 					});
 				}
 			}
@@ -374,7 +394,21 @@ export default function useChat(): ChatContextType {
 
 			// Handle Final Response & Tool Response
 			streamHandler.processResponse(response, expectedContent, existingIndex);
-			setLoadingMessage(`Calling ${streamHandler.toolNameRef.current} tool...`);
+
+			// Update loading message, preserving TTFT if available
+			setStreamingRate((prev: any) => {
+				if (streamHandler.toolNameRef.current) {
+					updateLoadingMessageWithMetrics(
+						prev,
+						`Calling ${streamHandler.toolNameRef.current} tool...`,
+					);
+				} else if (prev) {
+					// No tool call, just update with current metrics
+					updateLoadingMessageWithMetrics(prev);
+				}
+				return prev;
+			});
+
 			setMessagesState(streamHandler.history);
 			if (streamHandler.streamStop(response)) {
 				setLoading(false);


### PR DESCRIPTION
## Summary
Fixes the TTFT (Time To First Token) counter implementation to provide accurate performance metrics for streaming AI responses.

### Changes
- **TTFT Measurement**: Captures request submission timestamp and calculates actual time-to-first-token in milliseconds
- **Rate Calculation Fix**: Removes unexplained `/4` divisor, now shows accurate characters per second
- **Accurate Labels**: Updates display from misleading "tok/s" to accurate "chars/s" and "characters"
- **Metrics Persistence**: Metrics now persist after streaming completes for user review
- **Proper Reset**: Metrics are correctly cleared when starting new messages or aborting streams

### Technical Details
**State Structure Enhancement:**
```typescript
streamingRate: {
  submitTime: number | null;      // When request was submitted
  firstTokenTime: number | null;  // When first chunk arrived  
  ttft: number | null;            // Calculated TTFT in ms
  rate: number | null;            // chars/second
  count: number;                  // Total characters
}
```

**TTFT Calculation:**
- Submit time captured in `handleSubmit()` before SSE starts
- First token time captured on first content chunk
- TTFT = firstTokenTime - submitTime

**Rate Calculation:**
- Previous: `Math.round(count / elapsed / 4)` ❌
- Now: `Math.round(count / elapsed)` ✅

**Display Format:**
- During streaming: `42 chars/s • 1,234 characters` (animated)
- After completion: `TTFT: 245ms • 42 chars/s • 1,234 characters` (static)

### Files Modified
- `frontend/src/hooks/useChat.ts`: Core metrics tracking logic
- `frontend/src/components/lists/ChatMessages.tsx`: Metrics display

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Time To First Token (TTFT) display for streamed responses to show when the first output arrives.
  * Streaming metrics now show TTFT alongside rate/tokens and appear only for the latest streaming response.

* **Changed**
  * Expanded streaming-performance tracking and messaging (initialization, updates, and resets) to provide richer timing, rate, and count visibility; streaming metrics are cleared on abort/clear.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->