### PR TITLE
FROM bug/612-web-scrape-cannot-fetch-plain-text-pages development

### DIFF
--- a/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_API_GUARDIAN.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_API_GUARDIAN.md
@@ -1,0 +1,243 @@
+# PROPOSAL: Bug #612 - web_scrape Cannot Fetch text/plain Pages
+
+**Author:** AGENT_2 (API_GUARDIAN)
+**Date:** 2026-01-31
+**Status:** DRAFT
+
+---
+
+## 1. Executive Summary
+
+The `web_scrape` tool's `fetch_html` function explicitly rejects any response whose `Content-Type` is not `text/html` or `application/xhtml+xml`, causing all `text/plain` URLs (and other text-based content types like `application/json`, `text/xml`, `text/csv`) to fail with a `ValueError`. The fix requires broadening the content-type gate in `fetch_html` to accept text-based responses and routing them through an appropriate conversion path instead of forcing everything through the HTML-to-Markdown pipeline.
+
+## 2. Architectural Analysis
+
+### 2.1 Current State
+
+The scraping pipeline lives entirely in `backend/src/tools/search.py` and follows this flow:
+
+```
+web_scrape(urls)
+  -> urls_to_markdown(urls)
+    -> url_to_markdown(client, url, sem)   [per URL, concurrency-limited]
+      -> fetch_html(client, url)           [HTTP fetch + content-type gate]
+      -> html_to_markdown(html)            [markdownify conversion]
+```
+
+**The bug is at line 94 of `search.py`:**
+
+```python
+if ("text/html" not in ctype) and ("application/xhtml+xml" not in ctype):
+    raise ValueError(f"Non-HTML content-type: {ctype or 'unknown'}")
+```
+
+This is a hard reject. Any `text/plain`, `application/json`, `text/xml`, `text/csv`, or similar text-based content type triggers a `ValueError` that gets caught by `url_to_markdown` and rendered as an error block in the output.
+
+The error message shown to the LLM agent is misleading: it says "This often happens when the URL returns a PDF/image, or the payload is compressed/binary" -- but the actual cause is a plain text page.
+
+### 2.2 Proposed Changes
+
+Rename `fetch_html` to `fetch_content` (or keep the name but change its semantics) and return a tuple of `(content_string, content_type)`. Then in `url_to_markdown`, branch on the content type:
+
+- **HTML/XHTML**: existing path through `html_to_markdown`
+- **text/plain**: wrap in a markdown code block or return as-is (already readable)
+- **application/json**: pretty-print and wrap in a fenced code block
+- **text/xml, text/csv, etc.**: wrap in a fenced code block with language hint
+- **Binary types**: reject as today
+
+This keeps the API contract of `web_scrape` unchanged -- it still returns `str` (markdown-formatted content). No schema changes needed. No route changes needed. The tool signature and return type are preserved.
+
+### 2.3 Integration Points
+
+| Component | Impact |
+|-----------|--------|
+| `backend/src/tools/search.py` | Primary change location. `fetch_html`, `url_to_markdown`, `urls_to_markdown` |
+| `backend/src/loaders/__init__.py` | No change needed. The `Loader` class uses `WebBaseLoader` for `web_scrape` which is a separate code path (document ingestion, not the tool) |
+| `backend/src/schemas/examples/__init__.py` | No change needed. Example schema is unaffected |
+| API consumers (LLM agents) | No breaking change. Output is still markdown `str`. Agents will now receive content instead of error blocks for text URLs |
+
+## 3. Implementation Strategy
+
+### Step 1: Refactor `fetch_html` to `fetch_content`
+
+**File:** `backend/src/tools/search.py`
+
+Replace the content-type gate with an allowlist of text-based types and return a typed result:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class FetchResult:
+    """Result of fetching a URL."""
+    text: str
+    content_type: str  # simplified: "html", "plain", "json", "xml", "other_text"
+
+ALLOWED_TEXT_TYPES = {
+    "text/html": "html",
+    "application/xhtml+xml": "html",
+    "text/plain": "plain",
+    "application/json": "json",
+    "application/xml": "xml",
+    "text/xml": "xml",
+    "text/csv": "csv",
+    "text/markdown": "markdown",
+    "application/rss+xml": "xml",
+    "application/atom+xml": "xml",
+}
+
+async def fetch_content(client: httpx.AsyncClient, url: str) -> FetchResult:
+    r = await client.get(url)
+    r.raise_for_status()
+
+    ctype = (r.headers.get("content-type") or "").lower()
+    data = r.content
+
+    if looks_binary(data):
+        raise ValueError("Response looks binary/compressed; refusing to decode as text")
+
+    # Match against allowed types
+    matched_type = None
+    for type_prefix, category in ALLOWED_TEXT_TYPES.items():
+        if type_prefix in ctype:
+            matched_type = category
+            break
+
+    # Fallback: if content-type starts with "text/", allow it
+    if matched_type is None and ctype.startswith("text/"):
+        matched_type = "plain"
+
+    if matched_type is None:
+        raise ValueError(f"Non-text content-type: {ctype or 'unknown'}")
+
+    html = str(from_bytes(data).best())
+    return FetchResult(text=strip_control_chars(html), content_type=matched_type)
+```
+
+### Step 2: Update `url_to_markdown` to branch on content type
+
+```python
+async def content_to_markdown(result: FetchResult) -> str:
+    """Convert fetched content to markdown based on its type."""
+    if result.content_type == "html":
+        return await html_to_markdown(result.text)
+    elif result.content_type == "markdown":
+        return clean_markdown(result.text)
+    elif result.content_type in ("json", "xml", "csv"):
+        lang = result.content_type
+        return clean_markdown(f"```{lang}\n{result.text}\n```")
+    else:
+        # text/plain and other text types
+        return clean_markdown(result.text)
+
+
+async def url_to_markdown(
+    client: httpx.AsyncClient,
+    url: str,
+    sem: asyncio.Semaphore,
+) -> Tuple[str, Union[str, Exception]]:
+    try:
+        async with sem:
+            result = await fetch_content(client, url)
+            md_text = await content_to_markdown(result)
+            return url, md_text
+    except Exception as e:
+        return url, e
+```
+
+### Step 3: Update the `Accept` header
+
+In `urls_to_markdown`, broaden the `Accept` header to signal willingness to receive text content:
+
+```python
+"Accept": "text/html,application/xhtml+xml,text/plain,application/json,application/xml,text/xml,*/*;q=0.5",
+```
+
+### Step 4: Update error tip message
+
+In `urls_to_markdown`, update the error tip from the current misleading message to:
+
+```python
+"> Tip: This often happens when the URL returns binary content "
+"> (PDF, image, etc.) or the server blocks automated requests."
+```
+
+### Step 5: Add tests
+
+**File:** `backend/tests/unit/tools/test_web_scrape.py` (new)
+
+Test cases:
+1. `text/html` response -- existing behavior preserved, HTML converted to markdown
+2. `text/plain` response -- plain text returned as-is (cleaned)
+3. `application/json` response -- JSON wrapped in fenced code block
+4. `text/xml` response -- XML wrapped in fenced code block
+5. `image/png` response -- raises ValueError
+6. Binary payload with `text/html` header -- raises ValueError (binary detection)
+7. Missing `Content-Type` header -- raises ValueError
+8. `text/plain; charset=utf-8` (with params) -- correctly matched as plain
+
+## 4. Design Decisions
+
+### Decision 1: Return dataclass vs. tuple from fetch
+
+**Chosen:** `FetchResult` dataclass
+**Alternative:** Return `Tuple[str, str]`
+**Rationale:** Named fields are clearer and extensible (could add `status_code`, `url` later). Minimal overhead.
+
+### Decision 2: Plain text rendering -- raw vs. code block
+
+**Chosen:** Return plain text as-is (not in a code block)
+**Alternative:** Wrap in triple-backtick code block
+**Rationale:** Plain text is already readable by LLM agents. Wrapping in a code block would add noise and prevent the agent from treating it as natural language. JSON/XML/CSV are wrapped because the language hint aids parsing.
+
+### Decision 3: Allowlist vs. blocklist for content types
+
+**Chosen:** Allowlist of known text types + fallback for `text/*`
+**Alternative:** Block only known binary types
+**Rationale:** Allowlist is safer. Unknown types like `application/octet-stream` could be binary. The `text/*` fallback handles edge cases like `text/calendar` gracefully.
+
+### Decision 4: No schema or route changes
+
+**Chosen:** Keep `web_scrape` tool signature and return type identical
+**Rationale:** The tool returns `str` (markdown). This is a pure implementation fix, not an API contract change. LLM agents calling `web_scrape` need zero changes.
+
+## 5. Risk Assessment
+
+### Pitfalls
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Large plain text files (e.g., log dumps) producing huge output | Medium | Consider adding a max content length truncation (e.g., 100KB) with a note that content was truncated |
+| Servers returning `text/plain` for binary content (misconfigured) | Low | The `looks_binary` check already handles this |
+| Breaking existing HTML scraping behavior | High | Ensure HTML path is unchanged; the refactor only adds branches, does not modify the HTML flow |
+| `charset_normalizer` failing on some plain text encodings | Low | Already used today for HTML; same risk profile |
+
+### Edge Cases
+
+- **No Content-Type header**: Treated as unknown, rejected. Could optionally attempt binary detection and treat as plain text if it passes, but safer to reject.
+- **`text/plain` with HTML inside**: Will be returned as plain text, not parsed as HTML. This is correct -- respect the server's declared content type.
+- **Redirects changing content type**: Already handled by `follow_redirects=True` in httpx; the final response's content type is checked.
+- **Empty response body**: Returns empty string after cleaning. Not harmful.
+
+## 6. Estimated Complexity
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Scope** | Small. One file changed (`search.py`), one test file added. ~60 lines of new/modified code. |
+| **Risk Level** | Low. The change is additive -- existing HTML path is preserved. No schema, route, or database changes. |
+| **Priority Order** | 1. Refactor `fetch_html` to `fetch_content` with `FetchResult` dataclass |
+|  | 2. Add `content_to_markdown` branching function |
+|  | 3. Update `url_to_markdown` to use new functions |
+|  | 4. Update `Accept` header and error messages |
+|  | 5. Write unit tests |
+
+**Estimated effort:** 1-2 hours for implementation + tests.
+
+---
+
+## Files to Modify
+
+| File | Change Type |
+|------|-------------|
+| `backend/src/tools/search.py` | Modify: `fetch_html` -> `fetch_content`, add `FetchResult`, add `content_to_markdown`, update `url_to_markdown`, update `Accept` header, update error tip |
+| `backend/tests/unit/tools/test_web_scrape.py` | New: unit tests for all content type scenarios |

--- a/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_SCRAPE_ENGINEER.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_SCRAPE_ENGINEER.md
@@ -1,0 +1,160 @@
+# Proposal: BUG #612 - web_scrape cannot fetch plain/text pages
+
+## 1. Executive Summary
+
+The `web_scrape` tool fails on any URL returning `text/plain` content because `fetch_html()` in `backend/src/tools/search.py` explicitly rejects non-HTML content types with a `ValueError`. The fix is to detect textual content types and bypass HTML-to-markdown conversion for plain text responses, returning the text content directly (wrapped in a markdown code block for consistency).
+
+## 2. Architectural Analysis
+
+### Current State
+
+The scraping pipeline in `backend/src/tools/search.py` flows as:
+
+```
+web_scrape() -> urls_to_markdown() -> url_to_markdown() -> fetch_html() -> html_to_markdown()
+```
+
+The bug is on **line 94** of `search.py`:
+
+```python
+if ("text/html" not in ctype) and ("application/xhtml+xml" not in ctype):
+    raise ValueError(f"Non-HTML content-type: {ctype or 'unknown'}")
+```
+
+This guard was intentionally added to reject binary content (PDFs, images, etc.), but it also rejects legitimate textual content like `text/plain`, `text/xml`, `text/csv`, `application/json`, and `application/xml`.
+
+### Proposed Changes
+
+Modify the fetch layer to distinguish between three content categories:
+
+1. **HTML content** (`text/html`, `application/xhtml+xml`) -- existing path, convert via `markdownify`
+2. **Plain text content** (`text/plain`, `text/csv`, `text/xml`, `application/json`, `application/xml`, etc.) -- new path, return as-is or in a fenced code block
+3. **Binary content** (everything else) -- existing path, reject with `ValueError`
+
+### Integration Points
+
+- **Single file change**: `backend/src/tools/search.py`
+- No schema changes, no API route changes, no database changes
+- The `Accept` header (line 150) should be updated to express willingness to accept `text/plain`
+
+## 3. Implementation Strategy
+
+### Step 1: Rename `fetch_html` to `fetch_url_content` and return a tagged result
+
+Replace the single function with one that returns both the content and a flag indicating whether it is HTML or plain text.
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class FetchResult:
+    content: str
+    is_html: bool
+```
+
+### Step 2: Update content-type gate in the fetch function
+
+```python
+TEXTUAL_TYPES = ("text/", "application/json", "application/xml", "application/xhtml+xml")
+
+async def fetch_url_content(client: httpx.AsyncClient, url: str) -> FetchResult:
+    r = await client.get(url)
+    r.raise_for_status()
+
+    ctype = (r.headers.get("content-type") or "").lower()
+    is_html = ("text/html" in ctype) or ("application/xhtml+xml" in ctype)
+    is_textual = any(t in ctype for t in TEXTUAL_TYPES)
+
+    if not is_textual:
+        raise ValueError(f"Non-text content-type: {ctype or 'unknown'}")
+
+    data = r.content
+    if looks_binary(data):
+        raise ValueError("Response looks binary/compressed; refusing to decode as text")
+
+    text = str(from_bytes(data).best())
+    return FetchResult(content=strip_control_chars(text), is_html=is_html)
+```
+
+### Step 3: Update `url_to_markdown` to branch on content type
+
+```python
+async def url_to_markdown(client, url, sem):
+    try:
+        async with sem:
+            result = await fetch_url_content(client, url)
+            if result.is_html:
+                md_text = await html_to_markdown(result.content)
+            else:
+                # Wrap plain text in a fenced code block for readability
+                md_text = f"```\n{result.content}\n```"
+            return url, md_text
+    except Exception as e:
+        return url, e
+```
+
+### Step 4: Update the `Accept` header
+
+```python
+"Accept": "text/html,application/xhtml+xml,text/plain,application/xml;q=0.9,*/*;q=0.8",
+```
+
+### Step 5: Add unit tests
+
+Create `backend/tests/unit/tools/test_search_scrape.py`:
+
+- Test that `text/plain` responses are returned wrapped in a code block
+- Test that `text/html` responses still go through markdownify
+- Test that `application/pdf` responses are rejected
+- Test that binary payloads are rejected regardless of content-type header
+- Test that `application/json` responses are accepted as textual content
+
+## 4. Design Decisions
+
+| Decision | Choice | Alternative | Rationale |
+|----------|--------|-------------|-----------|
+| Plain text wrapping | Fenced code block | Raw text | Maintains markdown consistency; agents downstream expect markdown |
+| Textual type detection | Prefix match on `text/` + allow-list | Strict allow-list only | `text/*` is a broad MIME family that is always textual by definition |
+| Return type | `FetchResult` dataclass | Tuple `(str, bool)` | More readable, extensible if we later add content-type metadata |
+| Scope of text types | `text/*` + `application/json` + `application/xml` | Only `text/plain` | Minimal extra cost, significantly broader coverage for common use cases |
+
+## 5. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Very large plain text files (e.g., logs) could overwhelm LLM context | Medium | Add a max content length truncation (e.g., 100KB) with a truncation notice |
+| Some servers misreport content-type | Low | The existing `looks_binary()` heuristic catches this |
+| `application/json` may contain large API responses | Low | Same truncation mitigation as above |
+| Breaking change to existing behavior | Very Low | Only previously-failing URLs now succeed; no existing success paths change |
+
+### Edge Cases
+
+- URLs returning `text/plain; charset=utf-8` (content-type with parameters) -- handled by substring match
+- Empty responses -- `looks_binary()` returns `False` for empty data, will return empty string (acceptable)
+- Encoded content (gzip) -- httpx handles `Content-Encoding` decompression automatically
+
+## 6. Estimated Complexity
+
+| Dimension | Rating |
+|-----------|--------|
+| **Scope** | Small -- single file change + new test file |
+| **Risk Level** | Low -- additive change, no existing behavior modified |
+| **Effort** | 1-2 hours |
+| **Priority** | High -- this is a user-facing bug blocking a core tool capability |
+
+### Implementation Order
+
+1. Add `FetchResult` dataclass and `TEXTUAL_TYPES` constant
+2. Refactor `fetch_html` to `fetch_url_content` with broadened content-type handling
+3. Update `url_to_markdown` branching logic
+4. Update `Accept` header
+5. Add content length truncation safety valve
+6. Write unit tests
+7. Run `make format` and `make test`
+
+### Files Changed
+
+| File | Change Type |
+|------|-------------|
+| `backend/src/tools/search.py` | Modified (core fix) |
+| `backend/tests/unit/tools/test_search_scrape.py` | New (tests) |

--- a/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_TEST_SENTINEL.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/PROPOSAL_TEST_SENTINEL.md
@@ -1,0 +1,383 @@
+# PROPOSAL: Bug #612 - web_scrape Cannot Fetch plain/text Pages
+
+**Agent:** TEST_SENTINEL
+**Date:** 2026-01-31
+**Branch:** development
+
+---
+
+## 1. Executive Summary
+
+The `fetch_html` function in `backend/src/tools/search.py` (line 94) explicitly rejects any response whose `Content-Type` is not `text/html` or `application/xhtml+xml`, causing all `text/plain` URLs to fail with `ValueError: Non-HTML content-type`. The fix requires broadening content-type acceptance to include text-based types (especially `text/plain`) and routing them through an appropriate conversion path instead of the HTML-to-markdown pipeline. A comprehensive test suite for the scraping functions is entirely missing today and must be created alongside the fix.
+
+---
+
+## 2. Architectural Analysis
+
+### 2.1 Current State
+
+The scraping pipeline in `backend/src/tools/search.py` follows this call chain:
+
+```
+web_scrape(urls)
+  -> urls_to_markdown(urls)
+     -> url_to_markdown(client, url, sem)   [per URL, concurrently]
+        -> fetch_html(client, url)           [fetches + validates]
+        -> html_to_markdown(html)            [markdownify conversion]
+```
+
+**Key files:**
+- `/home/ryaneggz/ruska-ai/orchestra/.worktrees/bug-612/backend/src/tools/search.py` -- all scraping logic lives here (lines 24-179)
+
+**The bug (line 94):**
+```python
+if ("text/html" not in ctype) and ("application/xhtml+xml" not in ctype):
+    raise ValueError(f"Non-HTML content-type: {ctype or 'unknown'}")
+```
+
+This guard was added to prevent binary content from being processed but is overly restrictive -- it blocks `text/plain`, `text/xml`, `application/json`, and other perfectly scrapable text formats.
+
+**Existing test coverage for scraping: NONE.** The file `backend/tests/unit/tools/test_search.py` covers only `web_search` and its Tavily/SearXNG fallback logic. There are zero tests for `fetch_html`, `html_to_markdown`, `url_to_markdown`, `urls_to_markdown`, `web_scrape`, `clean_markdown`, `looks_binary`, or `strip_control_chars`.
+
+### 2.2 Proposed Changes
+
+1. **Rename `fetch_html` to `fetch_content`** (or add a new function) that accepts a whitelist of text-based content types.
+2. **Branch conversion logic** based on content type:
+   - `text/html`, `application/xhtml+xml` -> existing `html_to_markdown` path
+   - `text/plain` -> wrap in a markdown code fence or return as-is after `clean_markdown`
+   - `application/json`, `text/xml`, `text/csv` etc. -> wrap in appropriate code fence
+   - Binary types -> reject as today
+3. **Update `url_to_markdown`** to pass content type downstream so the correct converter is selected.
+
+### 2.3 Integration Points
+
+- `web_scrape` tool (line 469) -- no change needed, it delegates to `urls_to_markdown`.
+- `Loader` class in `backend/src/loaders/__init__.py` -- uses `WebBaseLoader` for `web_scrape` loader type; this is a separate code path (LangChain loader) and is NOT affected by this bug.
+- The `Accept` header in `urls_to_markdown` (line 150) already sends `*/*;q=0.8`, so servers will respond with `text/plain` when appropriate.
+
+---
+
+## 3. Implementation Strategy
+
+### Step 1: Refactor `fetch_html` into `fetch_content`
+
+**File:** `/home/ryaneggz/ruska-ai/orchestra/.worktrees/bug-612/backend/src/tools/search.py`
+
+Replace the content-type guard at line 94 with a whitelist approach:
+
+```python
+TEXT_CONTENT_TYPES = {
+    "text/html",
+    "application/xhtml+xml",
+    "text/plain",
+    "text/xml",
+    "application/xml",
+    "application/json",
+    "text/csv",
+    "text/markdown",
+    "application/rss+xml",
+    "application/atom+xml",
+}
+
+async def fetch_content(client: httpx.AsyncClient, url: str) -> tuple[str, str]:
+    """
+    Fetch textual content from a URL safely.
+    Returns (decoded_text, content_type).
+    """
+    r = await client.get(url)
+    r.raise_for_status()
+    ctype = (r.headers.get("content-type") or "").lower()
+
+    # Extract base content type (strip charset params)
+    base_ctype = ctype.split(";")[0].strip()
+
+    # Accept any text/* type plus known safe application types
+    if not (base_ctype.startswith("text/") or base_ctype in TEXT_CONTENT_TYPES):
+        raise ValueError(f"Non-text content-type: {ctype or 'unknown'}")
+
+    data = r.content
+    if looks_binary(data):
+        raise ValueError("Response looks binary/compressed; refusing to decode as text")
+
+    html = str(from_bytes(data).best())
+    return strip_control_chars(html), base_ctype
+```
+
+### Step 2: Add content-type-aware conversion
+
+```python
+async def content_to_markdown(text: str, content_type: str) -> str:
+    """Convert fetched content to markdown based on content type."""
+    if content_type in ("text/html", "application/xhtml+xml"):
+        return await html_to_markdown(text)
+    elif content_type == "text/plain":
+        return clean_markdown(text)
+    elif content_type in ("application/json", "text/xml", "application/xml",
+                          "application/rss+xml", "application/atom+xml"):
+        lang = "json" if "json" in content_type else "xml"
+        return f"```{lang}\n{text.strip()}\n```"
+    elif content_type == "text/csv":
+        return f"```csv\n{text.strip()}\n```"
+    elif content_type == "text/markdown":
+        return clean_markdown(text)
+    else:
+        return clean_markdown(text)
+```
+
+### Step 3: Update `url_to_markdown`
+
+```python
+async def url_to_markdown(client, url, sem):
+    try:
+        async with sem:
+            text, ctype = await fetch_content(client, url)
+            md_text = await content_to_markdown(text, ctype)
+            return url, md_text
+    except Exception as e:
+        return url, e
+```
+
+### Step 4: Create comprehensive test file
+
+**File:** `/home/ryaneggz/ruska-ai/orchestra/.worktrees/bug-612/backend/tests/unit/tools/test_web_scrape.py`
+
+```python
+"""
+Unit tests for web_scrape / URL fetching and content conversion.
+
+Tests cover:
+- fetch_content with various content types (HTML, plain text, JSON, XML, binary)
+- content_to_markdown routing for each content type
+- clean_markdown normalization
+- looks_binary heuristic
+- strip_control_chars
+- url_to_markdown error handling
+- urls_to_markdown concurrent fetching with mixed results
+- web_scrape tool integration
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from src.tools.search import (
+    clean_markdown,
+    looks_binary,
+    strip_control_chars,
+    # After refactor:
+    # fetch_content,
+    # content_to_markdown,
+)
+
+
+class TestStripControlChars:
+    def test_preserves_newlines_and_tabs(self):
+        assert strip_control_chars("hello\n\tworld") == "hello\n\tworld"
+
+    def test_removes_null_bytes(self):
+        assert strip_control_chars("hello\x00world") == "helloworld"
+
+    def test_removes_other_control_chars(self):
+        assert strip_control_chars("a\x01b\x02c") == "abc"
+
+
+class TestLooksBinary:
+    def test_empty_data_not_binary(self):
+        assert looks_binary(b"") is False
+
+    def test_plain_text_not_binary(self):
+        assert looks_binary(b"Hello, world!\n") is False
+
+    def test_html_not_binary(self):
+        assert looks_binary(b"<html><body>Hello</body></html>") is False
+
+    def test_binary_data_detected(self):
+        data = bytes(range(256)) * 20
+        assert looks_binary(data) is True
+
+    def test_pdf_header_detected(self):
+        assert looks_binary(b"%PDF-1.4\x00\x01\x02" + b"\x00" * 100) is True
+
+
+class TestCleanMarkdown:
+    def test_collapses_excessive_newlines(self):
+        result = clean_markdown("a\n\n\n\nb")
+        assert result == "a\n\nb"
+
+    def test_strips_trailing_whitespace(self):
+        result = clean_markdown("hello   \nworld  ")
+        assert result == "hello\nworld"
+
+    def test_normalizes_line_endings(self):
+        result = clean_markdown("a\r\nb\rc")
+        assert result == "a\nb\nc"
+
+
+class TestFetchContent:
+    """Tests for fetch_content (post-refactor)."""
+
+    @pytest.mark.asyncio
+    async def test_html_content_accepted(self):
+        """text/html responses are accepted and returned."""
+        # Mock httpx response with text/html
+        pass  # Implementation after refactor
+
+    @pytest.mark.asyncio
+    async def test_plain_text_accepted(self):
+        """text/plain responses are accepted and returned."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_json_content_accepted(self):
+        """application/json responses are accepted."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_binary_content_rejected(self):
+        """application/octet-stream is rejected with ValueError."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_image_content_rejected(self):
+        """image/png is rejected with ValueError."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_binary_payload_rejected(self):
+        """Even with text content-type, binary payload is rejected."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_charset_in_content_type_handled(self):
+        """Content-Type with charset parameter is parsed correctly."""
+        pass
+
+
+class TestContentToMarkdown:
+    """Tests for content_to_markdown routing."""
+
+    @pytest.mark.asyncio
+    async def test_html_uses_markdownify(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_plain_text_returned_as_is(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_json_wrapped_in_code_fence(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_xml_wrapped_in_code_fence(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_csv_wrapped_in_code_fence(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_markdown_cleaned_and_returned(self):
+        pass
+
+
+class TestUrlToMarkdown:
+    """Tests for url_to_markdown with error handling."""
+
+    @pytest.mark.asyncio
+    async def test_successful_fetch_returns_tuple(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_exception(self):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_exception(self):
+        pass
+
+
+class TestUrlsToMarkdown:
+    """Tests for concurrent URL fetching."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_success_and_failure(self):
+        """Some URLs succeed, others fail; all are represented in output."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_plain_text_url_included_in_output(self):
+        """A text/plain URL produces content in the final markdown."""
+        pass
+
+    @pytest.mark.asyncio
+    async def test_binary_url_produces_error_block(self):
+        """A binary URL produces an error block, not a crash."""
+        pass
+```
+
+### Step 5: Update existing test imports if `fetch_html` is renamed
+
+No other files import `fetch_html` directly, so this is a clean rename.
+
+---
+
+## 4. Design Decisions
+
+| Decision | Chosen Approach | Alternative | Rationale |
+|----------|----------------|-------------|-----------|
+| Content-type matching | Whitelist `text/*` + known safe types | Blacklist binary types | Whitelist is safer; unknown types are rejected by default |
+| Plain text conversion | Return cleaned text directly | Wrap in code fence | Plain text is already readable; code fences add noise |
+| JSON/XML conversion | Wrap in typed code fence | Parse and pretty-print | Code fence preserves original structure; parsing adds fragility |
+| Function rename | `fetch_html` -> `fetch_content` | Keep name, change behavior | Name should reflect capability; avoids confusion |
+| Return type change | Return `(text, content_type)` tuple | Add content_type to a dataclass | Tuple is minimal and sufficient; no new types needed |
+
+---
+
+## 5. Risk Assessment
+
+### Pitfalls
+
+1. **Servers returning wrong Content-Type.** Some servers report `text/html` for JSON APIs or vice versa. The current approach trusts the header, which is the pragmatic choice -- trying to detect content type from the body would be fragile.
+
+2. **Very large plain text files.** No size limit exists currently. A `robots.txt` is small, but a server could return a 100MB log file as `text/plain`. Consider adding a max response size (already partially handled by httpx timeout, but not by byte count).
+
+3. **Encoding issues with plain text.** The `charset_normalizer` library (`from_bytes`) handles this well for HTML and should work equally well for plain text.
+
+### Edge Cases
+
+- `text/plain; charset=utf-8` -- must strip params before matching
+- Empty response body with `text/plain` -- should produce empty string, not crash
+- `text/plain` with BOM (byte order mark) -- `charset_normalizer` handles this
+- Responses with no `Content-Type` header at all -- currently treated as `unknown`; should probably be rejected (safe default)
+
+### Testing Risks
+
+- The `conftest.py` uses `respx.mock` as an autouse fixture which intercepts all httpx calls. Tests for `fetch_content` / `urls_to_markdown` must either work within `respx.mock` (by registering mock routes) or explicitly disable the autouse fixture. Using `respx` route registration is the recommended approach since it aligns with the existing test patterns.
+
+---
+
+## 6. Estimated Complexity
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| **Scope** | Small | ~50 lines changed in search.py, ~200 lines of new tests |
+| **Risk Level** | Low | Change is additive (accepting more types), not removing existing behavior for HTML |
+| **Confidence** | High | The bug is clearly isolated to one guard clause; the fix is straightforward |
+
+### Priority Order
+
+1. **P0:** Fix `fetch_html` content-type guard to accept `text/plain` (the bug itself)
+2. **P0:** Add `content_to_markdown` routing so plain text skips markdownify
+3. **P1:** Write unit tests for all helper functions (`strip_control_chars`, `looks_binary`, `clean_markdown`)
+4. **P1:** Write unit tests for `fetch_content` with mocked httpx responses via `respx`
+5. **P1:** Write unit tests for `content_to_markdown` routing
+6. **P2:** Write integration-level tests for `urls_to_markdown` with mixed content types
+7. **P2:** Consider adding `max_response_bytes` guard for safety
+
+### Files Modified
+
+| File | Change Type |
+|------|-------------|
+| `backend/src/tools/search.py` | Modified -- refactor fetch_html, add content_to_markdown, update url_to_markdown |
+| `backend/tests/unit/tools/test_web_scrape.py` | New -- comprehensive test suite for scraping pipeline |

--- a/.claude/specs/bug-612-web-scrape-plain-text/REVIEW.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/REVIEW.md
@@ -1,0 +1,96 @@
+# Council Review: Bug #612 - web_scrape Cannot Fetch plain/text Pages
+
+## Proposal Comparison Matrix
+
+| Aspect | SCRAPE_ENGINEER | API_GUARDIAN | TEST_SENTINEL | Council Verdict |
+|--------|----------------|-------------|---------------|-----------------|
+| Architecture | `FetchResult(content, is_html)` dataclass | `FetchResult(text, content_type)` dataclass with category mapping | `tuple[str, str]` return | **FetchResult dataclass with content_type category** (API_GUARDIAN approach) |
+| Content-type matching | Prefix match `text/*` + tuple of prefixes | Explicit allowlist dict + `text/*` fallback | Set-based allowlist + `text/*` startswith | **Allowlist dict + `text/*` fallback** (API_GUARDIAN) |
+| Plain text rendering | Fenced code block | Raw text (cleaned) | Raw text (cleaned) | **Raw text via `clean_markdown`** (majority) |
+| JSON/XML rendering | Not detailed | Fenced code block with lang hint | Fenced code block with lang hint | **Fenced code block with lang hint** (consensus) |
+| Test approach | 5 test cases listed | 8 test cases listed | 6 test classes, ~25 cases with skeleton | **Comprehensive test file** (TEST_SENTINEL structure) |
+| Risk mitigation | Max content length truncation | Max content length truncation | Max response bytes guard | **Add truncation (P2, not blocking)** |
+
+## Consensus Points
+
+All three proposals agree on:
+
+1. **Root cause**: Line 94 of `backend/src/tools/search.py` — the `fetch_html` content-type guard rejects all non-HTML types
+2. **Fix location**: Single file change in `backend/src/tools/search.py`
+3. **Approach**: Broaden content-type acceptance, branch conversion logic based on type
+4. **No breaking changes**: `web_scrape` tool signature and return type unchanged
+5. **No schema/route/DB changes**: Pure implementation fix
+6. **Separate code path**: The `Loader` class `WebBaseLoader` is unaffected
+7. **Scope**: Small, low risk, additive change
+8. **Tests needed**: Zero existing test coverage for scraping pipeline; new test file required
+
+## Divergence Analysis
+
+### 1. Return type: dataclass vs. tuple
+- SCRAPE_ENGINEER: `FetchResult(content: str, is_html: bool)` — simple but limited
+- API_GUARDIAN: `FetchResult(text: str, content_type: str)` — category string enables richer routing
+- TEST_SENTINEL: `tuple[str, str]` — minimal, no new types
+
+**Council Decision**: Use `FetchResult` dataclass with `content_type` string category. More extensible than boolean, more readable than raw tuple. The category approach (API_GUARDIAN) is cleanest.
+
+### 2. Plain text rendering: code block vs. raw
+- SCRAPE_ENGINEER: Wrap in fenced code block for markdown consistency
+- API_GUARDIAN & TEST_SENTINEL: Return cleaned text as-is
+
+**Council Decision**: Return cleaned text as-is. Plain text (like `llm.txt`) is natural language meant to be read directly. Code blocks add noise for LLM consumption.
+
+### 3. Content-type charset handling
+- SCRAPE_ENGINEER: Substring match handles `text/plain; charset=utf-8` implicitly
+- TEST_SENTINEL: Explicitly strips params with `ctype.split(";")[0].strip()`
+
+**Council Decision**: Explicitly strip charset params (TEST_SENTINEL approach). More robust and intentional.
+
+## Unified Implementation Plan
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/tools/search.py` | Refactor `fetch_html` → `fetch_content`, add `FetchResult`, add `content_to_markdown`, update `url_to_markdown`, update `Accept` header, update error tip |
+| `backend/tests/unit/tools/test_web_scrape.py` | New: comprehensive test suite |
+
+### Implementation Sequence
+
+1. Add `FetchResult` dataclass and `ALLOWED_TEXT_TYPES` dict
+2. Refactor `fetch_html` to `fetch_content` with broadened content-type gate
+3. Add `content_to_markdown` function with type-based routing
+4. Update `url_to_markdown` to use new functions
+5. Update `Accept` header to include `text/plain`
+6. Update error tip message
+7. Write unit tests
+8. Run `make format` and `make test`
+
+### Critical Path
+
+- Step 1-4 are the core fix (unblocks the bug)
+- Step 5-6 are improvements (better HTTP negotiation and error messaging)
+- Step 7-8 are quality gates
+
+### Non-negotiable Requirements
+
+- HTML scraping path must remain unchanged
+- `web_scrape` tool signature must not change
+- `looks_binary` check must remain as safety net
+- Content-type charset params must be stripped before matching
+- Tests must cover: HTML accepted, plain text accepted, binary rejected, charset params handled
+
+## Risk Consolidation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Large text files overwhelming LLM context | Medium | P2: Add max content length truncation (~100KB) |
+| Binary payload with text content-type | Low | Existing `looks_binary()` heuristic handles this |
+| Breaking HTML scraping | High | HTML path is unchanged; only additive branches |
+| `conftest.py` autouse `respx.mock` intercepting test HTTP | Medium | Register mock routes via `respx` in tests |
+| Missing Content-Type header | Low | Reject as unknown (safe default) |
+
+## Final Verdict
+
+- **Recommendation**: GO
+- **Confidence**: High
+- **Rationale**: All three agents independently arrived at essentially the same fix. The bug is clearly isolated to one guard clause. The change is purely additive. No API contracts change. Risk is minimal.

--- a/.claude/specs/bug-612-web-scrape-plain-text/TASKS.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/TASKS.md
@@ -1,0 +1,62 @@
+# Implementation Tasks: Bug #612 - web_scrape Cannot Fetch plain/text Pages
+
+## Pre-Implementation
+
+- [ ] Review REVIEW.md council decisions
+- [ ] Read `backend/src/tools/search.py` fully to understand current implementation
+
+## Core Implementation
+
+- [ ] Task 1: Add `FetchResult` dataclass and `ALLOWED_TEXT_TYPES` constant
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: `FetchResult` has `text: str` and `content_type: str` fields; `ALLOWED_TEXT_TYPES` maps MIME types to category strings (html, plain, json, xml, csv, markdown)
+
+- [ ] Task 2: Refactor `fetch_html` to `fetch_content`
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: Function accepts `text/*` types + allowlisted application types; strips charset params from Content-Type; returns `FetchResult`; rejects binary/unknown types with `ValueError`; `looks_binary` check preserved
+
+- [ ] Task 3: Add `content_to_markdown` routing function
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: HTML → `html_to_markdown`; plain/markdown → `clean_markdown`; json/xml/csv → fenced code block with lang hint; unknown text → `clean_markdown`
+
+- [ ] Task 4: Update `url_to_markdown` to use new functions
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: Calls `fetch_content` then `content_to_markdown`; error handling preserved
+
+## Integration
+
+- [ ] Task 5: Update `Accept` header in `urls_to_markdown`
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: Header includes `text/plain` in addition to existing types
+
+- [ ] Task 6: Update error tip message
+    - Files: `backend/src/tools/search.py`
+    - Acceptance: Error tip no longer mentions "plain text" as a failure cause; refers to binary content and server blocks
+
+## Testing
+
+- [ ] Task 7: Create `backend/tests/unit/tools/test_web_scrape.py`
+    - Files: `backend/tests/unit/tools/test_web_scrape.py`
+    - Acceptance: Tests cover:
+      - `fetch_content` with text/html → accepted
+      - `fetch_content` with text/plain → accepted
+      - `fetch_content` with application/json → accepted
+      - `fetch_content` with image/png → rejected
+      - `fetch_content` with binary payload → rejected
+      - `fetch_content` with charset in content-type → handled
+      - `content_to_markdown` routing for each type
+      - Helper functions: `strip_control_chars`, `looks_binary`, `clean_markdown`
+
+## Verification
+
+- [ ] Run `make format` — no errors
+- [ ] Run `make test` — all tests passing
+- [ ] Typecheck passes
+- [ ] Self-review against REVIEW.md decisions
+
+## Completion Signature
+
+- Total Tasks: 11
+- Dependencies: None (sequential implementation in search.py)
+- Scope: Small
+- Risk: Low

--- a/.claude/specs/bug-612-web-scrape-plain-text/USER_STORIES.md
+++ b/.claude/specs/bug-612-web-scrape-plain-text/USER_STORIES.md
@@ -1,0 +1,31 @@
+# User Stories
+
+## Issue #612: BUG: web_scrape cannot fetch plain/text pages
+
+### Story 1: Fetch Plain Text URLs
+**As a** user of the web scrape tool,
+**I want** to scrape URLs that serve plain text content (e.g., `.txt` files, `text/plain` content-type),
+**So that** I can retrieve and analyze text-based resources without errors.
+
+**Acceptance Criteria:**
+- [ ] Web scraper detects `text/plain` content-type responses
+- [ ] Plain text content is returned directly without HTML parsing
+- [ ] URLs ending in `.txt` are handled correctly
+- [ ] Existing HTML scraping continues to work unchanged
+- [ ] Typecheck passes
+
+### Story 2: Graceful Content-Type Handling
+**As a** developer integrating the web scrape tool,
+**I want** the scraper to handle various content types gracefully (text/plain, text/markdown, text/csv, etc.),
+**So that** non-HTML text responses don't cause failures or empty results.
+
+**Acceptance Criteria:**
+- [ ] Non-HTML text content types are detected and handled
+- [ ] Response content is returned as-is for non-HTML types
+- [ ] Error messages clearly indicate what happened if content cannot be processed
+- [ ] Typecheck passes
+
+## Notes
+- The issue specifically mentions `https://ruska.ai/llm.txt` as a failing URL
+- The scraper currently only processes HTML content, failing on plain text
+- The fix should be in the web scraping backend service/tool

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -1,0 +1,76 @@
+{
+  "project": "Orchestra",
+  "branchName": "bug/612-web-scrape-cannot-fetch-plain-text-pages",
+  "description": "Fix web_scrape to Handle plain/text Pages (Issue #612) - The web_scrape tool fails on text/plain URLs because fetch_html rejects non-HTML content types. Broaden content-type gate and add type-aware markdown conversion.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Refactor fetch_html to Support Text Content Types",
+      "description": "As a developer, I need to refactor the fetch_html function to accept text-based content types so that plain text URLs no longer fail with a ValueError.",
+      "acceptanceCriteria": [
+        "Add FetchResult dataclass with text: str and content_type: str fields to backend/src/tools/search.py",
+        "Add ALLOWED_TEXT_TYPES dict mapping MIME types to category strings (html, plain, json, xml, csv, markdown)",
+        "Rename fetch_html to fetch_content that returns FetchResult",
+        "Content-type gate accepts all text/* types plus allowlisted application/* types (application/json, application/xml, application/xhtml+xml, application/rss+xml, application/atom+xml)",
+        "Charset parameters are stripped from Content-Type before matching (e.g., text/plain; charset=utf-8 → text/plain)",
+        "Binary content still rejected via existing looks_binary() check",
+        "Missing Content-Type header still rejected as unknown",
+        "Existing HTML scraping path unchanged",
+        "Typecheck passes",
+        "make format passes"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add Content-Type-Aware Markdown Conversion",
+      "description": "As a developer, I need a routing function that converts fetched content to markdown based on its content type, so that plain text is not forced through the HTML-to-markdown pipeline.",
+      "acceptanceCriteria": [
+        "Add content_to_markdown function to backend/src/tools/search.py",
+        "HTML (text/html, application/xhtml+xml) routes through existing html_to_markdown",
+        "Plain text (text/plain) routes through clean_markdown (returned as-is, cleaned)",
+        "Markdown (text/markdown) routes through clean_markdown",
+        "JSON (application/json) wrapped in ```json fenced code block",
+        "XML (text/xml, application/xml, application/rss+xml, application/atom+xml) wrapped in ```xml fenced code block",
+        "CSV (text/csv) wrapped in ```csv fenced code block",
+        "Unknown text types fall back to clean_markdown",
+        "Update url_to_markdown to call fetch_content then content_to_markdown",
+        "Update Accept header in urls_to_markdown to include text/plain",
+        "Update error tip message to no longer mention plain text as a failure cause",
+        "Typecheck passes",
+        "make format passes"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add Unit Tests for Web Scrape Pipeline",
+      "description": "As a developer, I need unit tests covering the web scraping pipeline so that the fix is verified and regressions are prevented.",
+      "acceptanceCriteria": [
+        "Create backend/tests/unit/tools/test_web_scrape.py",
+        "Test fetch_content with text/html response → accepted, returns FetchResult with content_type=html",
+        "Test fetch_content with text/plain response → accepted, returns FetchResult with content_type=plain",
+        "Test fetch_content with application/json response → accepted",
+        "Test fetch_content with text/plain; charset=utf-8 → charset stripped, accepted as plain",
+        "Test fetch_content with image/png response → raises ValueError",
+        "Test fetch_content with binary payload but text/html header → raises ValueError (binary detection)",
+        "Test fetch_content with missing Content-Type → raises ValueError",
+        "Test content_to_markdown routes HTML through html_to_markdown",
+        "Test content_to_markdown returns cleaned plain text for text/plain",
+        "Test content_to_markdown wraps JSON in fenced code block",
+        "Test content_to_markdown wraps XML in fenced code block",
+        "Test content_to_markdown wraps CSV in fenced code block",
+        "Test helper functions: strip_control_chars, looks_binary, clean_markdown",
+        "All tests pass with make test",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -69,7 +69,7 @@
         "Typecheck passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     }
   ]

--- a/.ralph/progress.txt
+++ b/.ralph/progress.txt
@@ -4,6 +4,9 @@
 - Cannot import backend modules directly without env vars (POSTGRES_CONNECTION_STRING etc.) — use `python -c "import ast; ast.parse(...)"` for syntax checks
 - `backend/src/tools/search.py` contains the web scraping pipeline: fetch → convert → combine
 - The `urls_to_markdown` function is the main entry point called by the `web_scrape` tool
+- Running tests requires: `POSTGRES_CONNECTION_STRING="postgresql://admin:test1234@localhost:5432/lg_template_test" OPENAI_API_KEY="sk-test" uv run pytest`
+- Pre-existing bug: ChatModels.OPENAI_GPT_5_2 requires OPENAI_API_KEY to be set at import time
+- `.ralph/` is gitignored — use `git add -f` to commit ralph files
 
 ---
 
@@ -29,4 +32,14 @@
 - **Learnings for future iterations:**
   - content_to_markdown is a simple dispatcher — easy to extend for new types
   - FetchResult.content_type category string makes routing clean
+---
+
+## 2026-01-31 - US-003
+- Created backend/tests/unit/tools/test_web_scrape.py with 31 tests
+- All tests pass: helpers, _resolve_content_type, fetch_content, content_to_markdown
+- Files changed: backend/tests/unit/tools/test_web_scrape.py
+- **Learnings for future iterations:**
+  - Tests require POSTGRES_CONNECTION_STRING and OPENAI_API_KEY env vars due to conftest.py loading the full app
+  - Use `httpx.Response` with `request=httpx.Request(...)` for mocking fetch responses
+  - Pre-existing ChatModels.OPENAI_GPT_5_2 bug requires OPENAI_API_KEY to be set for imports
 ---

--- a/.ralph/progress.txt
+++ b/.ralph/progress.txt
@@ -1,0 +1,32 @@
+## Codebase Patterns
+- Backend format: `uvx ruff format` (run from backend dir)
+- Backend lint: `uvx ruff check` (pre-existing unused import warnings exist)
+- Cannot import backend modules directly without env vars (POSTGRES_CONNECTION_STRING etc.) — use `python -c "import ast; ast.parse(...)"` for syntax checks
+- `backend/src/tools/search.py` contains the web scraping pipeline: fetch → convert → combine
+- The `urls_to_markdown` function is the main entry point called by the `web_scrape` tool
+
+---
+
+## 2026-01-31 - US-001
+- Implemented FetchResult dataclass and ALLOWED_TEXT_TYPES mapping
+- Renamed fetch_html → fetch_content returning FetchResult
+- Added _resolve_content_type helper that strips charset params and validates against allowlist
+- All text/* types accepted; specific application/* types allowlisted
+- Updated url_to_markdown to use fetch_content
+- Files changed: backend/src/tools/search.py
+- **Learnings for future iterations:**
+  - The content-type gate was the single point blocking plain text — only needed to broaden the check
+  - charset_normalizer's `from_bytes` works fine for all text types, not just HTML
+  - Pre-existing ruff lint warnings (unused imports) exist and should not block commits
+---
+
+## 2026-01-31 - US-002
+- Added content_to_markdown routing function (HTML→html_to_markdown, plain/markdown→clean_markdown, JSON/XML/CSV→fenced code blocks)
+- Updated url_to_markdown to call fetch_content then content_to_markdown
+- Updated Accept header to include text/plain
+- Updated error tip message to remove plain text mention
+- Files changed: backend/src/tools/search.py
+- **Learnings for future iterations:**
+  - content_to_markdown is a simple dispatcher — easy to extend for new types
+  - FetchResult.content_type category string makes routing clean
+---

--- a/Changelog.md
+++ b/Changelog.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - FEAT: Truncate Tool Calls. Allow extension (cli) #54
 
 ### Fixed
+  - bug/612-web-scrape-cannot-fetch-plain-text-pages (2026-01-31)
   - bug/705-fallback-searxng-from-exa (2026-01-29)
   - bug/662-fix-db-timeout (2026-01-19)
   - bug/677-nonetype-items-attributeerror (2026-01-16)

--- a/backend/src/tools/search.py
+++ b/backend/src/tools/search.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 import unicodedata
+from dataclasses import dataclass
 from typing import Literal, List, Optional, Tuple, Union
 
 import httpx
@@ -76,23 +77,64 @@ def clean_markdown(md_text: str) -> str:
 # -----------------------------
 # Fetch + convert
 # -----------------------------
-async def fetch_html(client: httpx.AsyncClient, url: str) -> str:
+@dataclass
+class FetchResult:
+    """Result of fetching a URL with its detected content type category."""
+
+    text: str
+    content_type: str
+
+
+ALLOWED_TEXT_TYPES: dict[str, str] = {
+    "text/html": "html",
+    "text/plain": "plain",
+    "text/csv": "csv",
+    "text/markdown": "markdown",
+    "text/xml": "xml",
+    "application/json": "json",
+    "application/xml": "xml",
+    "application/xhtml+xml": "html",
+    "application/rss+xml": "xml",
+    "application/atom+xml": "xml",
+}
+
+
+def _resolve_content_type(raw: str) -> str:
+    """Strip charset/parameters and match against ALLOWED_TEXT_TYPES.
+
+    Returns the category string (e.g. "html", "plain") or raises ValueError.
     """
-    Fetch HTML content from a URL safely.
+    if not raw:
+        raise ValueError("Non-text content-type: unknown")
+
+    # Strip parameters like "; charset=utf-8"
+    mime = raw.split(";")[0].strip().lower()
+
+    # Check explicit allowlist first
+    if mime in ALLOWED_TEXT_TYPES:
+        return ALLOWED_TEXT_TYPES[mime]
+
+    # Accept any text/* not in the allowlist as a fallback
+    if mime.startswith("text/"):
+        return "plain"
+
+    raise ValueError(f"Non-text content-type: {raw}")
+
+
+async def fetch_content(client: httpx.AsyncClient, url: str) -> FetchResult:
+    """
+    Fetch text-based content from a URL safely.
 
     Key protections:
-    - Reject non-HTML content-types (PDFs/images/zips/etc.)
+    - Reject non-text content-types (PDFs/images/zips/etc.)
     - Reject likely-binary payloads
-    - Robust decode from bytes (don’t trust server charset headers)
+    - Robust decode from bytes (don't trust server charset headers)
     """
     r = await client.get(url)
     r.raise_for_status()
 
     ctype = (r.headers.get("content-type") or "").lower()
-
-    # Only accept HTML-ish responses
-    if ("text/html" not in ctype) and ("application/xhtml+xml" not in ctype):
-        raise ValueError(f"Non-HTML content-type: {ctype or 'unknown'}")
+    category = _resolve_content_type(ctype)
 
     data = r.content
 
@@ -101,10 +143,10 @@ async def fetch_html(client: httpx.AsyncClient, url: str) -> str:
         raise ValueError("Response looks binary/compressed; refusing to decode as text")
 
     # Robust decode (handles missing/wrong charset)
-    html = str(from_bytes(data).best())
+    decoded = str(from_bytes(data).best())
 
     # Final safety
-    return strip_control_chars(html)
+    return FetchResult(text=strip_control_chars(decoded), content_type=category)
 
 
 async def html_to_markdown(html: str) -> str:
@@ -121,8 +163,8 @@ async def url_to_markdown(
     """Fetch a URL and convert to markdown with concurrency control."""
     try:
         async with sem:
-            html = await fetch_html(client, url)
-            md_text = await html_to_markdown(html)
+            result = await fetch_content(client, url)
+            md_text = await html_to_markdown(result.text)
             return url, md_text
     except Exception as e:
         return url, e

--- a/backend/src/tools/search.py
+++ b/backend/src/tools/search.py
@@ -155,6 +155,29 @@ async def html_to_markdown(html: str) -> str:
     return clean_markdown(md_text)
 
 
+async def content_to_markdown(result: FetchResult) -> str:
+    """Route fetched content to the appropriate markdown converter based on content type."""
+    ct = result.content_type
+
+    if ct == "html":
+        return await html_to_markdown(result.text)
+
+    if ct in ("plain", "markdown"):
+        return clean_markdown(result.text)
+
+    if ct == "json":
+        return f"```json\n{result.text}\n```"
+
+    if ct == "xml":
+        return f"```xml\n{result.text}\n```"
+
+    if ct == "csv":
+        return f"```csv\n{result.text}\n```"
+
+    # Unknown text types fall back to clean_markdown
+    return clean_markdown(result.text)
+
+
 async def url_to_markdown(
     client: httpx.AsyncClient,
     url: str,
@@ -164,7 +187,7 @@ async def url_to_markdown(
     try:
         async with sem:
             result = await fetch_content(client, url)
-            md_text = await html_to_markdown(result.text)
+            md_text = await content_to_markdown(result)
             return url, md_text
     except Exception as e:
         return url, e
@@ -188,8 +211,8 @@ async def urls_to_markdown(
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/131.0.0.0 Safari/537.36"
             ),
-            # Prefer HTML; still allow */* so some sites respond, but we gate by Content-Type anyway
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            # Prefer HTML but accept plain text and other text types too
+            "Accept": "text/html,application/xhtml+xml,text/plain,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": "en-US,en;q=0.9",
             # IMPORTANT: avoid brotli unless your runtime supports it
             "Accept-Encoding": "gzip, deflate",
@@ -209,8 +232,8 @@ async def urls_to_markdown(
                     f"<!-- SOURCE: {url} -->\n\n"
                     f"## Fetch/convert failed\n\n"
                     f"**Error:** `{type(outcome).__name__}: {outcome}`\n\n"
-                    f"> Tip: This often happens when the URL returns a PDF/image, "
-                    f"> or the payload is compressed/binary."
+                    f"> Tip: This often happens when the URL returns a PDF, image, "
+                    f"> or other binary/compressed content."
                 )
             )
             continue

--- a/backend/tests/unit/tools/test_web_scrape.py
+++ b/backend/tests/unit/tools/test_web_scrape.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for the web scrape pipeline: fetch_content, content_to_markdown,
+and helper functions (strip_control_chars, looks_binary, clean_markdown).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from src.tools.search import (
+    FetchResult,
+    ALLOWED_TEXT_TYPES,
+    _resolve_content_type,
+    fetch_content,
+    content_to_markdown,
+    strip_control_chars,
+    looks_binary,
+    clean_markdown,
+)
+
+
+# -----------------------------
+# Helper function tests
+# -----------------------------
+class TestStripControlChars:
+    """Tests for strip_control_chars helper."""
+
+    def test_keeps_normal_text(self):
+        assert strip_control_chars("hello world") == "hello world"
+
+    def test_keeps_newlines_and_tabs(self):
+        assert strip_control_chars("hello\n\tworld") == "hello\n\tworld"
+
+    def test_removes_control_chars(self):
+        # \x00 NUL, \x01 SOH, \x07 BEL
+        assert strip_control_chars("he\x00ll\x01o\x07") == "hello"
+
+
+class TestLooksBinary:
+    """Tests for looks_binary helper."""
+
+    def test_empty_data_is_not_binary(self):
+        assert looks_binary(b"") is False
+
+    def test_text_data_is_not_binary(self):
+        assert looks_binary(b"Hello, this is plain text\n") is False
+
+    def test_binary_data_detected(self):
+        # Lots of null bytes
+        assert looks_binary(b"\x00\x01\x02\x03" * 100) is True
+
+    def test_html_is_not_binary(self):
+        assert looks_binary(b"<html><body>Hello</body></html>") is False
+
+
+class TestCleanMarkdown:
+    """Tests for clean_markdown helper."""
+
+    def test_collapses_excessive_newlines(self):
+        result = clean_markdown("a\n\n\n\nb")
+        assert result == "a\n\nb"
+
+    def test_strips_trailing_whitespace(self):
+        result = clean_markdown("hello   \nworld   ")
+        assert result == "hello\nworld"
+
+    def test_normalizes_line_endings(self):
+        result = clean_markdown("a\r\nb\rc")
+        assert result == "a\nb\nc"
+
+
+# -----------------------------
+# _resolve_content_type tests
+# -----------------------------
+class TestResolveContentType:
+    """Tests for _resolve_content_type."""
+
+    def test_html(self):
+        assert _resolve_content_type("text/html") == "html"
+
+    def test_plain(self):
+        assert _resolve_content_type("text/plain") == "plain"
+
+    def test_json(self):
+        assert _resolve_content_type("application/json") == "json"
+
+    def test_xml(self):
+        assert _resolve_content_type("application/xml") == "xml"
+
+    def test_charset_stripped(self):
+        assert _resolve_content_type("text/plain; charset=utf-8") == "plain"
+
+    def test_unknown_text_falls_back_to_plain(self):
+        assert _resolve_content_type("text/x-custom") == "plain"
+
+    def test_binary_rejected(self):
+        with pytest.raises(ValueError, match="Non-text content-type"):
+            _resolve_content_type("image/png")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="Non-text content-type"):
+            _resolve_content_type("")
+
+
+# -----------------------------
+# fetch_content tests
+# -----------------------------
+class TestFetchContent:
+    """Tests for fetch_content function."""
+
+    def _make_response(self, content: bytes, content_type: str, status_code: int = 200):
+        """Create a mock httpx.Response."""
+        request = httpx.Request("GET", "http://example.com")
+        response = httpx.Response(
+            status_code=status_code,
+            content=content,
+            headers={"content-type": content_type},
+            request=request,
+        )
+        return response
+
+    @pytest.mark.asyncio
+    async def test_html_response_accepted(self):
+        client = AsyncMock()
+        client.get.return_value = self._make_response(
+            b"<html><body>Hello</body></html>", "text/html; charset=utf-8"
+        )
+        result = await fetch_content(client, "http://example.com")
+        assert result.content_type == "html"
+        assert "Hello" in result.text
+
+    @pytest.mark.asyncio
+    async def test_plain_text_accepted(self):
+        client = AsyncMock()
+        client.get.return_value = self._make_response(b"Hello plain text", "text/plain")
+        result = await fetch_content(client, "http://example.com")
+        assert result.content_type == "plain"
+        assert "Hello plain text" in result.text
+
+    @pytest.mark.asyncio
+    async def test_json_accepted(self):
+        client = AsyncMock()
+        client.get.return_value = self._make_response(
+            b'{"key": "value"}', "application/json"
+        )
+        result = await fetch_content(client, "http://example.com")
+        assert result.content_type == "json"
+
+    @pytest.mark.asyncio
+    async def test_charset_stripped(self):
+        client = AsyncMock()
+        client.get.return_value = self._make_response(
+            b"plain content", "text/plain; charset=utf-8"
+        )
+        result = await fetch_content(client, "http://example.com")
+        assert result.content_type == "plain"
+
+    @pytest.mark.asyncio
+    async def test_image_rejected(self):
+        client = AsyncMock()
+        client.get.return_value = self._make_response(b"\x89PNG\r\n", "image/png")
+        with pytest.raises(ValueError, match="Non-text content-type"):
+            await fetch_content(client, "http://example.com")
+
+    @pytest.mark.asyncio
+    async def test_binary_payload_rejected(self):
+        client = AsyncMock()
+        # text/html header but binary content
+        client.get.return_value = self._make_response(
+            b"\x00\x01\x02\x03" * 500, "text/html"
+        )
+        with pytest.raises(ValueError, match="binary"):
+            await fetch_content(client, "http://example.com")
+
+    @pytest.mark.asyncio
+    async def test_missing_content_type_rejected(self):
+        request = httpx.Request("GET", "http://example.com")
+        response = httpx.Response(
+            status_code=200,
+            content=b"some text",
+            headers={},
+            request=request,
+        )
+        client = AsyncMock()
+        client.get.return_value = response
+        with pytest.raises(ValueError, match="Non-text content-type"):
+            await fetch_content(client, "http://example.com")
+
+
+# -----------------------------
+# content_to_markdown tests
+# -----------------------------
+class TestContentToMarkdown:
+    """Tests for content_to_markdown routing function."""
+
+    @pytest.mark.asyncio
+    async def test_html_routes_through_html_to_markdown(self):
+        result = FetchResult(text="<h1>Title</h1><p>Body</p>", content_type="html")
+        md = await content_to_markdown(result)
+        # Should contain converted markdown, not raw HTML
+        assert "Title" in md
+        assert "<h1>" not in md
+
+    @pytest.mark.asyncio
+    async def test_plain_text_returned_cleaned(self):
+        result = FetchResult(text="Hello\n\n\n\nworld", content_type="plain")
+        md = await content_to_markdown(result)
+        assert md == "Hello\n\nworld"
+
+    @pytest.mark.asyncio
+    async def test_json_wrapped_in_code_block(self):
+        result = FetchResult(text='{"key": "value"}', content_type="json")
+        md = await content_to_markdown(result)
+        assert md.startswith("```json\n")
+        assert md.endswith("\n```")
+        assert '{"key": "value"}' in md
+
+    @pytest.mark.asyncio
+    async def test_xml_wrapped_in_code_block(self):
+        result = FetchResult(text="<root><item/></root>", content_type="xml")
+        md = await content_to_markdown(result)
+        assert md.startswith("```xml\n")
+        assert md.endswith("\n```")
+
+    @pytest.mark.asyncio
+    async def test_csv_wrapped_in_code_block(self):
+        result = FetchResult(text="a,b,c\n1,2,3", content_type="csv")
+        md = await content_to_markdown(result)
+        assert md.startswith("```csv\n")
+        assert md.endswith("\n```")
+
+    @pytest.mark.asyncio
+    async def test_markdown_returned_cleaned(self):
+        result = FetchResult(text="# Title\n\nBody", content_type="markdown")
+        md = await content_to_markdown(result)
+        assert "# Title" in md

--- a/tasks/prd-web-scrape-plain-text.md
+++ b/tasks/prd-web-scrape-plain-text.md
@@ -1,0 +1,115 @@
+# PRD: Fix web_scrape to Handle plain/text Pages (Issue #612)
+
+## Introduction
+
+The `web_scrape` tool in Orchestra's backend fails when fetching URLs that serve `text/plain` content (e.g., `.txt` files like `https://ruska.ai/llm.txt`). The `fetch_html` function in `backend/src/tools/search.py` explicitly rejects any response whose `Content-Type` is not `text/html` or `application/xhtml+xml`, causing a `ValueError` for all plain text URLs. This bug prevents agents from reading text-based resources that are not HTML.
+
+The fix broadens the content-type gate to accept text-based MIME types and routes non-HTML content through an appropriate conversion path instead of forcing everything through the HTML-to-markdown pipeline.
+
+## Goals
+
+- Fix the `web_scrape` tool to successfully fetch and return `text/plain` content
+- Support additional text-based content types (`application/json`, `text/xml`, `text/csv`, `text/markdown`)
+- Preserve existing HTML scraping behavior unchanged
+- Add unit test coverage for the scraping pipeline (currently at zero)
+- Keep the `web_scrape` tool API contract unchanged (returns `str` markdown)
+
+## User Stories
+
+### US-001: Refactor fetch_html to Support Text Content Types
+**Description:** As a developer, I need to refactor the `fetch_html` function to accept text-based content types so that plain text URLs no longer fail with a ValueError.
+
+**Acceptance Criteria:**
+- [ ] Add `FetchResult` dataclass with `text: str` and `content_type: str` fields to `backend/src/tools/search.py`
+- [ ] Add `ALLOWED_TEXT_TYPES` dict mapping MIME types to category strings (`html`, `plain`, `json`, `xml`, `csv`, `markdown`)
+- [ ] Rename `fetch_html` to `fetch_content` that returns `FetchResult`
+- [ ] Content-type gate accepts all `text/*` types plus allowlisted `application/*` types (`application/json`, `application/xml`, `application/xhtml+xml`, `application/rss+xml`, `application/atom+xml`)
+- [ ] Charset parameters are stripped from Content-Type before matching (e.g., `text/plain; charset=utf-8` → `text/plain`)
+- [ ] Binary content still rejected via existing `looks_binary()` check
+- [ ] Missing Content-Type header still rejected as unknown
+- [ ] Existing HTML scraping path unchanged
+- [ ] Typecheck passes
+- [ ] `make format` passes
+
+### US-002: Add Content-Type-Aware Markdown Conversion
+**Description:** As a developer, I need a routing function that converts fetched content to markdown based on its content type, so that plain text is not forced through the HTML-to-markdown pipeline.
+
+**Acceptance Criteria:**
+- [ ] Add `content_to_markdown` function to `backend/src/tools/search.py`
+- [ ] HTML (`text/html`, `application/xhtml+xml`) routes through existing `html_to_markdown`
+- [ ] Plain text (`text/plain`) routes through `clean_markdown` (returned as-is, cleaned)
+- [ ] Markdown (`text/markdown`) routes through `clean_markdown`
+- [ ] JSON (`application/json`) wrapped in ` ```json ` fenced code block
+- [ ] XML (`text/xml`, `application/xml`, `application/rss+xml`, `application/atom+xml`) wrapped in ` ```xml ` fenced code block
+- [ ] CSV (`text/csv`) wrapped in ` ```csv ` fenced code block
+- [ ] Unknown text types fall back to `clean_markdown`
+- [ ] Update `url_to_markdown` to call `fetch_content` then `content_to_markdown`
+- [ ] Update `Accept` header in `urls_to_markdown` to include `text/plain`
+- [ ] Update error tip message to no longer mention plain text as a failure cause
+- [ ] Typecheck passes
+- [ ] `make format` passes
+
+### US-003: Add Unit Tests for Web Scrape Pipeline
+**Description:** As a developer, I need unit tests covering the web scraping pipeline so that the fix is verified and regressions are prevented.
+
+**Acceptance Criteria:**
+- [ ] Create `backend/tests/unit/tools/test_web_scrape.py`
+- [ ] Test `fetch_content` with `text/html` response → accepted, returns `FetchResult` with `content_type="html"`
+- [ ] Test `fetch_content` with `text/plain` response → accepted, returns `FetchResult` with `content_type="plain"`
+- [ ] Test `fetch_content` with `application/json` response → accepted
+- [ ] Test `fetch_content` with `text/plain; charset=utf-8` → charset stripped, accepted as `plain`
+- [ ] Test `fetch_content` with `image/png` response → raises `ValueError`
+- [ ] Test `fetch_content` with binary payload but `text/html` header → raises `ValueError` (binary detection)
+- [ ] Test `fetch_content` with missing Content-Type → raises `ValueError`
+- [ ] Test `content_to_markdown` routes HTML through `html_to_markdown`
+- [ ] Test `content_to_markdown` returns cleaned plain text for `text/plain`
+- [ ] Test `content_to_markdown` wraps JSON in fenced code block
+- [ ] Test `content_to_markdown` wraps XML in fenced code block
+- [ ] Test `content_to_markdown` wraps CSV in fenced code block
+- [ ] Test helper functions: `strip_control_chars`, `looks_binary`, `clean_markdown`
+- [ ] All tests pass with `make test`
+- [ ] Typecheck passes
+
+## Functional Requirements
+
+- FR-1: The `fetch_content` function must accept any `text/*` MIME type and allowlisted `application/*` types
+- FR-2: The `fetch_content` function must strip charset parameters from Content-Type before matching
+- FR-3: The `fetch_content` function must reject non-text content types with a `ValueError`
+- FR-4: The `fetch_content` function must reject binary payloads via `looks_binary()` regardless of Content-Type header
+- FR-5: The `content_to_markdown` function must route HTML through `html_to_markdown`
+- FR-6: The `content_to_markdown` function must return plain text through `clean_markdown` without HTML parsing
+- FR-7: The `content_to_markdown` function must wrap JSON, XML, and CSV in language-hinted fenced code blocks
+- FR-8: The `web_scrape` tool must continue to return `str` (markdown) — no API contract change
+- FR-9: The `Accept` header must include `text/plain` to signal willingness to receive plain text
+- FR-10: Error tip messages must accurately describe failure causes (binary content, server blocks)
+
+## Non-Goals
+
+- No max content length truncation (deferred to P2)
+- No pretty-printing of JSON content (return as-is in code block)
+- No changes to the `Loader` class or `WebBaseLoader` (separate code path)
+- No changes to API routes, schemas, or database
+- No frontend changes
+- No changes to `web_search` function (only `web_scrape` affected)
+
+## Technical Considerations
+
+- **Single file change**: All scraping logic lives in `backend/src/tools/search.py` (lines 24-179)
+- **Separate code path**: The `Loader` class in `backend/src/loaders/__init__.py` uses `WebBaseLoader` for document ingestion — this is NOT affected by this bug
+- **Existing safety**: `looks_binary()` heuristic and `charset_normalizer` (`from_bytes`) are already used for HTML and work for plain text
+- **httpx handles**: Content-Encoding decompression (gzip), redirect following (`follow_redirects=True`)
+- **Test infrastructure**: `conftest.py` uses `respx.mock` as autouse fixture — tests must register mock routes via `respx`
+- **Dependencies**: No new dependencies needed; `httpx`, `charset_normalizer`, `markdownify` already installed
+
+## Success Metrics
+
+- `web_scrape` successfully fetches and returns content from `text/plain` URLs (e.g., `https://ruska.ai/llm.txt`)
+- All existing HTML scraping continues to work (no regressions)
+- Unit test coverage added for the scraping pipeline
+- All tests pass (`make test`)
+- Typecheck passes
+
+## Open Questions
+
+- Should a max content length (e.g., 100KB) be added to prevent very large text files from overwhelming LLM context? (Deferred to P2)
+- Should responses with no Content-Type header attempt text detection instead of rejecting? (Current decision: reject as safe default)


### PR DESCRIPTION
- init bug/612-web-scrape-cannot-fetch-plain-text-pages
- feat: [US-001] - Refactor fetch_html to Support Text Content Types
- feat: [US-002] - Add Content-Type-Aware Markdown Conversion
- feat: [US-003] - Add Unit Tests for Web Scrape Pipeline
- create pr
Closes #612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web scraping now supports plain text, JSON, XML, and CSV content types in addition to HTML.

* **Bug Fixes**
  * Fixed handling of plain text web pages that previously failed to process.
  * Improved error messaging to clarify when content types are unsupported.

* **Tests**
  * Added comprehensive unit tests covering various content type scenarios and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->