### PR TITLE
feat(skills): Pre-Configure Deep Agent Backend with Skill-Builder (#729)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.0.2-rc142
 
 ### Changed
+  - feat/729-pre-configure-deep-agent-backend-skill-builder (2026-02-04)
   - feat/722-frontend-schedule-refactor (2026-02-01)
   - feat/724-add-watcher-to-worker-reload (2026-02-01)
   - feat/715-ubuntu-execution-env (2026-01-31)

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -28,6 +28,8 @@ from src.schemas.contexts import ContextSchema
 from src.schemas.entities.a2a import A2AServers
 from src.utils.middleware import init_default_middleware
 from src.tools import default_tools
+from src.services.skill import SkillService
+from src.schemas.entities.skill import SkillTemplate
 
 
 CACHE_LLM = InMemoryCache()
@@ -148,6 +150,41 @@ async def init_subagents(
             subagent_dict["model"] = subagent.model
         result.append(subagent_dict)
     return result
+
+
+async def init_skills_as_subagents(
+    skill_service: SkillService,
+    service_context: ServiceContext,
+    categories: list[str] = None,
+) -> list[SubAgent]:
+    """Convert enabled skills into subagent dictionaries."""
+    skills = await skill_service.get_enabled_skills(categories=categories)
+    subagents = []
+
+    for skill in skills:
+        # Initialize tools for the skill
+        tools = await init_tools(
+            skill.tools,
+            None,  # a2a - skills don't use A2A by default
+            None,  # mcp - skills don't use MCP by default
+            service_context,
+        )
+
+        # Build subagent dict matching deepagents format
+        subagent_dict = {
+            "name": skill.slug,
+            "description": skill.description,
+            "system_prompt": skill.system_prompt,
+            "tools": tools,
+        }
+
+        if skill.model:
+            subagent_dict["model"] = skill.model
+
+        subagents.append(subagent_dict)
+        logger.debug(f"Loaded skill subagent: {skill.slug}")
+
+    return subagents
 
 
 async def init_memories(system_prompt: str, tools: list[BaseTool]):

--- a/backend/src/constants/skills.py
+++ b/backend/src/constants/skills.py
@@ -1,0 +1,55 @@
+"""Built-in skill templates for the deep agent system."""
+
+from src.schemas.entities.skill import SkillTemplate
+
+
+RESEARCH_SKILL = SkillTemplate(
+    name="Research Agent",
+    description=(
+        "Performs comprehensive web research, searches multiple sources, "
+        "and synthesizes findings into structured reports. Use for any task "
+        "requiring web search, fact verification, or information gathering."
+    ),
+    category="research",
+    system_prompt=(
+        "You are a Research Specialist focused on thorough information gathering.\n\n"
+        "Your approach:\n"
+        "1. Break down complex queries into searchable components\n"
+        "2. Search multiple sources for comprehensive coverage\n"
+        "3. Cross-reference findings for accuracy\n"
+        "4. Synthesize information into clear, structured reports\n"
+        "5. Cite sources and note confidence levels\n\n"
+        "Always prioritize accuracy over speed. When uncertain, search for verification."
+    ),
+    tools=["web_search", "think_tool"],
+    enabled=True,
+)
+
+
+CODE_SKILL = SkillTemplate(
+    name="Code Engineer",
+    description=(
+        "Writes, reviews, and refactors code with best practices. Use for any task "
+        "requiring code generation, debugging, or technical implementation."
+    ),
+    category="engineering",
+    system_prompt=(
+        "You are a Code Engineer focused on clean, maintainable code.\n\n"
+        "Your approach:\n"
+        "1. Understand requirements before writing code\n"
+        "2. Follow language-specific best practices\n"
+        "3. Write clear, self-documenting code\n"
+        "4. Include error handling and edge cases\n"
+        "5. Test your implementations\n\n"
+        "Prioritize readability and maintainability. Avoid over-engineering."
+    ),
+    tools=["think_tool"],
+    enabled=True,
+)
+
+
+# List of all built-in skills
+BUILTIN_SKILLS: list[SkillTemplate] = [
+    RESEARCH_SKILL,
+    CODE_SKILL,
+]

--- a/backend/src/routes/v0/__init__.py
+++ b/backend/src/routes/v0/__init__.py
@@ -18,6 +18,7 @@ from .api_tokens import router as api_tokens
 from .share import router as share
 from .settings import router as settings
 from .memory import router as memory
+from .skill import router as skill
 
 
 def create_api_router(app: FastAPI, prefix: str = "/api"):
@@ -39,6 +40,7 @@ def create_api_router(app: FastAPI, prefix: str = "/api"):
     app.include_router(share, prefix=prefix)
     app.include_router(settings, prefix=prefix)
     app.include_router(memory, prefix=prefix)
+    app.include_router(skill, prefix=prefix)
     return app
 
 

--- a/backend/src/routes/v0/skill.py
+++ b/backend/src/routes/v0/skill.py
@@ -1,0 +1,68 @@
+"""Skills API endpoints for skill discovery."""
+
+from typing import Optional
+from fastapi import APIRouter, HTTPException, Query, status
+from src.schemas.entities.skill import SkillTemplate, SkillsResponse
+from src.services.skill import skill_service
+
+router = APIRouter(prefix="/skills", tags=["Skills"])
+
+
+@router.get(
+    "",
+    response_model=SkillsResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "List of available skill templates",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "skills": [
+                            {
+                                "name": "Research Agent",
+                                "description": "Performs comprehensive web research...",
+                                "category": "research",
+                                "slug": "research-agent",
+                                "tools": ["web_search", "think_tool"],
+                                "enabled": True,
+                            }
+                        ],
+                        "total": 1,
+                    }
+                }
+            },
+        }
+    },
+)
+async def list_skills(
+    category: Optional[str] = Query(
+        default=None, description="Filter skills by category"
+    ),
+):
+    """List available skill templates."""
+    categories = [category] if category else None
+    skills = await skill_service.get_enabled_skills(categories=categories)
+    return SkillsResponse(skills=skills)
+
+
+@router.get(
+    "/{slug}",
+    response_model=SkillTemplate,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Skill template details",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Skill not found",
+            "content": {"application/json": {"example": {"detail": "Skill not found"}}},
+        },
+    },
+)
+async def get_skill(slug: str):
+    """Get a skill template by slug."""
+    skill = await skill_service.get_skill(slug)
+    if not skill:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Skill not found"
+        )
+    return skill

