### PR TITLE
fix(auth): prevent landing page redirect for anonymous users (#796)

### DIFF
--- a/backend/src/utils/auth.py
+++ b/backend/src/utils/auth.py
@@ -103,7 +103,8 @@ async def get_optional_user(
                     logger.info(f"Allowing unauthenticated access for public assistant: {params.metadata.assistant_id}")
                     return None
 
-        if not is_authorized_model(params.model):
+        # Empty model is allowed — the controller resolves it to DEFAULT_CHAT_MODEL
+        if params.model and not is_authorized_model(params.model):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail=(f"Unauthorized [{params.model}]\nPlease sign in for higher limits and better models!"),

--- a/frontend/src/components/inputs/ChatInput.tsx
+++ b/frontend/src/components/inputs/ChatInput.tsx
@@ -13,6 +13,7 @@ import { Button } from "../ui/button";
 import QueuePanel from "../panels/QueuePanel";
 import { ModelBadge } from "@/components/badges/ModelBadge";
 import { useNavigate } from "react-router";
+import { getAuthToken } from "@/lib/utils/auth";
 
 export default function ChatInput({
 	showAgentMenu = false,
@@ -177,8 +178,12 @@ export default function ChatInput({
 				<div className="flex items-center gap-2">
 					{displayModel && (
 						<button
-							onClick={() => navigate("/settings")}
-							title="Change default model"
+							onClick={() => navigate(getAuthToken() ? "/settings" : "/login")}
+							title={
+								getAuthToken()
+									? "Change default model"
+									: "Log in to change model"
+							}
 							className="cursor-pointer hover:opacity-80 transition-opacity"
 						>
 							<ModelBadge model={displayModel} />

--- a/frontend/src/components/menus/BaseToolMenu.tsx
+++ b/frontend/src/components/menus/BaseToolMenu.tsx
@@ -23,6 +23,7 @@ import { useChatContext } from "@/context/ChatContext";
 import ImageUpload from "../inputs/ImageUpload";
 import { ToolSelectionModal } from "@/components/modals/ToolSelectionModal";
 import { getSettings } from "@/lib/services/userSettingsService";
+import { getAuthToken } from "@/lib/utils/auth";
 
 const FALLBACK_TOOLS = [
 	"web_search",
@@ -70,6 +71,13 @@ export function BaseToolMenu() {
 	};
 
 	useEffect(() => {
+		if (!getAuthToken()) {
+			setAgent((prev) => ({
+				...prev,
+				tools: [...new Set([...prev.tools, ...FALLBACK_TOOLS])],
+			}));
+			return;
+		}
 		getSettings()
 			.then((res) => {
 				const tools = res.defaults.tools ?? FALLBACK_TOOLS;

--- a/frontend/src/components/modals/ToolSelectionModal/Sidebar.tsx
+++ b/frontend/src/components/modals/ToolSelectionModal/Sidebar.tsx
@@ -11,15 +11,24 @@ const categories: CategoryConfig[] = [
 interface SidebarProps {
 	activeCategory: ToolCategory;
 	onCategoryChange: (category: ToolCategory) => void;
+	visibleCategories?: ToolCategory[];
 }
 
-export function Sidebar({ activeCategory, onCategoryChange }: SidebarProps) {
+export function Sidebar({
+	activeCategory,
+	onCategoryChange,
+	visibleCategories,
+}: SidebarProps) {
+	const filteredCategories = visibleCategories
+		? categories.filter((c) => visibleCategories.includes(c.id))
+		: categories;
+
 	return (
 		<>
 			{/* Mobile: Horizontal scrolling tabs */}
 			<div className="sm:hidden border-b border-border flex-shrink-0 overflow-x-auto">
 				<nav className="flex p-2 gap-1 min-w-max">
-					{categories.map((category) => {
+					{filteredCategories.map((category) => {
 						const Icon = category.icon;
 						const isActive = activeCategory === category.id;
 
@@ -49,7 +58,7 @@ export function Sidebar({ activeCategory, onCategoryChange }: SidebarProps) {
 			{/* Desktop: Vertical sidebar */}
 			<div className="hidden sm:block w-60 border-r border-border flex-shrink-0">
 				<nav className="p-4 space-y-1">
-					{categories.map((category) => {
+					{filteredCategories.map((category) => {
 						const Icon = category.icon;
 						const isActive = activeCategory === category.id;
 

--- a/frontend/src/components/modals/ToolSelectionModal/index.tsx
+++ b/frontend/src/components/modals/ToolSelectionModal/index.tsx
@@ -15,8 +15,20 @@ import {
 import { useAgentContext } from "@/context/AgentContext";
 import { Agent } from "@/lib/services/agentService";
 import { patchDefaults } from "@/lib/services/userSettingsService";
+import { getAuthToken } from "@/lib/utils/auth";
 import { toast } from "sonner";
 import { X } from "lucide-react";
+
+const FALLBACK_TOOLS: Tool[] = [
+	{ name: "web_search", description: "Search the web", tags: ["search"] },
+	{ name: "web_scrape", description: "Scrape web pages", tags: ["search"] },
+	{
+		name: "math_calculator",
+		description: "Calculate math expressions",
+		tags: ["utility"],
+	},
+	{ name: "think_tool", description: "Think step by step", tags: ["utility"] },
+];
 
 interface ToolSelectionModalProps {
 	isOpen: boolean;
@@ -50,9 +62,20 @@ export function ToolSelectionModal({
 	const { selectedTools, toggleTool, selectedCount, flushPersist } =
 		useToolSelection(initialSelectedTools);
 
+	const isAuthenticated = !!getAuthToken();
+
+	// Derive visible categories based on auth state
+	const visibleCategories: ToolCategory[] = isAuthenticated
+		? ["platform", "api", "mcp", "a2a"]
+		: ["platform", "mcp", "a2a"];
+
 	// Fetch platform tools
 	useEffect(() => {
 		if (isOpen && activeCategory === "platform") {
+			if (!isAuthenticated) {
+				setPlatformTools(FALLBACK_TOOLS);
+				return;
+			}
 			listTools()
 				.then((data) => {
 					setPlatformTools(data.tools || []);
@@ -90,9 +113,11 @@ export function ToolSelectionModal({
 		setMcpServers((prev) => {
 			const updated = { ...prev, [name]: config };
 			setAgent((prev: Agent) => ({ ...prev, mcp: updated }));
-			patchDefaults({ mcp: updated }).catch(() =>
-				toast.error("Failed to save MCP defaults"),
-			);
+			if (getAuthToken()) {
+				patchDefaults({ mcp: updated }).catch(() =>
+					toast.error("Failed to save MCP defaults"),
+				);
+			}
 			return updated;
 		});
 	};
@@ -102,9 +127,11 @@ export function ToolSelectionModal({
 			const updated = { ...prev };
 			delete updated[name];
 			setAgent((prev: Agent) => ({ ...prev, mcp: updated }));
-			patchDefaults({ mcp: updated }).catch(() =>
-				toast.error("Failed to save MCP defaults"),
-			);
+			if (getAuthToken()) {
+				patchDefaults({ mcp: updated }).catch(() =>
+					toast.error("Failed to save MCP defaults"),
+				);
+			}
 			return updated;
 		});
 	};
@@ -137,9 +164,11 @@ export function ToolSelectionModal({
 		setA2aServers((prev) => {
 			const updated = { ...prev, [name]: config };
 			setAgent((prev: Agent) => ({ ...prev, a2a: updated }));
-			patchDefaults({ a2a: updated }).catch(() =>
-				toast.error("Failed to save A2A defaults"),
-			);
+			if (getAuthToken()) {
+				patchDefaults({ a2a: updated }).catch(() =>
+					toast.error("Failed to save A2A defaults"),
+				);
+			}
 			return updated;
 		});
 	};
@@ -149,9 +178,11 @@ export function ToolSelectionModal({
 			const updated = { ...prev };
 			delete updated[name];
 			setAgent((prev: Agent) => ({ ...prev, a2a: updated }));
-			patchDefaults({ a2a: updated }).catch(() =>
-				toast.error("Failed to save A2A defaults"),
-			);
+			if (getAuthToken()) {
+				patchDefaults({ a2a: updated }).catch(() =>
+					toast.error("Failed to save A2A defaults"),
+				);
+			}
 			return updated;
 		});
 	};
@@ -186,6 +217,7 @@ export function ToolSelectionModal({
 					<Sidebar
 						activeCategory={activeCategory}
 						onCategoryChange={setActiveCategory}
+						visibleCategories={visibleCategories}
 					/>
 
 					<div className="flex-1 flex flex-col overflow-hidden">

--- a/frontend/src/hooks/useModel.tsx
+++ b/frontend/src/hooks/useModel.tsx
@@ -1,4 +1,5 @@
 import { listModels, ModelsResponse } from "@/lib/services/modelService";
+import { getAuthToken } from "@/lib/utils/auth";
 import { useCallback, useEffect, useState } from "react";
 
 export function useModel() {
@@ -11,6 +12,7 @@ export function useModel() {
 
 	const useModelsEffect = () => {
 		useEffect(() => {
+			if (!getAuthToken()) return;
 			const fetchModels = async () => {
 				const response = await listModels();
 				setModels(response.data);

--- a/frontend/src/lib/utils/apiClient.ts
+++ b/frontend/src/lib/utils/apiClient.ts
@@ -45,10 +45,12 @@ apiClient.interceptors.response.use(
 		config.retryCount = config.retryCount || 0;
 
 		if (error.response?.status === 401) {
-			// Handle unauthorized access, e.g., logout user
-			console.error("Unauthorized! Redirecting to login...");
-			localStorage.removeItem(TOKEN_NAME); // Clear token
-			window.location.href = "/login"; // Redirect to login page
+			if (getAuthToken()) {
+				// Session expired — clear token and redirect
+				console.error("Unauthorized! Redirecting to login...");
+				localStorage.removeItem(TOKEN_NAME);
+				window.location.href = "/login";
+			}
 			return Promise.reject(error);
 		}
 

--- a/frontend/src/tests/hooks/useModel.test.ts
+++ b/frontend/src/tests/hooks/useModel.test.ts
@@ -13,6 +13,10 @@ vi.mock("@/lib/services/modelService", () => ({
 	}),
 }));
 
+vi.mock("@/lib/utils/auth", () => ({
+	getAuthToken: vi.fn().mockReturnValue("mock-token"),
+}));
+
 describe("useModel", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();


### PR DESCRIPTION
Anonymous users were redirected to /login on page load due to 401 responses from authenticated API calls. Fix the apiClient interceptor to only redirect when a token exists (real session expiry), guard useModelsEffect to skip API calls without auth, and allow empty model through backend auth so the controller resolves it to the default free model.

Closes #796 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unauthenticated users can now access a set of fallback tools.
  * Improved UI prompts intelligently redirect to login when accessing protected features.
  * Tool categories now adapt based on your authentication status.

* **Bug Fixes**
  * Enhanced authorization validation for model operations.
  * Improved authentication error handling in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->