### PR TITLE
FEAT: Render the `todos` state from useThread in Session (vibe-kanban)

### DIFF
--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -230,7 +230,7 @@ async def stream_generator(
                     if stream_type == "values" and "files" in chunk_data:
                         files_map = {**files_map, **chunk_data["files"]}
                     if stream_type == "values" and "todos" in chunk_data:
-                        todos_list = [*todos_list, *chunk_data["todos"]]
+                        todos_list = chunk_data["todos"]
                     data = ujson.dumps(stream_chunk)
                     log_to_file(str(data), agent.model) and APP_LOG_LEVEL == "DEBUG"
                     logger.debug(f"data: {str(data)}")

--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -12,6 +12,7 @@ import FileViewer from "../viewers/FileViewer";
 import { latestHumanMessage } from "@/lib/utils/message";
 import ToolTimeline from "../timeline/ToolTimeline";
 import TextSelectionPopover from "../popovers/TextSelectionPopover";
+import TodoList from "./TodoList";
 
 export const Message = memo(
 	function Message({
@@ -253,6 +254,7 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 		ttft,
 		submitStartTime,
 		appendToQuery,
+		todos,
 	} = useChatContext();
 	const [elapsedTime, setElapsedTime] = useState<number | null>(null);
 	const scrollRef = useRef<HTMLDivElement>(null);
@@ -421,6 +423,11 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 						);
 					})}
 				</div>
