### PR TITLE
Redirect initial /chat requests to canonical thread route

### DIFF
--- a/frontend/src/hooks/useInitialThreadRedirect.test.tsx
+++ b/frontend/src/hooks/useInitialThreadRedirect.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useInitialThreadRedirect from "./useInitialThreadRedirect";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+	const actual =
+		await vi.importActual<typeof import("react-router-dom")>(
+			"react-router-dom",
+		);
+
+	return {
+		...actual,
+		useNavigate: () => mockNavigate,
+	};
+});
+
+describe("useInitialThreadRedirect", () => {
+	beforeEach(() => {
+		mockNavigate.mockReset();
+	});
+
+	it("does not navigate when threadId is missing", () => {
+		renderHook(() =>
+			useInitialThreadRedirect({
+				threadId: undefined,
+				hasMessages: true,
+			}),
+		);
+
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+
+	it("does not navigate when there are no messages", () => {
+		renderHook(() =>
+			useInitialThreadRedirect({
+				threadId: "thread-123",
+				hasMessages: false,
+			}),
+		);
+
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+
+	it("navigates once when threadId appears for an active conversation", () => {
+		const { rerender } = renderHook(
+			({
+				threadId,
+				hasMessages,
+			}: {
+				threadId?: string;
+				hasMessages: boolean;
+			}) => useInitialThreadRedirect({ threadId, hasMessages }),
+			{
+				initialProps: {
+					threadId: undefined,
+					hasMessages: true,
+				},
+			},
+		);
+
+		rerender({ threadId: "thread-123", hasMessages: true });
+		rerender({ threadId: "thread-123", hasMessages: true });
+
+		expect(mockNavigate).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).toHaveBeenCalledWith("/thread/thread-123", {
+			replace: true,
+		});
+	});
+
+	it("can redirect again after the conversation resets", () => {
+		const { rerender } = renderHook(
+			({
+				threadId,
+				hasMessages,
+			}: {
+				threadId?: string;
+				hasMessages: boolean;
+			}) => useInitialThreadRedirect({ threadId, hasMessages }),
+			{
+				initialProps: {
+					threadId: "thread-123",
+					hasMessages: true,
+				},
+			},
+		);
+
+		expect(mockNavigate).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).toHaveBeenLastCalledWith("/thread/thread-123", {
+			replace: true,
+		});
+
+		rerender({ threadId: undefined, hasMessages: false });
+		rerender({ threadId: "thread-456", hasMessages: true });
+
+		expect(mockNavigate).toHaveBeenCalledTimes(2);
+		expect(mockNavigate).toHaveBeenLastCalledWith("/thread/thread-456", {
+			replace: true,
+		});
+	});
+});

--- a/frontend/src/hooks/useInitialThreadRedirect.ts
+++ b/frontend/src/hooks/useInitialThreadRedirect.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+type UseInitialThreadRedirectOptions = {
+	threadId?: string;
+	hasMessages: boolean;
+};
+
+export default function useInitialThreadRedirect({
+	threadId,
+	hasMessages,
+}: UseInitialThreadRedirectOptions): void {
+	const navigate = useNavigate();
+	const lastNavigatedThreadIdRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!threadId) {
+			lastNavigatedThreadIdRef.current = null;
+			return;
+		}
+
+		if (!hasMessages) {
+			return;
+		}
+
+		if (lastNavigatedThreadIdRef.current === threadId) {
+			return;
+		}
+
+		lastNavigatedThreadIdRef.current = threadId;
+		navigate(`/thread/${threadId}`, { replace: true });
+	}, [hasMessages, navigate, threadId]);
+}