--- a/backend/src/schemas/entities/skill.py
+++ b/backend/src/schemas/entities/skill.py
@@ -1,0 +1,53 @@
+"""Skill template schema for pre-configured agent skills."""
+
+from typing import Optional
+from pydantic import BaseModel, Field, computed_field
+from src.utils.format import slugify
+
+
+class SkillTemplate(BaseModel):
+    """Schema for a pre-configured skill template that can be converted to a SubAgent."""
+
+    name: str = Field(..., description="Display name of the skill")
+    description: str = Field(
+        ..., description="Description used for supervisor routing decisions"
+    )
+    category: str = Field(default="general", description="Skill category for filtering")
+    system_prompt: str = Field(..., description="System prompt for the skill agent")
+    tools: list[str] = Field(
+        default_factory=list, description="List of tool names available to this skill"
+    )
+    model: Optional[str] = Field(
+        default=None, description="Optional model override for this skill"
+    )
+    enabled: bool = Field(default=True, description="Whether the skill is enabled")
+
+    @computed_field
+    @property
+    def slug(self) -> str:
+        """Generate URL-friendly slug from name."""
+        return slugify(self.name)
+
+    def to_subagent_dict(self) -> dict:
+        """Convert to SubAgent dictionary format expected by deepagents."""
+        result = {
+            "name": self.slug,
+            "description": self.description,
+            "system_prompt": self.system_prompt,
+            "tools": self.tools,
+        }
+        if self.model:
+            result["model"] = self.model
+        return result
+
+
+class SkillsResponse(BaseModel):
+    """Response model for skills list endpoint."""
+
+    skills: list[SkillTemplate] = Field(default_factory=list)
+
+    @computed_field
+    @property
+    def total(self) -> int:
+        """Total number of skills in the response."""
+        return len(self.skills)