+				{todos && todos.length > 0 && (
+					<div className="max-w-4xl mx-auto px-5 mt-2 mb-2">
+						<TodoList todos={todos} />
+					</div>
+				)}
 				{loading && (
 					<div className="flex justify-start p-3 max-w-4xl mx-auto px-5">
 						<Loader2 className="h-5 w-5 animate-spin mx-2" />

--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -376,7 +376,7 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 			<div
 				ref={scrollRef}
 				onScroll={handleScroll}
-				className="flex-1 overflow-auto p-1 mb-1 pb-5"
+				className="flex-1 overflow-auto p-1 mb-1"
 			>
 				<div
 					ref={messagesContainerRef}

--- a/frontend/src/components/lists/TodoList.tsx
+++ b/frontend/src/components/lists/TodoList.tsx
@@ -1,0 +1,88 @@
+import { Circle, Loader2, CheckCircle2, ListTodo } from "lucide-react";
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/ui/accordion";
+import { cn } from "@/lib/utils/index";
+
+export interface Todo {
+	content: string;
+	status: "pending" | "in_progress" | "completed";
+	activeForm?: string;
+}
+
+interface TodoListProps {
+	todos: Todo[];
+	className?: string;
+}
+
+const statusConfig = {
+	pending: {
+		icon: Circle,
+		iconClass: "text-muted-foreground",
+		textClass: "",
+	},
+	in_progress: {
+		icon: Loader2,
+		iconClass: "text-blue-500 animate-spin",
+		textClass: "text-blue-500",
+	},
+	completed: {
+		icon: CheckCircle2,
+		iconClass: "text-green-500",
+		textClass: "text-muted-foreground line-through",
+	},
+};
+
+function TodoItem({ todo }: { todo: Todo }) {
+	const config = statusConfig[todo.status] || statusConfig.pending;
+	const Icon = config.icon;
+
+	return (
+		<div className="flex items-start gap-2 py-1.5">
+			<Icon className={cn("h-4 w-4 mt-0.5 shrink-0", config.iconClass)} />
+			<span className={cn("text-sm", config.textClass)}>{todo.content}</span>
+		</div>
+	);
+}
+
+export default function TodoList({ todos, className }: TodoListProps) {
+	if (!todos || todos.length === 0) {
+		return null;
+	}
+
+	const completedCount = todos.filter((t) => t.status === "completed").length;
+	const inProgressTodo = todos.find((t) => t.status === "in_progress");
+
+	return (
+		<Accordion type="single" collapsible className={cn("w-full", className)}>
+			<AccordionItem value="todos" className="border-border">
+				<AccordionTrigger className="hover:no-underline py-2">
+					<div className="flex items-center gap-2">
+						<ListTodo className="h-4 w-4 text-primary" />
+						<span className="text-sm font-medium">
+							Tasks ({todos.length})
+						</span>
+						<span className="text-xs text-muted-foreground">
+							{completedCount} of {todos.length} completed
+						</span>
+						{inProgressTodo && (
+							<span className="text-xs text-blue-500 ml-1 truncate max-w-[200px]">
+								{inProgressTodo.activeForm || inProgressTodo.content}
+							</span>
+						)}
+					</div>
+				</AccordionTrigger>
+				<AccordionContent>
+					<div className="space-y-0.5 px-1">
+						{todos.map((todo, index) => (
+							<TodoItem key={`${todo.content}-${index}`} todo={todo} />
+						))}
+					</div>
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -10,6 +10,7 @@ import apiClient from "@/lib/utils/apiClient";
 import { getAuthToken } from "@/lib/utils/auth";
 import { useAgentContext } from "@/context/AgentContext";
 import { StreamMessageHandler } from "@/lib/utils/message";
+import type { Todo } from "@/components/lists/TodoList";
 
 type StreamMode = "messages" | "values" | "updates" | "debug" | "tasks";
 
@@ -57,8 +58,8 @@ export type ChatContextType = {
 	} | null;
 	filesMap: Map<string, any>;
 	setFilesMap: (map: Map<string, any>) => void;
-	todos: any[];
-	setTodos: (todos: any[]) => void;
+	todos: Todo[];
+	setTodos: (todos: Todo[]) => void;
 	viewMode: "chat" | "editor";
 	setViewMode: (mode: "chat" | "editor") => void;
 	ttft: number | null;
@@ -110,7 +111,7 @@ export default function useChat(): ChatContextType {
 	});
 
 	const [filesMap, setFilesMap] = useState<Map<string, any>>(new Map());
-	const [todos, setTodos] = useState<any[]>([]);
+	const [todos, setTodos] = useState<Todo[]>([]);
 	const [viewMode, setViewMode] = useState<"chat" | "editor">("chat");
 	const [ttft, setTtft] = useState<number | null>(null);
 	const [submitStartTime, setSubmitStartTime] = useState<number | null>(null);

--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { searchThreads } from "@/lib/services/threadService";
 import { formatMessages } from "@/lib/utils/format";
 import { latestHumanMessage } from "@/lib/utils/message";
+import type { Todo } from "@/components/lists/TodoList";
 
 const LIMIT = 20;
 
@@ -9,7 +10,7 @@ export type ThreadData = {
 	checkpoints: any[];
 	messages: any[];
 	metadata: any;
-	todos: Record<string, any>;
+	todos: Todo[];
 	filesMap: Map<string, any>;
 	model: string;
 };
@@ -43,7 +44,7 @@ export type ThreadContextType = {
 			setMessages: (messages: any[]) => void;
 			setMetadata: (metadata: any) => void;
 			setFilesMap: (filesMap: Map<string, any>) => void;
-			setTodos: (todos: Record<string, any>) => void;
+			setTodos: (todos: Todo[]) => void;
 			setModel: (model: string) => void;
 		},
 	) => void;
@@ -91,11 +92,10 @@ export default function useThread(): ThreadContextType {
 				const latestCheckpoint = checkpointsData[0];
 				const threadData = latestCheckpoint.metadata || {};
 
-				// Extract todos
-				const todos =
-					threadData.todos && Object.keys(threadData.todos).length > 0
-						? threadData.todos
-						: {};
+				// Extract todos (backend sends as array)
+				const todos: Todo[] = Array.isArray(threadData.todos)
+					? threadData.todos
+					: [];
 
 				// Build filesMap
 				const filesMap = new Map<string, any>();
@@ -145,7 +145,7 @@ export default function useThread(): ThreadContextType {
 			setMessages: (messages: any[]) => void;
 			setMetadata: (metadata: any) => void;
 			setFilesMap: (filesMap: Map<string, any>) => void;
-			setTodos: (todos: Record<string, any>) => void;
+			setTodos: (todos: Todo[]) => void;
 			setModel: (model: string) => void;
 		},
 	) => {
@@ -159,9 +159,8 @@ export default function useThread(): ThreadContextType {
 					callbacks.setMessages(data.messages);
 					callbacks.setMetadata(data.metadata);
 					callbacks.setFilesMap(data.filesMap);
-					if (Object.keys(data.todos).length > 0) {
-						callbacks.setTodos(data.todos);
-					}
+					// Always set todos to clear stale data when switching threads
+					callbacks.setTodos(data.todos);
 					callbacks.setModel(data.model);
 				}
 			};


### PR DESCRIPTION
CONTEXT:

- Use Playwright MCP to do initial research.
- Default login: admin@example.com/test1234
- App ports (already running): frontend 5173 / backend 8000
- Test query: "Use todo list to plan out how return color of sky as one work."
- The current Todo list state is captured within orchestra/frontend/src/hooks/useThread.ts. Start from to branch out in your research.
- Should accentuate the chat session, not interfere.

FIRST ACTIONS TO DO:

- READ orchestra/.claude/commands/prime.md
- READ orchestra/.claude/commands/plan.md

GOAL:

Create a PLAN for rendering the todo list during the session when state exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo list integrated into the chat view, shown below messages when present.
  * Accordion-based task display with status indicators (pending, in progress, completed) and a completion summary.
  * Tasks now appear consistently across chat and thread views for clearer progress tracking.

* **Bug Fixes / Behaviour**
  * Streaming task updates now replace prior task lists rather than appending, avoiding duplicate or stale entries.

* **UI**
  * Minor spacing adjustment in chat message area for a tighter layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->