--- a/frontend/src/hooks/useThread.test.tsx
+++ b/frontend/src/hooks/useThread.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import useThread from "./useThread";
+
+const mockSearchThreads = vi.fn();
+
+vi.mock("@/lib/services/threadService", () => ({
+	searchThreads: (...args: any[]) => mockSearchThreads(...args),
+}));
+
+vi.mock("@/lib/utils/format", () => ({
+	formatMessages: (messages: any[]) => messages,
+}));
+
+vi.mock("@/lib/utils/message", () => ({
+	latestHumanMessage: () => ({ model: "openai:gpt-4.1-mini" }),
+}));
+
+type HookState = {
+	threadLoading: boolean;
+	threadError: string | null;
+};
+
+type ThreadCallbacks = {
+	setCheckpoints: ReturnType<typeof vi.fn>;
+	setMessages: ReturnType<typeof vi.fn>;
+	setMetadata: ReturnType<typeof vi.fn>;
+	setFilesMap: ReturnType<typeof vi.fn>;
+	setTodos: ReturnType<typeof vi.fn>;
+	setModel: ReturnType<typeof vi.fn>;
+};
+
+function UseLoadThreadEffectHarness({
+	threadId,
+	enabled,
+	onStateChange,
+	callbacks,
+}: {
+	threadId: string;
+	enabled: boolean;
+	onStateChange: (state: HookState) => void;
+	callbacks?: ThreadCallbacks;
+}) {
+	const thread = useThread();
+	const threadCallbacks = callbacks || {
+		setCheckpoints: vi.fn(),
+		setMessages: vi.fn(),
+		setMetadata: vi.fn(),
+		setFilesMap: vi.fn(),
+		setTodos: vi.fn(),
+		setModel: vi.fn(),
+	};
+
+	thread.useLoadThreadEffect(threadId, threadCallbacks, { enabled });
+
+	useEffect(() => {
+		onStateChange({
+			threadLoading: thread.threadLoading,
+			threadError: thread.threadError,
+		});
+	}, [onStateChange, thread.threadError, thread.threadLoading]);
+
+	return null;
+}
+
+describe("useThread", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("clears stale thread errors and loading state when hydration is disabled", async () => {
+		mockSearchThreads.mockResolvedValueOnce([]);
+
+		const state: HookState = {
+			threadLoading: false,
+			threadError: null,
+		};
+
+		const { rerender } = render(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={true}
+				onStateChange={(nextState) => Object.assign(state, nextState)}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(state.threadError).toBe("No checkpoints found for thread");
+		});
+
+		rerender(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={false}
+				onStateChange={(nextState) => Object.assign(state, nextState)}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(state.threadError).toBeNull();
+			expect(state.threadLoading).toBe(false);
+		});
+	});
+
+	it("does not apply late thread hydration after the effect is disabled", async () => {
+		let resolveSearch: (value: any[]) => void = () => undefined;
+		mockSearchThreads.mockImplementationOnce(
+			() =>
+				new Promise<any[]>((resolve) => {
+					resolveSearch = resolve;
+				}),
+		);
+
+		const callbacks: ThreadCallbacks = {
+			setCheckpoints: vi.fn(),
+			setMessages: vi.fn(),
+			setMetadata: vi.fn(),
+			setFilesMap: vi.fn(),
+			setTodos: vi.fn(),
+			setModel: vi.fn(),
+		};
+
+		const { rerender } = render(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={true}
+				callbacks={callbacks}
+				onStateChange={() => undefined}
+			/>,
+		);
+
+		rerender(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={false}
+				callbacks={callbacks}
+				onStateChange={() => undefined}
+			/>,
+		);
+
+		await act(async () => {
+			resolveSearch([
+				{
+					metadata: {
+						thread_id: "thread-123",
+						files: {},
+						todos: [],
+					},
+					values: {
+						messages: [{ id: "msg-1", role: "user", content: "Hello" }],
+					},
+				},
+			]);
+			await Promise.resolve();
+		});
+
+		expect(callbacks.setMessages).not.toHaveBeenCalled();
+		expect(callbacks.setMetadata).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -47,6 +47,9 @@ export type ThreadContextType = {
 			setTodos: (todos: Todo[]) => void;
 			setModel: (model: string) => void;
 		},
+		options?: {
+			enabled?: boolean;
+		},
 	) => void;
 };
 
@@ -148,12 +151,29 @@ export default function useThread(): ThreadContextType {
 			setTodos: (todos: Todo[]) => void;
 			setModel: (model: string) => void;
 		},