--- a/backend/src/services/skill.py
+++ b/backend/src/services/skill.py
@@ -1,0 +1,38 @@
+"""Skill service for managing skill templates."""
+
+from typing import Optional
+from src.schemas.entities.skill import SkillTemplate
+from src.constants.skills import BUILTIN_SKILLS
+
+
+class SkillService:
+    """Service for retrieving and managing skill templates."""
+
+    def __init__(self, user_id: Optional[str] = None):
+        self.user_id = user_id
+
+    async def get_enabled_skills(
+        self, categories: Optional[list[str]] = None
+    ) -> list[SkillTemplate]:
+        """Get all enabled skills, optionally filtered by category."""
+        skills = [s for s in BUILTIN_SKILLS if s.enabled]
+
+        if categories:
+            skills = [s for s in skills if s.category in categories]
+
+        return skills
+
+    async def get_skill(self, slug: str) -> Optional[SkillTemplate]:
+        """Get a skill by its slug."""
+        for skill in BUILTIN_SKILLS:
+            if skill.slug == slug:
+                return skill
+        return None
+
+    async def get_all_skills(self) -> list[SkillTemplate]:
+        """Get all skills regardless of enabled status."""
+        return list(BUILTIN_SKILLS)
+
+
+# Default service instance
+skill_service = SkillService()

