### PR TITLE
FEAT: Update README.md (out-of-sync)

### DIFF
--- a/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_ARCHITECT.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_ARCHITECT.md
@@ -1,0 +1,459 @@
+# PROPOSAL: ARCHITECT
+## GitHub Issue #680: Update README.md (out-of-sync)
+
+---
+
+## 1. EXECUTIVE SUMMARY
+
+The README.md requires targeted updates to remove deprecated Presidio documentation, add distributed worker environment variables, modernize development instructions with Makefile commands, and align database migration documentation with current tooling. This is a **documentation-only** change with **zero code impact** - the goal is to bring README.md into alignment with the actual codebase state after PRs #676 (Presidio removal) and #657 (distributed workers).
+
+---
+
+## 2. ARCHITECTURAL ANALYSIS
+
+### 2.1 Current State Assessment
+
+**README Structure Overview:**
+```
+README.md (466 lines)
+├── Header & Badges (1-33)
+├── Deployment Options (41-48)
+├── Table of Contents (51-57)
+├── Docker Deployment Quick (58-64)
+├── Prerequisites (66-70)
+├── Development Section (72-131)           ← NEEDS UPDATE
+│   ├── Environment Variables (74-86)
+│   ├── Docker Services (90-97)
+│   ├── Server Environment (99-118)        ← Manual commands, should use Makefile
+│   └── Client Environment (120-131)
+├── Database Migrations (133-171)          ← Manual alembic, should use Makefile
+├── Playwright MCP (173-188)
+├── Integrations (190-193)
+├── Roadmap (195-198)
+├── Enterprise (201-214)
+├── Docker Deployment Full (217-465)
+│   ├── Environment Variables (343-396)
+│   │   └── Services (Alpha) (380-386)     ← PRESIDIO REFERENCES - REMOVE
+│   └── ...rest
+```
+
+### 2.2 Issues Identified
+
+| Issue | Location | Severity | Impact |
+|-------|----------|----------|--------|
+| Presidio env vars documented | Lines 380-386 | HIGH | Confuses users with non-existent config |
+| Manual server setup commands | Lines 99-118 | MEDIUM | Missed opportunity for streamlined onboarding |
+| Manual migration commands | Lines 133-171 | MEDIUM | Inconsistent with Makefile patterns |
+| Missing distributed worker vars | Env var tables | MEDIUM | Users can't configure worker mode |
+| Duplicate Docker README content | Lines 217-465 vs `/docker/README.md` | LOW | Maintenance burden |
+
+### 2.3 Files Requiring Changes
+
+| File | Change Type | Scope |
+|------|-------------|-------|
+| `/README.md` | MODIFY | Primary target - all issues addressed here |
+| `/docker/README.md` | MODIFY | Remove Presidio, add distributed workers |
+| `/backend/README.md` | VERIFY | Check for Presidio references |
+
+### 2.4 Related Documentation State
+
+**CLAUDE.md already documents:**
+- `make test` - Run ALL test cases
+- `make format` - Format project files
+- `make dev` - Run dev server
+- `make seeds.user` - Seed default users
+
+**Backend Makefile provides:**
+- `make migrate.up` - Run all pending migrations
+- `make migrate.down` - Rollback one migration
+- `make migrate.history` - View migration history
+- `make migrate.revision` - Create new migration
+- `make dev.worker` - Run TaskIQ worker
+
+**Backend `.example.env` includes (from PR #657):**
+```bash
+## Distributed Workers (TaskIQ)
+REDIS_URL=redis://localhost:6379/0
+DISTRIBUTED_WORKERS=false
+```
+
+---
+
+## 3. IMPLEMENTATION STRATEGY
+
+### Phase 1: Remove Deprecated Presidio Documentation
+
+**Step 1.1: Remove from README.md (lines 380-386)**
+
+Current (to be removed):
+```markdown
+#### Services (Alpha)
+
+| Variable                  | Description                 | Default |
+| ------------------------- | --------------------------- | ------- |
+| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
+| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
+| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+```
+
+**Step 1.2: Remove from docker/README.md (lines 190-197)**
+
+Same Presidio section exists in the docker-specific README.
+
+### Phase 2: Add Distributed Worker Documentation
+
+**Step 2.1: Add new environment variable section**
+
+Add after "Storage" section in README.md:
+```markdown
+#### Distributed Workers (Optional)
+
+| Variable              | Description                           | Default     |
+| --------------------- | ------------------------------------- | ----------- |
+| `REDIS_URL`           | Redis connection for worker queue     | -           |
+| `DISTRIBUTED_WORKERS` | Enable distributed LLM execution      | `false`     |
+
+> **Note**: Distributed workers require Redis and TaskIQ. Use `make dev.worker` to start a worker process locally.
+```
+
+### Phase 3: Modernize Development Section
+
+**Step 3.1: Add Makefile commands table**
+
+Insert after "Setup Server Environment" section header:
+```markdown
+### Common Development Commands
+
+| Command           | Description                        |
+|-------------------|------------------------------------|
+| `make dev`        | Start backend server (port 8000)   |
+| `make test`       | Run all backend tests              |
+| `make format`     | Format code with Ruff              |
+| `make seeds.user` | Seed default users                 |
+| `make migrate.up` | Apply all pending migrations       |
+
+For a complete list, see `backend/Makefile`.
+```
+
+**Step 3.2: Streamline server setup instructions**
+
+Update the server setup to prefer Makefile while keeping manual commands as reference:
+```markdown
+**Using Makefile (Recommended):**
+```bash
+cd backend
+make dev
+```
+
+**Manual Setup (if needed):**
+[existing commands retained for reference]
+```
+
+### Phase 4: Modernize Database Migrations Section
+
+**Step 4.1: Replace manual alembic commands with Makefile**
+
+Update "Database Migrations" section:
+```markdown
+## Database Migrations
+
+### Using Makefile (Recommended)
+
+```bash
+cd backend
+
+# Apply all migrations
+make migrate.up
+
+# Rollback one migration
+make migrate.down
+
+# View migration history
+make migrate.history
+
+# Create new migration
+make migrate.revision
+```
+
+### Seeding Initial Data
+
+```bash
+make seeds.user
+```
+```
+
+---
+
+## 4. DESIGN DECISIONS
+
+### 4.1 Trade-offs Considered
+
+| Decision | Alternative | Rationale |
+|----------|-------------|-----------|
+| Keep manual commands as fallback | Remove entirely | Some users may need flexibility or be debugging |
+| Add distributed workers to README | Separate WORKERS.md | Workers are production-relevant; single README preferred |
+| Mirror changes to docker/README.md | Only update root README | Docker README is bundled into image; must stay in sync |
+
+### 4.2 Why This Approach
+
+1. **Single Source of Truth**: CLAUDE.md already documents Makefile commands; README should align
+2. **Backward Compatibility**: Manual commands remain for users who need them
+3. **Progressive Enhancement**: Distributed workers documented but marked optional
+4. **Consistency**: All env var tables follow same markdown format
+
+### 4.3 Alignment with Codebase Patterns
+
+- **CLAUDE.md Convention**: Development commands use Makefile (this proposal extends that pattern to README)
+- **Env Var Tables**: Existing format with Variable | Description | Default columns preserved
+- **Section Headers**: Existing emoji + title format maintained (e.g., "## :tools: Development")
+
+---
+
+## 5. RISK ASSESSMENT
+
+### 5.1 Low-Risk Factors
+
+1. **Documentation Only**: No code changes = no runtime risk
+2. **Additive Changes**: New sections don't break existing workflows
+3. **Clear Precedent**: CLAUDE.md already establishes Makefile pattern
+4. **Tested Configuration**: `.example.env` already contains worker vars
+
+### 5.2 Potential Pitfalls
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Broken markdown formatting | Low | Preview rendered output before commit |
+| Outdated info in docker/README.md | Medium | Update both files in same PR |
+| Missing Presidio reference elsewhere | Low | Grep for "presidio" across all .md files |
+| Line number drift from concurrent PRs | Medium | Use text patterns, not line numbers |
+
+### 5.3 Testing Considerations
+
+- **Manual Review**: Render README.md in GitHub preview
+- **Link Verification**: Ensure all internal anchor links work
+- **Grep Verification**: `grep -ri "presidio" *.md` should return no results after changes
+
+---
+
+## 6. ESTIMATED COMPLEXITY
+
+### Scope: **SMALL**
+
+| Metric | Value |
+|--------|-------|
+| Files to modify | 2 (README.md, docker/README.md) |
+| Sections to add | 2 (Distributed Workers, Makefile commands) |
+| Sections to remove | 1 (Services Alpha / Presidio) |
+| Sections to rewrite | 2 (Development, Database Migrations) |
+| Total lines changed | ~80-100 |
+
+### Risk Level: **LOW**
+
+- No code changes
+- No database migrations
+- No breaking API changes
+- Purely documentation synchronization
+
+### Suggested Priority Order
+
+1. **P1 (Must Have)**: Remove Presidio documentation (lines 380-386)
+2. **P1 (Must Have)**: Update docker/README.md to mirror changes
+3. **P2 (Should Have)**: Add Distributed Workers environment variables
+4. **P3 (Nice to Have)**: Modernize Development section with Makefile commands
+5. **P3 (Nice to Have)**: Modernize Database Migrations section
+
+---
+
+## 7. DETAILED CHANGE SPECIFICATIONS
+
+### 7.1 README.md Changes
+
+#### Change 1: Remove Services (Alpha) Section (Lines 380-386)
+
+**Before:**
+```markdown
+#### Services (Alpha)
+
+| Variable                  | Description                 | Default |
+| ------------------------- | --------------------------- | ------- |
+| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
+| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
+| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+```
+
+**After:** (section deleted entirely)
+
+#### Change 2: Add Distributed Workers Section (After Storage)
+
+**Insert after line ~396:**
+```markdown
+#### Distributed Workers (Optional)
+
+| Variable              | Description                           | Default     |
+| --------------------- | ------------------------------------- | ----------- |
+| `REDIS_URL`           | Redis connection for task queue       | -           |
+| `DISTRIBUTED_WORKERS` | Enable distributed agent execution    | `false`     |
+
+> **Note**: Distributed workers enable horizontal scaling of LLM workloads. Requires Redis and a worker process (`make dev.worker`).
+```
+
+#### Change 3: Add Makefile Commands Reference (After line ~72)
+
+**Insert after "## Development" header:**
+```markdown
+### Quick Reference
+
+| Command           | Description                        |
+|-------------------|------------------------------------|
+| `make dev`        | Start backend server (port 8000)   |
+| `make dev.worker` | Start TaskIQ worker                |
+| `make test`       | Run all backend tests              |
+| `make format`     | Format code with Ruff              |
+| `make seeds.user` | Seed default users                 |
+| `make migrate.up` | Apply all pending migrations       |
+
+For all available commands, see `backend/Makefile`.
+```
+
+#### Change 4: Simplify Development Server Setup (Lines 99-118)
+
+**Current (verbose manual commands):**
+```markdown
+3. **Setup Server Environment**
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation). See `./backend/scripts` directory for other dev utilities.
+
+    ```bash
+    # Change directory
+    cd <project-root>/backend
+
+    # Generate virtualenv
+    uv venv
+
+    # Activate
+    source .venv/bin/activate
+
+    # Install
+    uv sync
+
+    # Run
+    bash scripts/dev.sh # Select "no" when prompted.
+    ```
+```
+
+**Proposed (Makefile-first with manual fallback):**
+```markdown
+3. **Setup Server Environment**
+
+    ```bash
+    cd <project-root>/backend
+    make dev
+    ```
+
+    <details>
+    <summary>Manual setup (if Makefile unavailable)</summary>
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation).
+
+    ```bash
+    cd <project-root>/backend
+    uv venv
+    source .venv/bin/activate
+    uv sync
+    bash scripts/dev.sh
+    ```
+    </details>
+```
+
+#### Change 5: Modernize Database Migrations Section (Lines 133-171)
+
+**Proposed update:**
+```markdown
+## Database Migrations
+
+This project uses Alembic for database migrations. The Makefile provides convenient commands.
+
+### Apply Migrations
+
+```bash
+cd backend
+
+# Apply all pending migrations
+make migrate.up
+
+# Apply next migration only
+make migrate.upgrade
+```
+
+### Rollback Migrations
+
+```bash
+# Rollback one migration
+make migrate.down
+```
+
+### Create New Migration
+
+```bash
+make migrate.revision
+# Edit the generated file in migrations/versions/
+```
+
+### View Migration History
+
+```bash
+make migrate.history
+```
+
+### Seed Initial Data
+
+```bash
+make seeds.user
+```
+
+<details>
+<summary>Manual Alembic commands (advanced)</summary>
+
+```bash
+# Direct alembic commands (requires env file setup)
+alembic upgrade head
+alembic downgrade -1
+alembic history
+alembic revision -m "description_of_changes"
+```
+</details>
+```
+
+### 7.2 docker/README.md Changes
+
+#### Change 1: Remove Services (Alpha) Section (Lines 190-197)
+
+Same removal as README.md - delete the Presidio environment variable table.
+
+#### Change 2: Add Distributed Workers Section
+
+Same addition as README.md - add after Storage section.
+
+---
+
+## 8. VERIFICATION CHECKLIST
+
+After implementation, verify:
+
+- [ ] `grep -ri "presidio" *.md` returns no results in README files
+- [ ] README.md renders correctly in GitHub preview
+- [ ] docker/README.md renders correctly in GitHub preview
+- [ ] All internal anchor links work
+- [ ] Makefile commands match what's documented
+- [ ] Environment variables match `.example.env`
+
+---
+
+## 9. APPENDIX: ALIGNMENT MATRIX
+
+| User Story | Addressed By |
+|------------|--------------|
+| Story 1: Remove Presidio Documentation | Change 1 (both files) |
+| Story 2: Document Makefile Commands | Change 3 |
+| Story 3: Modernize Development Setup | Change 4, Change 5 |
+| Story 4: Document Distributed Workers | Change 2 (both files) |

--- a/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_CRAFTSMAN.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_CRAFTSMAN.md
@@ -1,0 +1,404 @@
+# PROPOSAL: Update README.md (Out-of-Sync) - Issue #680
+
+## Agent: THE CRAFTSMAN
+**Expertise Focus:** Clean Code, Maintainability, SOLID Principles Applied to Documentation
+
+---
+
+## 1. Executive Summary
+
+The README.md documentation has drifted out of sync with the actual codebase following PR #676 (Presidio removal) and PR #657 (distributed workers). This proposal recommends a targeted, maintainable update that:
+
+1. **Removes obsolete Presidio references** from the environment variables documentation
+2. **Adds distributed worker configuration** to align with the new `.example.env` and docker-compose.yml
+3. **Streamlines development instructions** by promoting Makefile commands as the primary interface
+4. **Ensures alignment** between README.md, docker/README.md, backend/README.md, and CLAUDE.md
+
+---
+
+## 2. Architectural Analysis
+
+### 2.1 Current State Assessment
+
+#### Files Requiring Updates
+
+| File | Issue | Lines Affected |
+|------|-------|----------------|
+| `README.md` | Contains obsolete "Services (Alpha)" Presidio section | 380-386 |
+| `README.md` | Missing distributed worker env vars (REDIS_URL, DISTRIBUTED_WORKERS) | N/A (need to add) |
+| `README.md` | Development section uses verbose manual commands | 99-131 |
+| `docker/README.md` | Contains same obsolete Presidio section | 190-196 |
+| `backend/README.md` | Identical to root README.md (copied during build) | Same as root |
+
+#### Documentation Hierarchy
+
+```
+CLAUDE.md (AI Agent source of truth)
+    |
+    +-- README.md (Human developer primary reference)
+    |       |
+    |       +-- Duplicated to backend/README.md during docker build
+    |
+    +-- docker/README.md (Docker-specific deployment guide)
+```
+
+**Key Insight:** `backend/README.md` is auto-generated from either `README.md` or `docker/README.md` via `scripts/build.sh`. Only `README.md` and `docker/README.md` need direct updates.
+
+### 2.2 Proposed Changes
+
+#### A. Remove Presidio References (Breaking Change from PR #676)
+
+The Presidio service has been completely removed and replaced by PIIMiddleware, which requires no user configuration. The "Services (Alpha)" section is now obsolete.
+
+**Current (README.md lines 380-386):**
+```markdown
+#### Services (Alpha)
+
+| Variable                  | Description                 | Default |
+| ------------------------- | --------------------------- | ------- |
+| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
+| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
+| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+```
+
+**Proposed:** Remove this section entirely. PII handling is now automatic via middleware.
+
+#### B. Add Distributed Workers Configuration (New Feature from PR #657)
+
+The `.example.env` now includes worker configuration that should be documented:
+
+**Proposed new section (replace "Services (Alpha)"):**
+```markdown
+#### Distributed Workers (Optional)
+
+| Variable              | Description                              | Default   |
+| --------------------- | ---------------------------------------- | --------- |
+| `REDIS_URL`           | Redis connection URL for worker queue    | -         |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode           | `false`   |
+```
+
+#### C. Streamline Development Instructions (Maintainability)
+
+**Current Problem:** The development section (lines 99-131) uses verbose manual commands that duplicate Makefile functionality and are harder to maintain.
+
+**Proposed Enhancement:** Restructure to highlight Makefile commands while preserving manual commands for advanced users.
+
+**Current (lines 99-118):**
+```markdown
+3. **Setup Server Environment**
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation). See `./backend/scripts` directory for other dev utilities.
+
+    ```bash
+    # Change directory
+    cd <project-root>/backend
+
+    # Generate virtualenv
+    uv venv
+
+    # Activate
+    source .venv/bin/activate
+
+    # Install
+    uv sync
+
+    # Run
+    bash scripts/dev.sh # Select "no" when prompted.
+    ```
+```
+
+**Proposed:**
+```markdown
+3. **Setup Server Environment**
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation).
+
+    ```bash
+    cd <project-root>/backend
+
+    # Option A: Quick Start (Recommended)
+    make dev  # Starts dev server on port 8000
+
+    # Option B: Manual Setup
+    uv venv && source .venv/bin/activate && uv sync
+    bash scripts/dev.sh
+    ```
+
+    **Common Backend Commands:**
+
+    | Command           | Description                    |
+    |-------------------|--------------------------------|
+    | `make dev`        | Run dev server on port 8000    |
+    | `make test`       | Run all tests                  |
+    | `make format`     | Format code with Ruff          |
+    | `make seeds.user` | Seed default users             |
+```
+
+### 2.3 Integration Points and Dependencies
+
+| Dependency | Impact | Action Required |
+|------------|--------|-----------------|
+| `backend/.example.env` | Already updated in PR #657 | No action (source of truth for env vars) |
+| `docker-compose.yml` | Already includes worker/redis services | Document in README |
+| `CLAUDE.md` | Already documents Makefile commands | Align README with CLAUDE.md |
+| `docker/README.md` | Mirrors root README structure | Apply same Presidio removal |
+
+---
+
+## 3. Implementation Strategy
+
+### 3.1 Step-by-Step Implementation Plan
+
+#### Phase 1: Remove Obsolete Content (Priority: High)
+
+**Step 1.1:** Edit `README.md` lines 380-386 - Remove "Services (Alpha)" section
+
+**Step 1.2:** Edit `docker/README.md` lines 190-196 - Remove matching "Services (Alpha)" section
+
+**Step 1.3:** Verify no other Presidio references exist in README files
+```bash
+grep -i "presidio" README.md docker/README.md
+# Expected: No matches
+```
+
+#### Phase 2: Add Distributed Workers Section (Priority: Medium)
+
+**Step 2.1:** In `README.md`, replace the removed "Services (Alpha)" section (after line 378) with:
+
+```markdown
+#### Distributed Workers (Optional)
+
+For high-throughput deployments, Orchestra supports distributed worker mode using Redis and TaskIQ.
+
+| Variable              | Description                              | Default   |
+| --------------------- | ---------------------------------------- | --------- |
+| `REDIS_URL`           | Redis connection URL for worker queue    | -         |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode           | `false`   |
+
+> **Note:** When `DISTRIBUTED_WORKERS=true`, ensure Redis is available and run the worker process separately:
+> ```bash
+> make dev.worker  # In a separate terminal
+> ```
+```
+
+**Step 2.2:** Apply the same addition to `docker/README.md` after removing Presidio section
+
+**Step 2.3:** Update docker-compose services table to include `redis` and `worker`:
+
+In `README.md` around line 278, add:
+```markdown
+| `redis`         | 6379      | Redis message broker (for workers)     |
+| `worker`        | -         | TaskIQ worker (no external port)       |
+```
+
+#### Phase 3: Streamline Development Section (Priority: Low)
+
+**Step 3.1:** Update "Setup Server Environment" section (lines 99-118) to promote Makefile commands
+
+**Step 3.2:** Add a condensed "Common Commands" table after the setup instructions
+
+**Step 3.3:** Align "Database Migrations" section (lines 133-171) to reference Makefile commands:
+
+**Current (verbose Alembic commands):**
+```markdown
+### Initial Setup
+
+1. Create the database (if not exists):
+
+    ```bash
+    cd backend
+    alembic upgrade head
+    ```
+```
+
+**Proposed (Makefile-first):**
+```markdown
+### Initial Setup
+
+1. Apply all migrations:
+
+    ```bash
+    cd backend
+    make migrate.up  # or: alembic upgrade head
+    ```
+```
+
+### 3.2 File Changes Summary
+
+| File | Change Type | Lines | Description |
+|------|-------------|-------|-------------|
+| `README.md` | DELETE | 380-386 | Remove "Services (Alpha)" section |
+| `README.md` | INSERT | ~380 | Add "Distributed Workers" section |
+| `README.md` | UPDATE | ~278-286 | Add redis/worker to services table |
+| `README.md` | UPDATE | 99-118 | Streamline server setup with Makefile |
+| `README.md` | UPDATE | 133-171 | Update migration docs to use Makefile |
+| `docker/README.md` | DELETE | 190-196 | Remove "Services (Alpha)" section |
+| `docker/README.md` | INSERT | ~190 | Add "Distributed Workers" section |
+
+### 3.3 Key Patterns to Follow
+
+1. **Table Format Consistency:** Use the existing markdown table alignment style with `|` padding
+2. **Code Block Style:** Use triple-backtick with language hints (bash, yaml, markdown)
+3. **Section Headers:** Use `####` for subsections within the Environment Variables section
+4. **Note Blocks:** Use `> **Note:**` for callouts
+5. **Cross-Reference Style:** Link to other sections using `#-section-name` anchors
+
+---
+
+## 4. Design Decisions
+
+### 4.1 Trade-offs Considered
+
+| Decision | Alternative Considered | Why This Approach |
+|----------|------------------------|-------------------|
+| **Remove Presidio entirely** vs comment it out | Keep section with "deprecated" note | Clean removal follows YAGNI - obsolete docs cause confusion |
+| **Add Worker docs to README** vs separate doc | Create new WORKERS.md | Keep entry point simple; advanced users can reference docker-compose.yml |
+| **Promote Makefile** vs keep manual commands | Only show Makefile commands | Balance: Show Makefile first, keep manual for flexibility |
+| **Update both README.md and docker/README.md** | Only update root README | Consistency across all entry points prevents confusion |
+
+### 4.2 Why This Approach Over Alternatives
+
+**Single Responsibility (Documentation SOLID):**
+- README.md = Quick start + development overview
+- docker/README.md = Docker-specific deployment details
+- CLAUDE.md = AI agent reference (already well-structured)
+
+**DRY Principle:**
+- The Makefile encapsulates common commands
+- Documentation should point to Makefile rather than duplicate command logic
+- When Makefile commands change, only Makefile and CLAUDE.md need updates
+
+**Open/Closed Principle:**
+- New features (workers) are added as new sections, not modifications to existing sections
+- Removal of features (Presidio) cleanly removes entire sections
+
+### 4.3 Alignment with Existing Codebase Patterns
+
+- **Markdown Style:** Follows existing heading hierarchy (##, ###, ####)
+- **Table Alignment:** Matches existing pipe-aligned tables
+- **Code Examples:** Uses existing bash code block pattern with comments
+- **Variable Documentation:** Follows Variable | Description | Default pattern
+
+---
+
+## 5. Risk Assessment
+
+### 5.1 Potential Pitfalls
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Missing Presidio reference elsewhere** | Low | Low | Grep verification after changes |
+| **Breaking docker build** | Very Low | Medium | backend/README.md is copied from docker/README.md during build; verify build script |
+| **Inconsistency between files** | Medium | Low | Update both README.md and docker/README.md in same commit |
+| **Worker docs premature** | Low | Low | Mark as "Optional" and reference docker-compose for full config |
+
+### 5.2 Edge Cases to Handle
+
+1. **Users with existing .env files containing PRESIDIO vars:**
+   - These vars are now no-ops; no action needed
+   - Consider adding migration note: "PRESIDIO_* variables can be safely removed"
+
+2. **Users running older docker-compose without redis:**
+   - Workers are optional; document as enhancement, not requirement
+   - `DISTRIBUTED_WORKERS=false` (default) works without Redis
+
+3. **CI/CD pipelines referencing old env vars:**
+   - Workflows already updated in PR #657
+   - README update is documentation catch-up only
+
+### 5.3 Testing Considerations
+
+| Test Type | Approach |
+|-----------|----------|
+| **Link Validation** | Verify all anchor links resolve correctly |
+| **Markdown Lint** | Run markdownlint to catch formatting issues |
+| **Visual Review** | Preview rendered markdown on GitHub before merge |
+| **Grep Verification** | `grep -i presidio README.md docker/README.md` should return empty |
+| **Build Test** | Run `bash backend/scripts/build.sh` to verify no README-related errors |
+
+---
+
+## 6. Estimated Complexity
+
+| Metric | Assessment |
+|--------|------------|
+| **Scope** | **Small** - Documentation-only changes to 2 files |
+| **Risk Level** | **Low** - No code changes, only documentation |
+| **Estimated Time** | 30-45 minutes for implementation |
+| **Review Effort** | Low - Straightforward line-by-line comparison |
+
+### 6.1 Suggested Priority Order
+
+1. **P0 (Must-Have):** Remove Presidio section from README.md and docker/README.md
+2. **P1 (Should-Have):** Add Distributed Workers section
+3. **P1 (Should-Have):** Update docker-compose services table with redis/worker
+4. **P2 (Nice-to-Have):** Streamline development section with Makefile commands
+5. **P2 (Nice-to-Have):** Update migration section with Makefile references
+
+### 6.2 Minimal Viable Change
+
+If time-constrained, the absolute minimum change is:
+- Delete lines 380-386 in README.md (Presidio section)
+- Delete lines 190-196 in docker/README.md (Presidio section)
+
+This removes the documented-but-nonexistent feature, preventing user confusion.
+
+---
+
+## 7. Verification Checklist
+
+After implementation, verify:
+
+- [ ] `grep -i presidio README.md docker/README.md` returns no matches
+- [ ] `grep -i "REDIS_URL\|DISTRIBUTED_WORKERS" README.md` returns matches in new section
+- [ ] Markdown renders correctly in GitHub preview
+- [ ] All internal anchor links work (#-section-name)
+- [ ] `bash backend/scripts/build.sh` completes without errors
+- [ ] CLAUDE.md remains aligned (already correct - no changes needed)
+- [ ] `.example.env` already has correct variables (verified - no changes needed)
+
+---
+
+## 8. Appendix: Diff Preview
+
+### README.md - Remove Presidio (lines 380-386)
+
+```diff
+-#### Services (Alpha)
+-
+-| Variable                  | Description                 | Default |
+-| ------------------------- | --------------------------- | ------- |
+-| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
+-| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
+-| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
++#### Distributed Workers (Optional)
++
++For high-throughput deployments, Orchestra supports distributed worker mode using Redis and TaskIQ.
++
++| Variable              | Description                              | Default   |
++| --------------------- | ---------------------------------------- | --------- |
++| `REDIS_URL`           | Redis connection URL for worker queue    | -         |
++| `DISTRIBUTED_WORKERS` | Enable distributed worker mode           | `false`   |
++
++> **Note:** When `DISTRIBUTED_WORKERS=true`, ensure Redis is available and run the worker process separately:
++> ```bash
++> make dev.worker  # In a separate terminal
++> ```
+```
+
+### README.md - Services Table Update (around line 286)
+
+```diff
+ | `search_engine` | 8080      | SearXNG search engine              |
+ | `exec_server`   | 3005      | Shell execution server             |
+ | `ollama`        | 11434     | Local LLM inference (requires GPU) |
++| `redis`         | 6379      | Redis message broker (for workers) |
++| `worker`        | -         | TaskIQ worker (no exposed port)    |
+```
+
+---
+
+**Prepared by:** THE CRAFTSMAN
+**Date:** 2026-01-16
+**Issue Reference:** GitHub Issue #680
+**Related PRs:** #676 (Presidio removal), #657 (Distributed workers)

--- a/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_GUARDIAN.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/PROPOSAL_GUARDIAN.md
@@ -1,0 +1,398 @@
+# PROPOSAL: GUARDIAN
+## GitHub Issue #680: Update README.md (Out-of-Sync)
+
+**Author**: AGENT_3: THE GUARDIAN
+**Expertise Lens**: Security, Error Handling, Edge Cases, Testing
+**Date**: 2026-01-16
+
+---
+
+## 1. Executive Summary
+
+The README.md contains outdated environment variable documentation for Presidio services that no longer exist (removed in PR #676), creating a security anti-pattern where developers may waste time configuring deprecated services while missing the actual PIIMiddleware that provides automatic PII protection. This proposal recommends surgically removing the obsolete Presidio section, adding documentation for the new distributed worker environment variables (PR #657), and modernizing the development section to leverage Makefile commands for reduced onboarding friction and fewer configuration errors.
+
+---
+
+## 2. Architectural Analysis
+
+### 2.1 Current State Assessment
+
+#### Security Concerns Identified
+
+| Issue | Severity | Impact |
+|-------|----------|--------|
+| **Ghost configuration** - Presidio env vars documented but service removed | MEDIUM | Developers may create `.env` entries for non-existent services, potentially exposing configuration habits |
+| **Hidden security feature** - PIIMiddleware not documented | LOW | Developers unaware that credit card masking and API key blocking is automatic |
+| **Missing distributed worker vars** - REDIS_URL, DISTRIBUTED_WORKERS undocumented | LOW | Production deployments may fail silently |
+| **Stale migration commands** - Manual alembic vs Makefile | LOW | More error-prone manual approach documented |
+
+#### Files With Outdated Documentation
+
+| File | Issue | Lines Affected |
+|------|-------|----------------|
+| `/README.md` | Presidio env vars table | Lines 380-386 |
+| `/backend/README.md` | Same content duplicated | Lines 380-386 |
+| `/docker/README.md` | Same content duplicated | Lines 190-196 |
+
+#### Source of Truth Comparison
+
+| Configuration | `.example.env` | `README.md` | Status |
+|---------------|----------------|-------------|--------|
+| PRESIDIO_ANALYZE_HOST | Commented out | Documented | **OUT OF SYNC** |
+| PRESIDIO_ANONYMIZE_HOST | Commented out | Documented | **OUT OF SYNC** |
+| PRESIDIO_API_KEY | Commented out | Documented | **OUT OF SYNC** |
+| REDIS_URL | Present | Missing | **OUT OF SYNC** |
+| DISTRIBUTED_WORKERS | Present | Missing | **OUT OF SYNC** |
+
+### 2.2 Proposed Changes
+
+#### Change 1: Remove Presidio Documentation
+
+**Rationale**: The Presidio service was completely removed in PR #676. The PIIMiddleware in `/backend/src/utils/middleware.py` now handles PII protection automatically via:
+- Credit card masking (`strategy="mask"`)
+- API key blocking (`strategy="block"` with regex `sk-[A-Za-z0-9]+`)
+
+Documenting removed configuration creates security anti-patterns where developers expect to configure external services when protection is already built-in.
+
+#### Change 2: Add Distributed Worker Documentation (Optional Section)
+
+**Rationale**: PR #657 introduced TaskIQ-based distributed workers. The `.example.env` already contains:
+```bash
+## Distributed Workers (TaskIQ)
+REDIS_URL=redis://localhost:6379/0
+DISTRIBUTED_WORKERS=false
+```
+
+For production scalability, operators need this documented.
+
+#### Change 3: Modernize Development Commands
+
+**Rationale**: The Makefile provides standardized commands that reduce:
+- Environment configuration errors
+- Inconsistent development setups
+- Onboarding time for new developers
+
+Current README uses manual `alembic` commands while `backend/CLAUDE.md` and the Makefile provide cleaner alternatives.
+
+### 2.3 Integration Points and Dependencies
+
+| Component | Dependency | Risk |
+|-----------|------------|------|
+| README.md | None | No code changes |
+| backend/README.md | README.md | Keep in sync |
+| docker/README.md | README.md | Keep in sync |
+| .example.env | Already updated | Source of truth |
+| CLAUDE.md | Already correct | Reference only |
+
+---
+
+## 3. Implementation Strategy
+
+### Step-by-Step Plan
+
+#### Phase 1: Remove Presidio Section (All READMEs)
+
+**File**: `/README.md`
+**Action**: Remove lines 380-386 (Services Alpha table)
+
+```markdown
+<!-- REMOVE THIS ENTIRE SECTION -->
+#### Services (Alpha)
+
+| Variable                  | Description                 | Default |
+| ------------------------- | --------------------------- | ------- |
+| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
+| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
+| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+```
+
+**Repeat for**:
+- `/backend/README.md` (same line range)
+- `/docker/README.md` (lines 190-196)
+
+#### Phase 2: Add Distributed Workers Section (Optional)
+
+**File**: `/README.md`
+**Location**: After "Tool Config" section, before "Storage"
+
+```markdown
+#### Distributed Workers (Optional)
+
+For high-availability deployments, Orchestra supports distributed LLM streaming via Redis and TaskIQ.
+
+| Variable              | Description                           | Default                     |
+| --------------------- | ------------------------------------- | --------------------------- |
+| `REDIS_URL`           | Redis connection string for task queue | `redis://localhost:6379/0` |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode        | `false`                     |
+
+> **Note**: When `DISTRIBUTED_WORKERS=true`, you must run a separate worker process: `make dev.worker`
+```
+
+#### Phase 3: Modernize Development Section
+
+**File**: `/README.md`
+**Location**: Lines 99-118 (Setup Server Environment)
+
+Replace manual commands with Makefile reference:
+
+```markdown
+3. **Setup Server Environment**
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation).
+
+    ```bash
+    # Change directory
+    cd <project-root>/backend
+
+    # Generate virtualenv and install dependencies
+    uv venv && source .venv/bin/activate && uv sync
+
+    # Run dev server (uses ~/.env/orchestra/.env.backend)
+    make dev
+    ```
+
+    **Available Makefile Commands:**
+
+    | Command | Description |
+    |---------|-------------|
+    | `make dev` | Start dev server on port 8000 |
+    | `make dev.worker` | Start TaskIQ worker (for distributed mode) |
+    | `make test` | Run all tests |
+    | `make format` | Format code with Ruff |
+    | `make seeds.user` | Seed default users |
+    | `make migrate.up` | Run all pending migrations |
+    | `make migrate.down` | Rollback one migration |
+
+    See `backend/CLAUDE.md` for detailed development instructions.
+```
+
+#### Phase 4: Add PIIMiddleware Note (Security Documentation)
+
+**File**: `/README.md`
+**Location**: After "Security" in Production Considerations section
+
+```markdown
+#### Built-in PII Protection
+
+Orchestra includes automatic PII protection via PIIMiddleware (no configuration required):
+- **Credit card masking**: Numbers are automatically masked in responses
+- **API key blocking**: Known API key patterns (e.g., `sk-*`) are blocked from being processed
+
+This protection is enabled by default and requires no additional configuration.
+```
+
+### File Changes Summary
+
+| File | Action | Estimated Lines Changed |
+|------|--------|------------------------|
+| `/README.md` | Edit | ~40 lines |
+| `/backend/README.md` | Edit | ~10 lines |
+| `/docker/README.md` | Edit | ~10 lines |
+
+---
+
+## 4. Design Decisions
+
+### 4.1 Trade-offs Considered
+
+| Decision | Alternative | Chosen Approach | Rationale |
+|----------|-------------|-----------------|-----------|
+| Remove vs Comment Presidio | Comment out | **Remove entirely** | Commented docs suggest feature exists; removal is cleaner |
+| Document worker vars in README | Separate DEPLOYMENT.md | **README** | Single source reduces fragmentation |
+| Makefile table vs inline | Inline commands | **Table format** | Scannable, consistent with existing style |
+| PIIMiddleware note location | Dedicated section | **Security subsection** | Contextually appropriate for production guidance |
+
+### 4.2 Why This Approach Over Alternatives
+
+**Alternative 1: Minimal Change (Remove Presidio Only)**
+- Pros: Smallest diff
+- Cons: Misses opportunity to improve developer experience
+- Rejected: Technical debt accumulates
+
+**Alternative 2: Complete README Rewrite**
+- Pros: Fresh, optimized structure
+- Cons: High review burden, regression risk
+- Rejected: Overkill for this issue
+
+**Alternative 3: Symlink/Include from CLAUDE.md**
+- Pros: Single source of truth
+- Cons: README must be self-contained for GitHub display
+- Rejected: Platform limitations
+
+### 4.3 Alignment with Existing Patterns
+
+- **Table format**: Matches existing env var documentation style
+- **Section headers**: Uses existing emoji + title pattern
+- **Command examples**: Uses existing code block format
+- **No emojis in technical content**: Per CLAUDE.md guidelines
+
+---
+
+## 5. Risk Assessment
+
+### 5.1 Potential Pitfalls
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking existing deployments | NONE | - | Documentation-only changes |
+| Confusing users with removed vars | LOW | LOW | Clean removal, no deprecated notice needed for alpha feature |
+| Missing other stale docs | MEDIUM | LOW | Grep verification step included |
+| Inconsistency across 3 READMEs | MEDIUM | MEDIUM | Apply changes atomically |
+
+### 5.2 Edge Cases to Handle
+
+1. **Users with existing PRESIDIO_* in .env**
+   - Impact: Variables will be ignored (no error)
+   - Resolution: Not a breaking change; users can clean up at leisure
+
+2. **Users expecting Presidio functionality**
+   - Impact: May be confused when config doesn't work
+   - Resolution: PIIMiddleware provides equivalent/better protection automatically
+
+3. **Docker deployments using old README as reference**
+   - Impact: May try to configure non-existent services
+   - Resolution: Update docker/README.md simultaneously
+
+4. **CI/CD scripts parsing README for env vars**
+   - Impact: Unlikely but possible
+   - Resolution: This is an anti-pattern; not a supported use case
+
+### 5.3 Testing Considerations
+
+#### Pre-Implementation Verification
+
+```bash
+# Verify Presidio is truly removed from codebase
+grep -r "presidio\|Presidio" backend/src --include="*.py" | grep -v "PII"
+# Expected: No results or only comments
+
+# Verify .example.env is the source of truth
+diff -u <(grep -E "^[A-Z_]+=" backend/.example.env | sort) <(grep -E "^\| \`[A-Z_]+\`" README.md | sed 's/.*`\([A-Z_]*\)`.*/\1/' | sort)
+# Should show PRESIDIO_* only in README, REDIS_URL/DISTRIBUTED_WORKERS only in .example.env
+```
+
+#### Post-Implementation Verification
+
+```bash
+# No Presidio references in any README
+grep -l "PRESIDIO" README.md backend/README.md docker/README.md
+# Expected: No results
+
+# Distributed worker vars documented
+grep "DISTRIBUTED_WORKERS\|REDIS_URL" README.md
+# Expected: Both present
+
+# Makefile commands documented
+grep "make dev\|make test\|make format" README.md
+# Expected: All present
+```
+
+#### Documentation Rendering Test
+
+1. View README.md in GitHub web interface
+2. Verify tables render correctly
+3. Verify code blocks have syntax highlighting
+4. Verify links work
+
+---
+
+## 6. Estimated Complexity
+
+### Scope: **Small**
+
+| Metric | Assessment |
+|--------|------------|
+| Files changed | 3 |
+| Lines changed | ~60 |
+| Code complexity | None (documentation only) |
+| Test requirements | Manual verification |
+| Review burden | Low |
+
+### Risk Level: **Low**
+
+| Factor | Assessment |
+|--------|------------|
+| Breaking changes | None |
+| Security impact | Positive (removes misleading config) |
+| Rollback complexity | Trivial (git revert) |
+| Cross-team coordination | None |
+
+### Suggested Priority Order
+
+1. **Remove Presidio section** (all 3 files) - Eliminates confusion immediately
+2. **Add distributed worker section** - Enables production deployments
+3. **Modernize development commands** - Improves DX
+4. **Add PIIMiddleware note** - Completes security documentation
+
+### Estimated Effort
+
+| Task | Time |
+|------|------|
+| Phase 1: Remove Presidio | 5 minutes |
+| Phase 2: Add workers | 10 minutes |
+| Phase 3: Dev commands | 15 minutes |
+| Phase 4: PII note | 5 minutes |
+| Verification | 10 minutes |
+| **Total** | **~45 minutes** |
+
+---
+
+## 7. Security-Specific Recommendations
+
+### 7.1 Do NOT Document
+
+- Specific API key patterns blocked by PIIMiddleware (security through obscurity helps here)
+- Internal Redis authentication if used
+- Any bypass mechanisms
+
+### 7.2 DO Document
+
+- That PII protection is automatic (sets expectations)
+- That sensitive data should still not be logged (defense in depth)
+- Strong secret generation for JWT_SECRET_KEY and APP_SECRET_KEY
+
+### 7.3 Security Review Checklist
+
+- [ ] No secrets committed in documentation examples
+- [ ] No internal URLs/IPs exposed
+- [ ] No vulnerable version numbers pinned
+- [ ] Strong secret generation guidance included
+- [ ] Default credentials clearly marked as examples only
+
+---
+
+## 8. Summary
+
+This proposal addresses documentation drift between the codebase and README by:
+
+1. **Removing obsolete Presidio configuration** - Eliminates developer confusion and false security expectations
+2. **Adding distributed worker documentation** - Enables production scalability
+3. **Modernizing development commands** - Reduces onboarding friction and configuration errors
+4. **Documenting built-in PII protection** - Sets correct security expectations
+
+The changes are low-risk, documentation-only modifications that bring the README into alignment with the actual system behavior. No code changes are required, and the implementation can be completed in under an hour with minimal review burden.
+
+---
+
+## Appendix: Cross-Reference Validation
+
+### Files Verified
+
+| File | Status | Notes |
+|------|--------|-------|
+| `/backend/src/utils/middleware.py` | CURRENT | PIIMiddleware active |
+| `/backend/.example.env` | CURRENT | Source of truth for env vars |
+| `/backend/Makefile` | CURRENT | Commands documented |
+| `/backend/CLAUDE.md` | CURRENT | Detailed dev instructions |
+| `/.claude/specs/feat-675-cleanup-presidio/REVIEW.md` | MERGED | Presidio removal complete |
+| `/.claude/specs/feat-656-distributed-workers-taskiq/FRONTEND-SPEC.md` | MERGED | Worker vars documented |
+
+### Grep Results Summary
+
+```
+PRESIDIO references in README: 3 files (to be removed)
+PRESIDIO references in backend/src: 0 files (already cleaned)
+PIIMiddleware references: Active in middleware.py
+DISTRIBUTED_WORKERS in .example.env: Present (line 56)
+REDIS_URL in .example.env: Present (line 55)
+```

--- a/.claude/specs/feat-680-update-readme-out-of-sync/REVIEW.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/REVIEW.md
@@ -1,0 +1,215 @@
+# COUNCIL REVIEW: GitHub Issue #680 - Update README.md (Out-of-Sync)
+
+**Review Date:** 2026-01-16
+**Proposals Reviewed:** ARCHITECT, CRAFTSMAN, GUARDIAN
+**Feature Under Review:** Update README.md to reflect Presidio removal (PR #676) and distributed workers (PR #657)
+
+---
+
+## 1. Proposal Comparison Matrix
+
+| Aspect | ARCHITECT | CRAFTSMAN | GUARDIAN | Council Verdict |
+|--------|-----------|-----------|----------|-----------------|
+| **Scope Assessment** | Small (~80-100 lines) | Small (2 files) | Small (~60 lines) | **Small** - All agree |
+| **Risk Level** | Low | Low | Low | **Low** - Unanimous |
+| **Primary Focus** | Structure & organization | Maintainability & DRY | Security & edge cases | Complementary strengths |
+| **Presidio Action** | Remove entirely | Remove entirely | Remove entirely | **Remove entirely** |
+| **Worker Docs** | Add new section | Add new section | Add new section | **Add new section** |
+| **Files to Update** | 2 (README.md, docker/README.md) | 2 | 3 (includes backend/README.md) | **2 files** (see note below) |
+| **Makefile Table** | Yes, detailed | Yes, streamlined | Yes, comprehensive | **Yes - include table** |
+| **Collapsible Manual** | Yes (details block) | No (inline) | No (inline) | **Optional** - nice to have |
+
+**Note on Files:** GUARDIAN identified `backend/README.md` but build script copies `docker/README.md` to `backend/README.md`. We only need to modify `README.md` and `docker/README.md`.
+
+---
+
+## 2. Consensus Points
+
+All three proposals unanimously agree on:
+
+1. **Remove the "Services (Alpha)" Presidio section entirely** - Lines 380-386 in README.md and 190-196 in docker/README.md
+2. **Add Distributed Workers section** with REDIS_URL and DISTRIBUTED_WORKERS variables
+3. **Add Makefile commands table** to improve developer onboarding
+4. **Keep manual commands available** as fallback for advanced users
+5. **This is documentation-only** - zero code risk, trivial rollback
+6. **Total effort: ~45 minutes** including verification
+
+---
+
+## 3. Divergence Analysis
+
+### 3.1 Docker Services Table Update
+
+| Proposal | Recommendation |
+|----------|----------------|
+| ARCHITECT | Update to add redis/worker services |
+| CRAFTSMAN | Explicitly add redis/worker to table |
+| GUARDIAN | Not mentioned |
+
+**Council Decision:** Include redis and worker in the Docker Compose services table. This aligns with the docker-compose.yml that already defines these services.
+
+### 3.2 PIIMiddleware Documentation
+
+| Proposal | Recommendation |
+|----------|----------------|
+| ARCHITECT | Not mentioned |
+| CRAFTSMAN | Not mentioned |
+| GUARDIAN | Add "Built-in PII Protection" note |
+
+**Council Decision:** Skip PIIMiddleware documentation for this PR. While informative, it's out of scope for the immediate issue (removing Presidio refs, adding worker vars). Can be addressed in a follow-up.
+
+### 3.3 Database Migration Section
+
+| Proposal | Recommendation |
+|----------|----------------|
+| ARCHITECT | Rewrite with Makefile commands |
+| CRAFTSMAN | Update to reference Makefile |
+| GUARDIAN | Not specifically addressed |
+
+**Council Decision:** Update the migration section to show Makefile commands first, keep manual alembic as collapsed details. This is a "nice to have" for this PR.
+
+---
+
+## 4. Unified Implementation Plan
+
+### Priority Order (Must Have → Nice to Have)
+
+| Phase | Task | Priority | Files |
+|-------|------|----------|-------|
+| 1 | Remove Presidio section | **P0** | README.md, docker/README.md |
+| 2 | Add Distributed Workers section | **P1** | README.md, docker/README.md |
+| 3 | Add redis/worker to Docker services table | **P1** | README.md |
+| 4 | Add Makefile commands quick reference table | **P2** | README.md |
+| 5 | Streamline development setup section | **P2** | README.md |
+| 6 | Modernize database migrations section | **P3** | README.md |
+
+### Recommended Architecture (from ARCHITECT)
+
+Use collapsible `<details>` blocks for manual commands to keep the README scannable while preserving advanced options:
+
+```markdown
+**Quick Start:**
+```bash
+make dev
+```
+
+<details>
+<summary>Manual setup (if needed)</summary>
+... manual commands here ...
+</details>
+```
+
+### Content Specifications
+
+#### Distributed Workers Section (insert after Storage section, replacing Services Alpha)
+
+```markdown
+#### Distributed Workers (Optional)
+
+| Variable              | Description                           | Default |
+| --------------------- | ------------------------------------- | ------- |
+| `REDIS_URL`           | Redis connection for task queue       | -       |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode        | `false` |
+
+> **Note**: When enabled, run the worker process separately: `make dev.worker`
+```
+
+#### Docker Services Table Addition (line ~286)
+
+```markdown
+| `redis`         | 6379      | Redis message broker (for workers) |
+| `worker`        | -         | TaskIQ worker (no exposed port)    |
+```
+
+#### Makefile Commands Table (after Development section header)
+
+```markdown
+### Quick Reference
+
+| Command           | Description                      |
+|-------------------|----------------------------------|
+| `make dev`        | Start backend server (port 8000) |
+| `make dev.worker` | Start TaskIQ worker              |
+| `make test`       | Run all backend tests            |
+| `make format`     | Format code with Ruff            |
+| `make seeds.user` | Seed default users               |
+| `make migrate.up` | Apply all pending migrations     |
+
+For all commands, see `backend/Makefile`.
+```
+
+---
+
+## 5. Risk Consolidation
+
+### Combined Risk Assessment
+
+| Risk | Source | Likelihood | Impact | Mitigation |
+|------|--------|------------|--------|------------|
+| Broken markdown formatting | All | Low | Low | Preview in GitHub before merge |
+| Missing Presidio reference elsewhere | All | Low | Low | Grep verification: `grep -ri "presidio" *.md` |
+| Inconsistency between README files | All | Medium | Medium | Update both files atomically in same commit |
+| Line number drift from concurrent PRs | ARCHITECT | Medium | Low | Use text patterns, not line numbers |
+| Users with existing PRESIDIO_* env vars | GUARDIAN | Low | None | Variables are no-ops; no breaking change |
+
+### Mitigation Strategy
+
+1. **Pre-commit check**: Verify all changes compile correctly in markdown
+2. **Grep verification**: After changes, ensure no presidio references remain
+3. **Atomic commit**: Both README.md and docker/README.md updated together
+4. **Visual verification**: Preview rendered markdown in GitHub before PR approval
+
+---
+
+## 6. Final Verdict
+
+### Decision: **GO**
+
+| Criteria | Assessment |
+|----------|------------|
+| Scope | Small (documentation only) |
+| Risk | Low (trivial rollback) |
+| Value | High (removes confusion, improves DX) |
+| Effort | ~45 minutes |
+| Dependencies | None (PRs #676 and #657 already merged) |
+
+### Confidence Level: **HIGH**
+
+All three expert agents reached the same conclusions. The implementation is straightforward, low-risk, and addresses a real documentation gap.
+
+### Required Conditions
+
+1. Remove Presidio section from both README.md and docker/README.md
+2. Add Distributed Workers section to both files
+3. Verify with grep that no Presidio references remain
+
+### Optional Enhancements (can be omitted if time-constrained)
+
+- Add Makefile commands quick reference table
+- Update development section with streamlined commands
+- Modernize database migrations section
+
+---
+
+## 7. Implementation Contract
+
+The following will be implemented based on council synthesis:
+
+### Must Complete (P0/P1)
+- [x] Remove "Services (Alpha)" section from README.md (lines 380-386)
+- [x] Remove "Services (Alpha)" section from docker/README.md (lines 190-196)
+- [x] Add "Distributed Workers (Optional)" section to README.md
+- [x] Add "Distributed Workers (Optional)" section to docker/README.md
+- [x] Add redis/worker to Docker Compose services table in README.md
+
+### Should Complete (P2)
+- [x] Add Makefile commands quick reference table to README.md
+- [x] Streamline development setup section with Makefile commands
+
+### Nice to Have (P3)
+- [ ] Modernize database migrations section (defer to follow-up if time constrained)
+
+---
+
+**Council Review Complete**
+**Approved for Implementation**

--- a/.claude/specs/feat-680-update-readme-out-of-sync/TASKS.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/TASKS.md
@@ -1,0 +1,161 @@
+# Implementation Tasks: Update README.md (Issue #680)
+
+**Created:** 2026-01-16
+**Based on:** REVIEW.md Council Synthesis
+**Scope:** Small | **Risk:** Low
+
+---
+
+## Pre-Implementation
+
+- [x] Verify development environment setup
+- [x] Review REVIEW.md council decisions
+- [x] Confirm current working directory is `.worktrees/feat-680`
+
+## Core Implementation
+
+### Task 1: Remove Presidio Section from README.md
+- **Files:** `README.md`
+- **Lines:** 380-386 (Services Alpha section)
+- **Action:** Delete entire section
+- **Acceptance:** `grep -i "presidio" README.md` returns no results
+
+### Task 2: Remove Presidio Section from docker/README.md
+- **Files:** `docker/README.md`
+- **Lines:** 190-196 (Services Alpha section)
+- **Action:** Delete entire section
+- **Acceptance:** `grep -i "presidio" docker/README.md` returns no results
+
+### Task 3: Add Distributed Workers Section to README.md
+- **Files:** `README.md`
+- **Location:** Replace removed Services Alpha section
+- **Content:**
+```markdown
+#### Distributed Workers (Optional)
+
+| Variable              | Description                           | Default |
+| --------------------- | ------------------------------------- | ------- |
+| `REDIS_URL`           | Redis connection for task queue       | -       |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode        | `false` |
+
+> **Note**: When enabled, run the worker process separately: `make dev.worker`
+```
+- **Acceptance:** `grep "DISTRIBUTED_WORKERS\|REDIS_URL" README.md` returns matches
+
+### Task 4: Add Distributed Workers Section to docker/README.md
+- **Files:** `docker/README.md`
+- **Location:** Replace removed Services Alpha section
+- **Content:** Same as Task 3
+- **Acceptance:** `grep "DISTRIBUTED_WORKERS\|REDIS_URL" docker/README.md` returns matches
+
+### Task 5: Add redis/worker to Docker Services Table
+- **Files:** `README.md`
+- **Location:** After `ollama` row in Docker Compose Services table (~line 286)
+- **Content:**
+```markdown
+| `redis`         | 6379      | Redis message broker (for workers) |
+| `worker`        | -         | TaskIQ worker (no exposed port)    |
+```
+- **Acceptance:** `grep "redis.*6379\|worker.*TaskIQ" README.md` returns matches
+
+### Task 6: Add Makefile Quick Reference Table
+- **Files:** `README.md`
+- **Location:** After "## Development" header, before "Environment Variables"
+- **Content:**
+```markdown
+### Quick Reference
+
+| Command           | Description                      |
+|-------------------|----------------------------------|
+| `make dev`        | Start backend server (port 8000) |
+| `make dev.worker` | Start TaskIQ worker              |
+| `make test`       | Run all backend tests            |
+| `make format`     | Format code with Ruff            |
+| `make seeds.user` | Seed default users               |
+| `make migrate.up` | Apply all pending migrations     |
+
+For all commands, see `backend/Makefile`.
+```
+- **Acceptance:** Table rendered correctly, commands match backend/Makefile
+
+### Task 7: Streamline Server Setup Section
+- **Files:** `README.md`
+- **Location:** Lines 99-118 (Setup Server Environment)
+- **Action:** Update to prefer Makefile commands, keep manual as optional
+- **Content:**
+```markdown
+3. **Setup Server Environment**
+
+    ```bash
+    cd <project-root>/backend
+    make dev
+    ```
+
+    <details>
+    <summary>Manual setup (if Makefile unavailable)</summary>
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation).
+
+    ```bash
+    cd <project-root>/backend
+    uv venv
+    source .venv/bin/activate
+    uv sync
+    bash scripts/dev.sh
+    ```
+    </details>
+```
+- **Acceptance:** Section shows `make dev` prominently with manual fallback
+
+## Verification
+
+- [x] `grep -ri "presidio" README.md docker/README.md` returns no results
+- [x] `grep "DISTRIBUTED_WORKERS" README.md docker/README.md` returns matches in both files
+- [x] `grep "make dev" README.md` returns matches for quick reference and setup
+- [ ] README.md renders correctly in GitHub preview
+- [ ] docker/README.md renders correctly in GitHub preview
+- [ ] All internal anchor links work
+
+## Post-Implementation
+
+- [ ] Stage all changes: `git add README.md docker/README.md`
+- [ ] Commit with descriptive message
+- [ ] Verify commit succeeded
+
+---
+
+## Completion Signature
+
+- **Total Tasks:** 7 core tasks + verification
+- **Estimated Effort:** ~45 minutes
+- **Dependencies:** None (PRs #676 and #657 already merged)
+- **Risk:** Low (documentation only, trivial rollback)
+
+---
+
+## Progress Log
+
+- [x] Task 1: Removed Presidio section from README.md - 2026-01-16
+- [x] Task 2: Removed Presidio section from docker/README.md - 2026-01-16
+- [x] Task 3: Added Distributed Workers section to README.md - 2026-01-16
+- [x] Task 4: Added Distributed Workers section to docker/README.md - 2026-01-16
+- [x] Task 5: Added redis/worker to Docker Services tables in both files - 2026-01-16
+- [x] Task 6: Added Makefile Quick Reference table to README.md - 2026-01-16
+- [x] Task 7: Streamlined Server Setup section with collapsible manual fallback - 2026-01-16
+
+## Validation Results
+
+**Status: PASS**
+
+### Verification Commands Executed:
+1. `grep -ri "presidio" README.md docker/README.md` - No results (PASS)
+2. `grep "DISTRIBUTED_WORKERS" README.md docker/README.md` - Found in both files (PASS)
+3. `grep "make dev" README.md` - Found in quick reference and setup sections (PASS)
+
+### Summary:
+- All Presidio references successfully removed
+- Distributed worker documentation added to both README files
+- Docker services tables updated with redis/worker entries
+- Development section modernized with Makefile commands
+- Server setup streamlined with collapsible manual fallback
+

--- a/.claude/specs/feat-680-update-readme-out-of-sync/USER_STORIES.md
+++ b/.claude/specs/feat-680-update-readme-out-of-sync/USER_STORIES.md
@@ -1,0 +1,51 @@
+# User Stories
+
+## Issue #680: FEAT: Update README.md (out-of-sync)
+
+### Story 1: Remove Presidio Documentation
+**As a** developer setting up Orchestra,
+**I want** the README to not reference removed Presidio services,
+**So that** I don't waste time trying to configure services that no longer exist.
+
+**Acceptance Criteria:**
+- [ ] Remove the "Services (Alpha)" section referencing PRESIDIO_* environment variables (lines ~380-386)
+- [ ] Ensure no other references to Presidio remain in the README
+
+### Story 2: Document Makefile Developer Commands
+**As a** developer working on Orchestra,
+**I want** clear documentation on how to use the Makefile for common tasks,
+**So that** I can quickly run tests, format code, and start the development server.
+
+**Acceptance Criteria:**
+- [ ] Add a section documenting available Makefile commands
+- [ ] Include `make test` - Run ALL test cases
+- [ ] Include `make format` - Format project files
+- [ ] Include `make dev` - Run dev server
+- [ ] Include `make seeds.user` - Seed default users
+- [ ] Position this documentation prominently in the Development section
+
+### Story 3: Modernize Development Setup Instructions
+**As a** new contributor to Orchestra,
+**I want** streamlined development setup instructions using the Makefile,
+**So that** I can get started quickly without running multiple manual commands.
+
+**Acceptance Criteria:**
+- [ ] Update the "Setup Server Environment" section to prefer Makefile commands
+- [ ] Retain the manual uv commands for users who need them
+- [ ] Ensure the flow is clear: env setup → docker services → backend → frontend
+
+### Story 4: Document Distributed Worker Configuration (Optional)
+**As a** developer deploying Orchestra with distributed workers,
+**I want** documentation on the new Redis-based worker configuration,
+**So that** I can properly set up distributed LLM streaming.
+
+**Acceptance Criteria:**
+- [ ] Add worker-related environment variables if applicable (from PR #657)
+- [ ] Document docker-compose services for worker mode if needed
+- [ ] This is optional - only if worker documentation is appropriate for README level
+
+## Notes
+- PR #676 removed Presidio service entirely - it's replaced by PIIMiddleware (no user configuration needed)
+- PR #657 added distributed worker mode with Redis/TaskIQ - check if env vars need documentation
+- CLAUDE.md already documents the Makefile commands - README should align with this
+- The `.example.env` in backend was updated in PR #657 with new worker-related vars

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.0.2-rc142
 
 ### Changed
+  - feat/680-update-readme-out-of-sync (2026-01-16)
   - feat/664-edit-project-information-settings (2026-01-16)
   - feat/675-cleanup-presidio-service (2026-01-16)
   - feat/673-web-scrape-dump-tool-results (2026-01-15)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 
 ## 🛠️ Development
 
+### Quick Reference
+
+| Command           | Description                      |
+|-------------------|----------------------------------|
+| `make dev`        | Start backend server (port 8000) |
+| `make dev.worker` | Start TaskIQ worker              |
+| `make test`       | Run all backend tests            |
+| `make format`     | Format code with Ruff            |
+| `make seeds.user` | Seed default users               |
+| `make migrate.up` | Apply all pending migrations     |
+
+For all commands, see `backend/Makefile`.
+
 1. **Environment Variables:**
 
     Create a `.env` file in the root directory and add your API key(s):
@@ -98,24 +111,24 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 
 3. **Setup Server Environment**
 
-    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation). See `./backend/scripts` directory for other dev utilities.
+    ```bash
+    cd <project-root>/backend
+    make dev
+    ```
+
+    <details>
+    <summary>Manual setup (if Makefile unavailable)</summary>
+
+    Assumes you're using [astral uv](https://github.com/astral-sh/uv?tab=readme-ov-file#installation).
 
     ```bash
-    # Change directory
     cd <project-root>/backend
-
-    # Generate virtualenv
     uv venv
-
-    # Activate
     source .venv/bin/activate
-
-    # Install
     uv sync
-
-    # Run
-    bash scripts/dev.sh # Select "no" when prompted.
+    bash scripts/dev.sh
     ```
+    </details>
 
 4. **Setup Client Environment**
 
@@ -284,6 +297,8 @@ The API will be available at `http://localhost:8000`
 | `search_engine` | 8080      | SearXNG search engine              |
 | `exec_server`   | 3005      | Shell execution server             |
 | `ollama`        | 11434     | Local LLM inference (requires GPU) |
+| `redis`         | 6379      | Redis message broker (for workers) |
+| `worker`        | -         | TaskIQ worker (no exposed port)    |
 
 ### 🧱 Docker Compose Example
 
@@ -377,13 +392,14 @@ docker build -t orchestra:local .
 | `SHELL_EXEC_SERVER_URL` | Shell execution endpoint | `http://localhost:3005/exec` |
 | `TAVILY_API_KEY`        | Tavily search API key    | -                            |
 
-#### Services (Alpha)
+#### Distributed Workers (Optional)
 
-| Variable                  | Description                 | Default |
-| ------------------------- | --------------------------- | ------- |
-| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
-| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
-| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+| Variable              | Description                    | Default |
+| --------------------- | ------------------------------ | ------- |
+| `REDIS_URL`           | Redis connection for task queue | -       |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode | `false` |
+
+> **Note**: When enabled, run the worker process separately: `make dev.worker`
 
 #### Storage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -94,6 +94,8 @@ The API will be available at `http://localhost:8000`
 | `search_engine` | 8080      | SearXNG search engine              |
 | `exec_server`   | 3005      | Shell execution server             |
 | `ollama`        | 11434     | Local LLM inference (requires GPU) |
+| `redis`         | 6379      | Redis message broker (for workers) |
+| `worker`        | -         | TaskIQ worker (no exposed port)    |
 
 ## 🧱 Docker Compose Example
 
@@ -187,13 +189,14 @@ docker build -t orchestra:local .
 | `SHELL_EXEC_SERVER_URL` | Shell execution endpoint | `http://localhost:3005/exec` |
 | `TAVILY_API_KEY`        | Tavily search API key    | -                            |
 
-### Services (Alpha)
+### Distributed Workers (Optional)
 
-| Variable                  | Description                 | Default |
-| ------------------------- | --------------------------- | ------- |
-| `PRESIDIO_ANALYZE_HOST`   | Presidio analyze endpoint   | -       |
-| `PRESIDIO_ANONYMIZE_HOST` | Presidio anonymize endpoint | -       |
-| `PRESIDIO_API_KEY`        | Presidio API key            | -       |
+| Variable              | Description                    | Default |
+| --------------------- | ------------------------------ | ------- |
+| `REDIS_URL`           | Redis connection for task queue | -       |
+| `DISTRIBUTED_WORKERS` | Enable distributed worker mode | `false` |
+
+> **Note**: When enabled, run the worker process separately: `make dev.worker`
 
 ### Storage
 


### PR DESCRIPTION
## Summary
Resolves #680

This PR updates the README.md documentation to reflect breaking changes from recent PRs:
- **PR #676**: Removed Presidio service (replaced by PIIMiddleware)
- **PR #657**: Added distributed worker mode with Redis/TaskIQ

## User Stories

### Story 1: Remove Presidio Documentation
**As a** developer setting up Orchestra,
**I want** the README to not reference removed Presidio services,
**So that** I don't waste time trying to configure services that no longer exist.

### Story 2: Document Makefile Developer Commands
**As a** developer working on Orchestra,
**I want** clear documentation on how to use the Makefile for common tasks,
**So that** I can quickly run tests, format code, and start the development server.

### Story 3: Modernize Development Setup Instructions
**As a** new contributor to Orchestra,
**I want** streamlined development setup instructions using the Makefile,
**So that** I can get started quickly without running multiple manual commands.

### Story 4: Document Distributed Worker Configuration
**As a** developer deploying Orchestra with distributed workers,
**I want** documentation on the new Redis-based worker configuration,
**So that** I can properly set up distributed LLM streaming.

## Implementation

### Changes Made:
1. **Removed "Services (Alpha)" section** - Deleted obsolete Presidio environment variables from both `README.md` and `docker/README.md`

2. **Added "Distributed Workers (Optional)" section** - Documented `REDIS_URL` and `DISTRIBUTED_WORKERS` environment variables

3. **Added redis/worker to Docker Compose services table** - Updated services table in both README files

4. **Added Makefile Quick Reference table** - Prominent table showing common commands (`make dev`, `make test`, etc.)

5. **Streamlined Server Setup section** - Now shows `make dev` as primary approach with collapsible manual fallback

## Testing
- [x] `grep -ri "presidio" README.md docker/README.md` - No results (PASS)
- [x] `grep "DISTRIBUTED_WORKERS" README.md docker/README.md` - Found in both files (PASS)
- [x] `grep "make dev" README.md` - Found in quick reference and setup sections (PASS)
- [ ] Visual verification in GitHub preview

## Spec Artifacts
The `.claude/specs/feat-680-update-readme-out-of-sync/` folder contains:
- `USER_STORIES.md` - User stories with acceptance criteria
- `PROPOSAL_ARCHITECT.md` - System design perspective
- `PROPOSAL_CRAFTSMAN.md` - Clean code perspective
- `PROPOSAL_GUARDIAN.md` - Security/testing perspective
- `REVIEW.md` - Council synthesis
- `TASKS.md` - Implementation contract with validation results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Removed deprecated Presidio service documentation from README and docker README.
* Added Distributed Workers (Optional) configuration guide with Redis support and environment variables.
* Introduced Makefile quick reference for common development commands (dev, test, format, seeds.user, migrate.up).
* Modernized server setup instructions to prioritize Makefile-driven workflow with manual fallback option.
* Updated Docker Compose services to include Redis and worker components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->