+		options: {
+			enabled?: boolean;
+		} = {},
 	) => {
+		const enabled = options.enabled ?? true;
+
 		useEffect(() => {
+			if (!enabled) {
+				setThreadLoading(false);
+				setThreadError(null);
+				return;
+			}
+
+			let isActive = true;
+
 			const fetchThread = async () => {
 				if (!threadId) return;
 
 				const data = await loadThread(threadId);
+				if (!isActive || !data) {
+					return;
+				}
+
 				if (data) {
 					callbacks.setCheckpoints(data.checkpoints);
 					callbacks.setMessages(data.messages);
@@ -166,7 +186,11 @@ export default function useThread(): ThreadContextType {
 			};
 
 			fetchThread();
-		}, [threadId]);
+
+			return () => {
+				isActive = false;
+			};
+		}, [threadId, enabled]);
 	};
 
 	const fetchThreads = async (

--- a/frontend/src/pages/chat/chat-v2.tsx
+++ b/frontend/src/pages/chat/chat-v2.tsx
@@ -6,6 +6,7 @@ import { useAppContext } from "@/context/AppContext";
 import { Agent } from "@/lib/services/agentService";
 import { ChatNav } from "@/components/nav/ChatNav";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import useInitialThreadRedirect from "@/hooks/useInitialThreadRedirect";
 
 export function ChatV2Page() {
 	const { loading } = useAppContext();
@@ -15,6 +16,7 @@ export function ChatV2Page() {
 		useListThreadsEffect,
 		useListCheckpointsEffect,
 		metadata,
+		messages,
 		useModelsEffect,
 		useMemoryFilesEffect,
 	} = useChatContext();
@@ -26,6 +28,10 @@ export function ChatV2Page() {
 
 	useListThreadsEffect(!loading);
 	useListCheckpointsEffect(!loading, metadata);
+	useInitialThreadRedirect({
+		threadId: metadata?.thread_id,
+		hasMessages: messages.length > 0,
+	});
 
 	const defaultAgent: Agent = {
 		name: "ORCHESTRA",

--- a/frontend/src/pages/threads/ThreadPage.test.tsx
+++ b/frontend/src/pages/threads/ThreadPage.test.tsx
@@ -1,0 +1,212 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import ThreadPage from "./ThreadPage";
+
+const mockUseChatContext = vi.fn();
+const mockUseAppContext = vi.fn();
+const mockUseAgentContext = vi.fn();
+const mockUseProjectContext = vi.fn();
+const mockUseModel = vi.fn();
+
+vi.mock("@/context/ChatContext", () => ({
+	useChatContext: () => mockUseChatContext(),
+}));
+
+vi.mock("@/context/AppContext", () => ({
+	useAppContext: () => mockUseAppContext(),
+}));
+
+vi.mock("@/context/AgentContext", () => ({
+	useAgentContext: () => mockUseAgentContext(),
+}));
+
+vi.mock("@/context/ProjectContext", () => ({
+	useProjectContext: () => mockUseProjectContext(),
+}));
+
+vi.mock("@/hooks/useModel", () => ({
+	default: () => mockUseModel(),
+}));
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+	useMediaQuery: () => false,
+}));
+
+vi.mock("@/layouts/chat-layout-v2", () => ({
+	default: ({ children }: { children: ReactNode }) => (
+		<div data-testid="chat-layout">{children}</div>
+	),
+}));
+
+vi.mock("@/components/nav/ChatNav", () => ({
+	ChatNav: () => <div data-testid="chat-nav" />,
+}));
+
+vi.mock("@/components/inputs/ChatInput", () => ({
+	default: () => <div data-testid="chat-input" />,
+}));
+
+vi.mock("@/components/lists/ChatMessages", () => ({
+	default: ({ messages }: { messages: any[] }) => (
+		<div data-testid="chat-messages">{messages.length}</div>
+	),
+}));
+
+vi.mock("@/components/lists/ChatMessagesSkeleton", () => ({
+	default: () => <div data-testid="chat-messages-skeleton" />,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+	SidebarTrigger: () => <div data-testid="sidebar-trigger" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button {...props}>{children}</button>
+	),
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+	ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizablePanel: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizableHandle: () => <div />,
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+	Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SheetContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+vi.mock("@/components/panels/FileEditorPanel", () => ({
+	default: () => <div data-testid="file-editor-panel" />,
+}));
+
+function renderThreadPage(pathname: string) {
+	return render(
+		<MemoryRouter initialEntries={[pathname]}>
+			<Routes>
+				<Route path="/thread/:threadId" element={<ThreadPage />} />
+			</Routes>
+		</MemoryRouter>,
+	);
+}
+
+describe("ThreadPage", () => {
+	const mockUseLoadThreadEffect = vi.fn();
+	const baseChatContext = {
+		messages: [],
+		setMessages: vi.fn(),
+		metadata: {},
+		setViewMode: vi.fn(),
+		setMetadata: vi.fn(),
+		setFilesMap: vi.fn(),
+		setCheckpoints: vi.fn(),
+		useEffectUpdateAssistantId: vi.fn(),
+		useListThreadsEffect: vi.fn(),
+		useListCheckpointsEffect: vi.fn(),
+		useModelsEffect: vi.fn(),
+		viewMode: "chat",
+		setTodos: vi.fn(),
+		useLoadThreadEffect: mockUseLoadThreadEffect,
+		threadLoading: false,
+		threadError: null,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockUseAppContext.mockReturnValue({
+			loading: false,
+		});
+
+		mockUseAgentContext.mockReturnValue({
+			useEffectGetAgents: vi.fn(),
+		});
+
+		mockUseProjectContext.mockReturnValue({
+			selectProject: vi.fn(),
+			projects: [],
+		});
+
+		mockUseModel.mockReturnValue({
+			setModel: vi.fn(),
+		});
+
+		mockUseChatContext.mockReturnValue({
+			...baseChatContext,
+		});
+	});
+
+	it("skips initial thread hydration when the live thread already matches the route", () => {
+		mockUseChatContext.mockReturnValue({
+			...baseChatContext,
+			messages: [{ id: "msg-1", content: "Hello" }],
+			metadata: { thread_id: "live-123" },
+		});
+
+		renderThreadPage("/thread/live-123");
+
+		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
+			"live-123",
+			expect.any(Object),
+			{ enabled: false },
+		);
+	});
+
+	it("hydrates from the backend when there are no in-memory messages", () => {
+		mockUseChatContext.mockReturnValue({
+			...baseChatContext,
+			messages: [],
+			metadata: { thread_id: "live-123" },
+		});
+
+		renderThreadPage("/thread/live-123");
+
+		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
+			"live-123",
+			expect.any(Object),
+			{ enabled: true },
+		);
+	});
+
+	it("hydrates from the backend when the route thread differs from the current chat state", () => {
+		mockUseChatContext.mockReturnValue({
+			...baseChatContext,
+			messages: [{ id: "msg-1", content: "Hello" }],
+			metadata: { thread_id: "other-thread" },
+		});
+
+		renderThreadPage("/thread/live-123");
+
+		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
+			"live-123",
+			expect.any(Object),
+			{ enabled: true },
+		);
+	});
+
+	it("does not render a stale thread error when reusing live in-memory state", () => {
+		mockUseChatContext.mockReturnValue({
+			...baseChatContext,
+			messages: [{ id: "msg-1", content: "Hello" }],
+			metadata: { thread_id: "live-123" },
+			threadError: "No checkpoints found for thread",
+		});
+
+		renderThreadPage("/thread/live-123");
+
+		expect(
+			screen.queryByText("No checkpoints found for thread"),
+		).not.toBeInTheDocument();
+		expect(screen.getByTestId("chat-messages")).toHaveTextContent("1");
+	});
+});