--- a/backend/tests/integration/test_skill_routes.py
+++ b/backend/tests/integration/test_skill_routes.py
@@ -1,0 +1,74 @@
+"""Integration tests for skills API routes."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_list_skills_endpoint(async_client: AsyncClient):
+    """Test GET /api/skills returns skills list."""
+    response = await async_client.get("/api/skills")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "skills" in data
+    assert "total" in data
+    assert isinstance(data["skills"], list)
+    assert data["total"] >= 2  # At least research-agent and code-engineer
+
+
+@pytest.mark.asyncio
+async def test_list_skills_with_category_filter(async_client: AsyncClient):
+    """Test GET /api/skills with category filter."""
+    response = await async_client.get("/api/skills?category=research")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "skills" in data
+    # All returned skills should be in research category
+    for skill in data["skills"]:
+        assert skill["category"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_get_skill_by_slug(async_client: AsyncClient):
+    """Test GET /api/skills/{slug} returns skill details."""
+    response = await async_client.get("/api/skills/research-agent")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Research Agent"
+    assert data["slug"] == "research-agent"
+    assert "description" in data
+    assert "tools" in data
+    assert "system_prompt" in data
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_skill_returns_404(async_client: AsyncClient):
+    """Test GET /api/skills/{slug} returns 404 for nonexistent skill."""
+    response = await async_client.get("/api/skills/does-not-exist")
+
+    assert response.status_code == 404
+    data = response.json()
+    assert "detail" in data
+    assert data["detail"] == "Skill not found"
+
+
+@pytest.mark.asyncio
+async def test_skill_response_structure(async_client: AsyncClient):
+    """Test that skill response has correct structure."""
+    response = await async_client.get("/api/skills")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check first skill has required fields
+    if data["skills"]:
+        skill = data["skills"][0]
+        assert "name" in skill
+        assert "description" in skill
+        assert "slug" in skill
+        assert "category" in skill
+        assert "tools" in skill
+        assert "enabled" in skill

--- a/backend/tests/unit/schemas/test_skill_template.py
+++ b/backend/tests/unit/schemas/test_skill_template.py
@@ -1,0 +1,124 @@
+"""Test skill template schema module."""
+
+import unittest
+from src.schemas.entities.skill import SkillTemplate, SkillsResponse
+
+
+class TestSkillTemplate(unittest.TestCase):
+    """Tests for SkillTemplate schema."""
+
+    def test_skill_template_creation(self):
+        """Test valid skill template creation."""
+        skill = SkillTemplate(
+            name="Test Skill",
+            description="A test skill",
+            system_prompt="You are a test agent.",
+            tools=["web_search"]
+        )
+
+        assert skill.name == "Test Skill"
+        assert skill.description == "A test skill"
+        assert skill.enabled is True
+        assert skill.category == "general"
+
+    def test_slug_generation(self):
+        """Test that slug is correctly computed from name."""
+        skill = SkillTemplate(
+            name="Test Skill Name",
+            description="Test",
+            system_prompt="Prompt"
+        )
+
+        assert skill.slug == "test-skill-name"
+
+    def test_slug_with_special_characters(self):
+        """Test slug generation with special characters."""
+        skill = SkillTemplate(
+            name="Test Skill (v2.0)",
+            description="Test",
+            system_prompt="Prompt"
+        )
+
+        # Should only contain alphanumeric and hyphens
+        assert "-" in skill.slug or skill.slug.isalnum()
+        assert " " not in skill.slug
+        assert "(" not in skill.slug
+
+    def test_to_subagent_dict(self):
+        """Test conversion to subagent dictionary format."""
+        skill = SkillTemplate(
+            name="Test Skill",
+            description="Test description",
+            system_prompt="Test prompt",
+            tools=["tool1", "tool2"]
+        )
+
+        result = skill.to_subagent_dict()
+
+        assert result["name"] == "test-skill"
+        assert result["description"] == "Test description"
+        assert result["system_prompt"] == "Test prompt"
+        assert result["tools"] == ["tool1", "tool2"]
+        assert "model" not in result
+
+    def test_to_subagent_dict_with_model(self):
+        """Test conversion includes model when specified."""
+        skill = SkillTemplate(
+            name="Test Skill",
+            description="Test",
+            system_prompt="Prompt",
+            model="gpt-4"
+        )
+
+        result = skill.to_subagent_dict()
+
+        assert result["model"] == "gpt-4"
+
+    def test_default_tools_empty_list(self):
+        """Test that tools defaults to empty list."""
+        skill = SkillTemplate(
+            name="Test",
+            description="Test",
+            system_prompt="Prompt"
+        )
+
+        assert skill.tools == []
+
+    def test_disabled_skill(self):
+        """Test creating a disabled skill."""
+        skill = SkillTemplate(
+            name="Disabled Skill",
+            description="Test",
+            system_prompt="Prompt",
+            enabled=False
+        )
+
+        assert skill.enabled is False
+
+
+class TestSkillsResponse(unittest.TestCase):
+    """Tests for SkillsResponse schema."""
+
+    def test_skills_response_total(self):
+        """Test that total is computed from skills list."""
+        skill1 = SkillTemplate(
+            name="Skill 1",
+            description="Test",
+            system_prompt="Prompt"
+        )
+        skill2 = SkillTemplate(
+            name="Skill 2",
+            description="Test",
+            system_prompt="Prompt"
+        )
+
+        response = SkillsResponse(skills=[skill1, skill2])
+
+        assert response.total == 2
+
+    def test_empty_skills_response(self):
+        """Test empty skills response."""
+        response = SkillsResponse(skills=[])
+
+        assert response.total == 0
+        assert response.skills == []

--- a/backend/tests/unit/services/test_skill_service.py
+++ b/backend/tests/unit/services/test_skill_service.py
@@ -1,0 +1,56 @@
+"""Test skill service module."""
+
+import unittest
+from src.services.skill import SkillService, skill_service
+from src.constants.skills import BUILTIN_SKILLS
+
+
+class TestSkillService(unittest.IsolatedAsyncioTestCase):
+    """Tests for SkillService."""
+
+    async def asyncSetUp(self):
+        self.service = SkillService(user_id="test-user")
+
+    async def test_get_enabled_skills_returns_builtins(self):
+        """Test that get_enabled_skills returns built-in skills."""
+        skills = await self.service.get_enabled_skills()
+
+        assert len(skills) >= 2
+        assert any(s.slug == "research-agent" for s in skills)
+        assert any(s.slug == "code-engineer" for s in skills)
+
+    async def test_get_skill_by_slug(self):
+        """Test retrieving specific skill by slug."""
+        skill = await self.service.get_skill("research-agent")
+
+        assert skill is not None
+        assert skill.name == "Research Agent"
+        assert "web_search" in skill.tools
+        assert skill.category == "research"
+
+    async def test_get_nonexistent_skill_returns_none(self):
+        """Test that nonexistent skill returns None."""
+        skill = await self.service.get_skill("nonexistent-skill")
+        assert skill is None
+
+    async def test_category_filtering(self):
+        """Test filtering skills by category."""
+        skills = await self.service.get_enabled_skills(categories=["research"])
+
+        assert len(skills) >= 1
+        assert all(s.category == "research" for s in skills)
+
+    async def test_category_filtering_empty_result(self):
+        """Test that filtering by nonexistent category returns empty list."""
+        skills = await self.service.get_enabled_skills(categories=["nonexistent"])
+        assert len(skills) == 0
+
+    async def test_get_all_skills(self):
+        """Test getting all skills regardless of enabled status."""
+        skills = await self.service.get_all_skills()
+        assert len(skills) == len(BUILTIN_SKILLS)
+
+    async def test_default_service_instance(self):
+        """Test that default service instance works."""
+        skills = await skill_service.get_enabled_skills()
+        assert len(skills) >= 2

--- a/frontend/src/components/skills/SkillCard.tsx
+++ b/frontend/src/components/skills/SkillCard.tsx
@@ -1,0 +1,49 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles, Wrench } from "lucide-react";
+import { Skill } from "@/lib/entities/skill";
+
+interface SkillCardProps {
+	skill: Skill;
+	onClick?: () => void;
+}
+
+export function SkillCard({ skill, onClick }: SkillCardProps) {
+	return (
+		<Card
+			className="cursor-pointer hover:shadow-lg transition-shadow duration-200 group"
+			onClick={onClick}
+		>
+			<CardHeader className="pb-3">
+				<div className="flex items-start justify-between">
+					<Sparkles className="h-5 w-5 text-primary flex-shrink-0" />
+					{skill.category && (
+						<Badge variant="outline" className="text-xs">
+							{skill.category}
+						</Badge>
+					)}
+				</div>
+				<CardTitle className="text-base group-hover:text-primary transition-colors line-clamp-1">
+					{skill.name}
+				</CardTitle>
+				<CardDescription className="text-xs line-clamp-2">
+					{skill.description}
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="pt-0">
+				{skill.tools && skill.tools.length > 0 && (
+					<div className="flex items-center gap-1 text-xs text-muted-foreground">
+						<Wrench className="h-3 w-3" />
+						<span>{skill.tools.length} tools</span>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/skills/SkillDiscoveryPanel.tsx
+++ b/frontend/src/components/skills/SkillDiscoveryPanel.tsx
@@ -1,0 +1,76 @@
+import { useState, useMemo } from "react";
+import { Input } from "@/components/ui/input";
+import { Loader2, Search, AlertCircle } from "lucide-react";
+import { useSkills } from "@/hooks/useSkills";
+import { SkillCard } from "./SkillCard";
+import { Skill } from "@/lib/entities/skill";
+
+interface SkillDiscoveryPanelProps {
+	onSkillSelect?: (skill: Skill) => void;
+}
+
+export function SkillDiscoveryPanel({ onSkillSelect }: SkillDiscoveryPanelProps) {
+	const { skills, isLoading, error } = useSkills();
+	const [searchQuery, setSearchQuery] = useState("");
+
+	const filteredSkills = useMemo(() => {
+		if (!searchQuery.trim()) return skills;
+		const query = searchQuery.toLowerCase();
+		return skills.filter(
+			(skill) =>
+				skill.name.toLowerCase().includes(query) ||
+				skill.description.toLowerCase().includes(query) ||
+				skill.category?.toLowerCase().includes(query)
+		);
+	}, [skills, searchQuery]);
+
+	return (
+		<div className="flex flex-col h-full">
+			<div className="border-b px-6 py-4">
+				<h2 className="text-xl font-semibold mb-3">Skill Discovery</h2>
+				<div className="relative">
+					<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+					<Input
+						placeholder="Search skills..."
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						className="pl-9"
+					/>
+				</div>
+			</div>
+
+			<div className="flex-1 overflow-auto p-6">
+				{isLoading && (
+					<div className="flex items-center justify-center py-12">
+						<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+					</div>
+				)}
+
+				{error && (
+					<div className="flex items-center justify-center py-12 text-destructive">
+						<AlertCircle className="h-5 w-5 mr-2" />
+						<span>{error}</span>
+					</div>
+				)}
+
+				{!isLoading && !error && filteredSkills.length === 0 && (
+					<div className="flex items-center justify-center py-12 text-muted-foreground">
+						<span>No skills found</span>
+					</div>
+				)}
+
+				{!isLoading && !error && filteredSkills.length > 0 && (
+					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+						{filteredSkills.map((skill) => (
+							<SkillCard
+								key={skill.slug}
+								skill={skill}
+								onClick={() => onSkillSelect?.(skill)}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/skills/index.ts
+++ b/frontend/src/components/skills/index.ts
@@ -1,0 +1,2 @@
+export { SkillCard } from "./SkillCard";
+export { SkillDiscoveryPanel } from "./SkillDiscoveryPanel";

--- a/frontend/src/hooks/useSkills.ts
+++ b/frontend/src/hooks/useSkills.ts
@@ -1,0 +1,42 @@
+import { useState, useCallback, useEffect } from "react";
+import { Skill } from "@/lib/entities/skill";
+import SkillService from "@/lib/services/skillService";
+
+export interface UseSkillsReturn {
+	skills: Skill[];
+	isLoading: boolean;
+	error: string | null;
+	refetch: () => Promise<void>;
+}
+
+export const useSkills = (category?: string): UseSkillsReturn => {
+	const [skills, setSkills] = useState<Skill[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchSkills = useCallback(async () => {
+		setIsLoading(true);
+		setError(null);
+		try {
+			const response = await SkillService.listSkills(category);
+			setSkills(response.skills || []);
+		} catch (err) {
+			const errorMessage =
+				err instanceof Error ? err.message : "Failed to load skills";
+			setError(errorMessage);
+		} finally {
+			setIsLoading(false);
+		}
+	}, [category]);
+
+	useEffect(() => {
+		fetchSkills();
+	}, [fetchSkills]);
+
+	return {
+		skills,
+		isLoading,
+		error,
+		refetch: fetchSkills,
+	};
+};

--- a/frontend/src/lib/entities/skill.ts
+++ b/frontend/src/lib/entities/skill.ts
@@ -1,0 +1,15 @@
+export type Skill = {
+	name: string;
+	description: string;
+	slug: string;
+	category?: string;
+	system_prompt?: string;
+	tools?: string[];
+	model?: string;
+	enabled?: boolean;
+};
+
+export type SkillsResponse = {
+	skills: Skill[];
+	total: number;
+};

--- a/frontend/src/lib/services/skillService.ts
+++ b/frontend/src/lib/services/skillService.ts
@@ -1,0 +1,35 @@
+import apiClient from "@/lib/utils/apiClient";
+import { Skill, SkillsResponse } from "@/lib/entities/skill";
+
+export default class SkillService {
+	private static readonly BASE_URL = "/skills";
+
+	/**
+	 * List all available skills
+	 */
+	static async listSkills(category?: string): Promise<SkillsResponse> {
+		try {
+			const params = category ? `?category=${encodeURIComponent(category)}` : "";
+			const response = await apiClient.get(`${this.BASE_URL}${params}`);
+			return response.data;
+		} catch (error) {
+			console.error("Failed to list skills:", error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Get a skill by slug
+	 */
+	static async getSkill(slug: string): Promise<Skill> {
+		try {
+			const response = await apiClient.get(`${this.BASE_URL}/${slug}`);
+			return response.data;
+		} catch (error) {
+			console.error("Failed to get skill:", error);
+			throw error;
+		}
+	}
+}
+
+export const skillService = new SkillService();

--- a/frontend/src/pages/skills/SkillsPage.tsx
+++ b/frontend/src/pages/skills/SkillsPage.tsx
@@ -1,0 +1,14 @@
+import { SkillDiscoveryPanel } from "@/components/skills";
+
+export default function SkillsPage() {
+	return (
+		<div className="container mx-auto py-8">
+			<h1 className="text-2xl font-bold mb-6">Skills Discovery</h1>
+			<SkillDiscoveryPanel
+				onSkillSelect={(skill) => {
+					console.log("Selected skill:", skill);
+				}}
+			/>
+		</div>
+	);
+}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -29,6 +29,7 @@ import ProjectPage from "@/pages/projects/ProjectPage";
 import ThreadPage from "@/pages/threads/ThreadPage";
 import AgentThreadPage from "@/pages/agents/thread";
 import SettingsPage from "@/pages/settings";
+import SkillsPage from "@/pages/skills/SkillsPage";
 
 const AppRoutes: React.FC = () => {
 	return (
@@ -173,6 +174,14 @@ const AppRoutes: React.FC = () => {
 						element={
 							<PrivateRoute>
 								<SettingsPage />
+							</PrivateRoute>
+						}
+					/>
+					<Route
+						path="/skills"
+						element={
+							<PrivateRoute>
+								<SkillsPage />
 							</PrivateRoute>
 						}
 					/>


### PR DESCRIPTION
## Summary
- Implements skill templates for compound engineering patterns similar to Claude Code's approach
- Creates pre-configured Research Agent and Code Engineer built-in skills
- Adds API endpoints for skill discovery (`GET /api/skills`, `GET /api/skills/{slug}`)
- Adds frontend components for skill display (SkillCard, SkillDiscoveryPanel)
- Integrates skills with deepagents SubAgent format via `init_skills_as_subagents()`

## Test plan
- [x] Unit tests for SkillTemplate schema (9 tests pass)
- [x] Unit tests for SkillService (7 tests pass)
- [x] Integration tests for Skills API routes (5 tests pass)
- [x] TypeScript check passes (frontend)
- [x] All 21 tests pass

## Files Changed
**Backend (New):**
- `backend/src/schemas/entities/skill.py` - SkillTemplate schema
- `backend/src/constants/skills.py` - Built-in skills
- `backend/src/services/skill.py` - SkillService
- `backend/src/routes/v0/skill.py` - API endpoints

**Frontend (New):**
- `frontend/src/lib/entities/skill.ts` - TypeScript types
- `frontend/src/lib/services/skillService.ts` - API client
- `frontend/src/hooks/useSkills.ts` - React hook
- `frontend/src/components/skills/` - UI components

**Modified:**
- `backend/src/routes/v0/__init__.py` - Register skills router
- `backend/src/agents/__init__.py` - Add `init_skills_as_subagents()`

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skill discovery UI with search, filtering, and selection
  * Introduced two built-in skills: Research Agent and Code Engineer
  * Added APIs to list skills and fetch skill details (supports category filtering)
  * Enabled skills to be exposed/configured as subagents

* **Documentation**
  * Added changelog entry for the release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->