--- a/frontend/src/pages/threads/ThreadPage.tsx
+++ b/frontend/src/pages/threads/ThreadPage.tsx
@@ -51,6 +51,10 @@ export default function ThreadPage() {
 		threadError,
 	} = useChatContext();
 	const isMobile = useMediaQuery("(max-width: 768px)");
+	const hasLiveThreadState =
+		metadata?.thread_id === threadId && messages.length > 0;
+	const effectiveThreadLoading = !hasLiveThreadState && threadLoading;
+	const effectiveThreadError = !hasLiveThreadState ? threadError : null;
 
 	useModelsEffect();
 	useEffectGetAgents();
@@ -59,14 +63,20 @@ export default function ThreadPage() {
 	useListCheckpointsEffect(!loading, metadata);
 
 	// Load thread data using modularized hook
-	useLoadThreadEffect(threadId, {
-		setCheckpoints,
-		setMessages,
-		setMetadata,
-		setFilesMap,
-		setTodos,
-		setModel,
-	});
+	useLoadThreadEffect(
+		threadId,
+		{
+			setCheckpoints,
+			setMessages,
+			setMetadata,
+			setFilesMap,
+			setTodos,
+			setModel,
+		},
+		{
+			enabled: !hasLiveThreadState,
+		},
+	);
 
 	// Handle project context if on /p/:projectId/t/:threadId
 	useEffect(() => {
@@ -96,11 +106,11 @@ export default function ThreadPage() {
 		};
 	}, [projectId, projects]);
 
-	if (threadError) {
+	if (effectiveThreadError) {
 		return (
 			<ChatLayout>
 				<div className="flex h-full flex-col items-center justify-center gap-4">
-					<p className="text-muted-foreground">{threadError}</p>
+					<p className="text-muted-foreground">{effectiveThreadError}</p>
 					<button
 						onClick={() => navigate("/chat")}
 						className="text-primary hover:underline"
@@ -119,7 +129,7 @@ export default function ThreadPage() {
 					<div className="flex-1 flex flex-col min-h-0 overflow-hidden">
 						<ChatNav sidebarTrigger={<SidebarTrigger />} />
 						<div className="flex-1 min-h-0">
-							{threadLoading ? (
+							{effectiveThreadLoading ? (
 								<ChatMessagesSkeleton />
 							) : (
 								<ChatMessages messages={messages} />
@@ -150,7 +160,7 @@ export default function ThreadPage() {
 								<div className="flex flex-col h-full min-h-0 overflow-hidden">
 									<ChatNav sidebarTrigger={<SidebarTrigger />} />
 									<div className="flex-1 min-h-0">
-										{threadLoading ? (
+										{effectiveThreadLoading ? (
 											<ChatMessagesSkeleton />
 										) : (
 											<ChatMessages messages={messages} />
@@ -173,7 +183,7 @@ export default function ThreadPage() {
 							<div className="flex-1 flex flex-col min-h-0 overflow-hidden">
 								<ChatNav sidebarTrigger={<SidebarTrigger />} />
 								<div className="flex-1 min-h-0">
-									{threadLoading ? (
+									{effectiveThreadLoading ? (
 										<ChatMessagesSkeleton />
 									) : (
 										<ChatMessages messages={messages} />


### PR DESCRIPTION
## Summary
- redirect the first `/chat` submission to `/thread/:threadId` once the frontend receives thread metadata
- preserve in-memory chat state on the redirected thread page by skipping initial hydration when the current thread is already live in context
- add focused tests around redirect deduping, thread hydration gating, and late hydration cancellation

## Verification
- `npm run test -- src/hooks/useInitialThreadRedirect.test.tsx src/hooks/useThread.test.tsx src/pages/threads/ThreadPage.test.tsx`
- pre-commit hooks passed during commit, including frontend lint and frontend test

## QA Status
- Headed browser QA still reproduces a `New Chat` race and this PR is **not ready for merge** yet
- In 5 headed runs using `Use think_tool to detail color of sky: one word response`, `New Chat` either stayed on the existing `/thread/:threadId` route or briefly moved to `/chat` and then bounced back to the same thread
- Keeping this PR as draft so the current implementation and reproduction details are preserved while the race is fixed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic initial thread navigation when loading conversations.
  * Added intelligent thread state detection to avoid unnecessary reloading of cached threads.

* **Bug Fixes**
  * Prevents stale error messages from displaying when reusing in-memory thread data.

* **Tests**
  * Added comprehensive unit test coverage for thread loading and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->