### PR TITLE
Move sandbox status above chat composer

### DIFF
--- a/.claude/plans/parsed-swimming-pnueli.md
+++ b/.claude/plans/parsed-swimming-pnueli.md
@@ -1,0 +1,50 @@
+# Plan: Fix Sandbox "State" Selection Still Using Daytona
+
+## Context
+
+**Bug**: User switches sandbox from "Daytona" to "State" in the UI, but the backend still executes commands in Daytona (confirmed by `pwd` returning `/home/daytona`).
+
+**Root cause**: `toSandboxPatchValue("state")` in `frontend/src/lib/config/sandbox.ts:48-50` converts the default value to `null` before sending to the backend. The backend stores `default_sandbox = None`. Then `resolve_sandbox_backend(None)` in `backend/src/agents/__init__.py:332-340` treats `None` as "auto" — try Daytona first, fall back to State. So selecting "State" effectively becomes "Auto" behavior.
+
+**Resolution path**: The frontend `toSandboxPatchValue` function should always send the literal string value (`"state"` or `"daytona"`), never `null`. This ensures the backend receives and stores `"state"` explicitly, and `resolve_sandbox_backend("state")` correctly routes to StateBackend without trying Daytona.
+
+## Changes
+
+### 1. Frontend: `frontend/src/lib/config/sandbox.ts`
+
+**`toSandboxPatchValue()`** — always return the literal value, never `null`:
+```typescript
+// BEFORE (buggy):
+export function toSandboxPatchValue(value: SandboxType): string | null {
+    return value === DEFAULT_SANDBOX ? null : value;
+}
+
+// AFTER (fixed):
+export function toSandboxPatchValue(value: SandboxType): string {
+    return value;
+}
+```
+
+### 2. Frontend: `frontend/src/components/status/ThreadSandboxStatus.test.tsx`
+
+Update the test assertion that checks the PATCH payload:
+```typescript
+// BEFORE:
+expect(mockPatchDefaults).toHaveBeenCalledWith({ sandbox: null });
+
+// AFTER:
+expect(mockPatchDefaults).toHaveBeenCalledWith({ sandbox: "state" });
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `frontend/src/lib/config/sandbox.ts` | `toSandboxPatchValue` always returns the literal string |
+| `frontend/src/components/status/ThreadSandboxStatus.test.tsx` | Update expected PATCH payload from `null` to `"state"` |
+
+## Verification
+
+1. `cd frontend && npx vitest run src/components/status/ThreadSandboxStatus.test.tsx` — tests pass
+2. `cd frontend && npm run test` — all tests pass
+3. Manual: Set sandbox to "State" → run a command → `pwd` should NOT return `/home/daytona`

--- a/.claude/plans/rosy-launching-narwhal.md
+++ b/.claude/plans/rosy-launching-narwhal.md
@@ -1,0 +1,30 @@
+# Plan: Move Links Above ChatInput in AgentSection
+
+## Context
+On the `/chat` page (initial landing view), the links row (Docs, Blog, Social, Slack) currently renders **below** the ChatInput. The user wants them moved **between the subtext and the ChatInput** — i.e., above the input area.
+
+## File to Modify
+
+### `frontend/src/components/sections/agent-section.tsx`
+
+Current order (lines 22-90):
+1. `<p>` subtext (line 23)
+2. `<div>` ChatInput wrapper (lines 24-26)
+3. `<div>` links row (lines 29-90)
+
+Target order:
+1. `<p>` subtext (line 23)
+2. `<div>` links row — moved here, update comment and change `mt-3` → `mb-3`
+3. `<div>` ChatInput wrapper
+
+**Changes:**
+- Cut the links `<div>` block (lines 28-90) and paste it between line 23 (`<p>` subtext) and line 24 (`<div>` ChatInput wrapper)
+- Change `mt-3` to `mb-3` on the links container so spacing flows downward toward the input
+- Update the comment to reflect new position
+
+No other files need changes.
+
+## Verification
+1. `npx tsc --noEmit` from `frontend/` — no type errors
+2. `npm run test` — no test regressions
+3. Navigate to `/chat` — links row (Docs, Blog, Social, Slack) appears between subtext and ChatInput

--- a/.claude/plans/structured-sniffing-dahl.md
+++ b/.claude/plans/structured-sniffing-dahl.md
@@ -1,0 +1,20 @@
+# Fix CI Tests Not Running on Push
+
+## Context
+CI tests stopped running on feature branch pushes after commit `9952aa01` (Feb 23) restricted the push trigger in `test.yml` to only `development` and `main` branches. The `pull_request` trigger was also commented out. This means no tests run for any feature branch work.
+
+## Change
+**File:** `.github/workflows/test.yml`
+
+1. **Line 5-7**: Change push branch filter from explicit list to wildcard:
+   ```yaml
+   push:
+       branches:
+           - "*"
+   ```
+2. **Leave `pull_request` commented out** — not needed since push covers all branches now.
+
+## Verification
+- Push to the current feature branch (`feat/843-sandbox-composer-position`)
+- Confirm the Test workflow appears in GitHub Actions
+- Verify both `test-frontend` and `test-backend` jobs run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: Test
 on:
     push:
         branches:
-            - "development"
-            - "main"
+            - "*"
         paths-ignore:
             - "Changelog.md"
             - "docker/**"

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -22,11 +22,13 @@ from deepagents.backends.utils import create_file_data
 # Conditional import for Daytona sandbox support
 try:
     from daytona import Daytona, DaytonaConfig
+    from daytona.common.errors import DaytonaError
     from langchain_daytona import DaytonaSandbox
 except ImportError:
     Daytona = None  # type: ignore[assignment,misc]
     DaytonaConfig = None  # type: ignore[assignment,misc]
     DaytonaSandbox = None  # type: ignore[assignment,misc]
+    DaytonaError = None  # type: ignore[assignment,misc]
 
 from src.constants import APP_ENV, DAYTONA_API_KEY
 from src.contexts.service import ServiceContext
@@ -41,6 +43,13 @@ from src.schemas.contexts import ContextSchema
 from src.schemas.entities.a2a import A2AServers
 from src.utils.middleware import init_default_middleware
 from src.tools import default_tools
+
+
+def is_daytona_error(exc: Exception) -> bool:
+    """Check if an exception is a DaytonaError (safe when package not installed)."""
+    if DaytonaError is None:
+        return False
+    return isinstance(exc, DaytonaError)
 
 
 CACHE_LLM = InMemoryCache()
@@ -306,7 +315,7 @@ _SANDBOX_FACTORIES: dict[str, Callable] = {
 def resolve_sandbox_backend(
     runtime: ToolRuntime,
     sandbox_type: str | None = None,
-) -> tuple[CompositeBackend, Any]:
+) -> tuple[CompositeBackend, Any, str]:
     """Resolve a sandbox backend based on *sandbox_type*.
 
     Dispatch rules:
@@ -315,20 +324,23 @@ def resolve_sandbox_backend(
     * ``"daytona"`` — try Daytona, fall back to State if unavailable.
     * Any unknown value — treated as ``"auto"``.
 
-    Returns ``(backend, daytona_sandbox_or_None)``.
+    Returns ``(backend, daytona_sandbox_or_None, effective_type)``
+    where effective_type is ``"daytona"`` or ``"state"``.
     """
     effective = sandbox_type if sandbox_type in _SANDBOX_FACTORIES else None
 
     if effective == "state":
-        return _create_state_backend(runtime)
+        backend, sandbox = _create_state_backend(runtime)
+        return backend, sandbox, "state"
 
     # "daytona" or auto (None) — try Daytona first
     result = _create_daytona_backend_checked(runtime)
     if result is not None:
-        return result
+        return result[0], result[1], "daytona"
 
     # Fallback: plain StateBackend (silent, no messages)
-    return _create_state_backend(runtime)
+    backend, sandbox = _create_state_backend(runtime)
+    return backend, sandbox, "state"
 
 
 ################################################################################

--- a/backend/src/controllers/llm.py
+++ b/backend/src/controllers/llm.py
@@ -11,8 +11,10 @@ from src.contexts.service import ServiceContext
 from src.agents import (
     construct_agent,
     init_config,
+    is_daytona_error,
     prepare_memory_files,
     resolve_sandbox_backend,
+    _create_state_backend,
 )
 from src.services.db import get_checkpoint_db
 from src.utils.stream import stream_generator
@@ -125,7 +127,7 @@ class LLMController:
 
             async with get_checkpoint_db() as checkpointer:
                 runtime = self._init_runtime(params)
-                backend, _sandbox = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
+                backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
                 agent: Orchestra = await construct_agent(
                     instructions=params.instructions,
                     system_prompt=params.system_prompt,
@@ -145,6 +147,42 @@ class LLMController:
                 )
                 return response
         except Exception as e:
+            if is_daytona_error(e):
+                if default_sandbox == "daytona":
+                    # Explicit daytona mode: surface the detailed error
+                    logger.error(f"Daytona sandbox error (daytona mode): {e}")
+                    if agent and config:
+                        await self._update_store(agent, config)
+                    raise
+                elif default_sandbox in (None, "auto") and effective_type == "daytona":
+                    # Auto mode: fallback to local StateBackend and retry
+                    logger.warning(f"Daytona sandbox error in auto mode, falling back to local: {e}")
+                    try:
+                        fallback_backend, _ = _create_state_backend(runtime)
+                        agent = await construct_agent(
+                            instructions=params.instructions,
+                            system_prompt=params.system_prompt,
+                            model=params.model,
+                            tools=params.tools,
+                            subagents=params.subagents,
+                            checkpointer=checkpointer,
+                            backend=fallback_backend,
+                            service_context=self.service_context,
+                            api_key=api_key,
+                            memory=memory_sources,
+                        )
+                        response = await agent.invoke(
+                            params.input,
+                            config=config,
+                            context=self._init_context(params),
+                        )
+                        return response
+                    except Exception as fallback_err:
+                        logger.exception(f"Fallback also failed in llm_invoke: {fallback_err}")
+                        if agent and config:
+                            await self._update_store(agent, config)
+                        raise fallback_err
+
             logger.exception(f"Error in llm_invoke: {e}")
             if agent and config:
                 await self._update_store(agent, config)

--- a/backend/src/schemas/entities/settings.py
+++ b/backend/src/schemas/entities/settings.py
@@ -9,7 +9,6 @@ from src.schemas.entities.store import BaseEntity
 class SandboxType(str, Enum):
     """Supported sandbox backend types."""
 
-    AUTO = "auto"
     DAYTONA = "daytona"
     STATE = "state"
 

--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -14,7 +14,13 @@ from src.schemas.contexts import ContextSchema
 from src.contexts.service import ServiceContext
 from src.schemas.entities import LLMInput
 from src.constants import APP_LOG_LEVEL
-from src.agents import construct_agent, resolve_sandbox_backend, prepare_memory_files
+from src.agents import (
+    construct_agent,
+    resolve_sandbox_backend,
+    prepare_memory_files,
+    is_daytona_error,
+    _create_state_backend,
+)
 from src.services.db import get_checkpoint_db
 from src.utils.messages import from_message_to_dict
 from langchain_core.messages import (
@@ -223,7 +229,7 @@ async def stream_generator(
                 stream_writer=lambda _: None,
                 config=config,
             )
-            backend, _sandbox = resolve_sandbox_backend(runtime, sandbox_type=sandbox_type)
+            backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=sandbox_type)
             agent = await construct_agent(
                 instructions=instructions,
                 system_prompt=system_prompt,
@@ -281,16 +287,62 @@ async def stream_generator(
         except PIIDetectionError as e:
             # Yield error as SSE if streaming fails
             logger.warning(f"Sensitive data detected in the query: {e}")
-            # raise HTTPException(status_code=500, detail=str(e))
             error_msg = ujson.dumps(("error", str(e)))
             yield f"data: {error_msg}\n\n"
 
         except Exception as e:
-            # Yield error as SSE if streaming fails
-            logger.exception("Error in stream_generator: %s", e)
-            # raise HTTPException(status_code=500, detail=str(e))
-            error_msg = ujson.dumps(("error", str(e)))
-            yield f"data: {error_msg}\n\n"
+            if is_daytona_error(e):
+                if sandbox_type == "daytona":
+                    # Explicit daytona mode: surface the detailed error
+                    logger.error(f"Daytona sandbox error (daytona mode): {e}")
+                    error_msg = ujson.dumps(("error", f"Daytona sandbox error: {e}"))
+                    yield f"data: {error_msg}\n\n"
+                elif sandbox_type in (None, "auto") and effective_type == "daytona":
+                    # Auto mode: fallback to local StateBackend and retry
+                    logger.warning(f"Daytona sandbox error in auto mode, falling back to local: {e}")
+                    try:
+                        fallback_backend, _ = _create_state_backend(runtime)
+                        agent = await construct_agent(
+                            instructions=instructions,
+                            system_prompt=system_prompt,
+                            model=model,
+                            tools=tools,
+                            subagents=subagents,
+                            checkpointer=checkpointer,
+                            backend=fallback_backend,
+                            service_context=service_context,
+                            api_key=api_key,
+                            memory=memory_sources,
+                        )
+                        async for chunk in agent.astream(
+                            input,
+                            **astream_kwargs,
+                        ):
+                            stream_chunk = handle_multi_mode(chunk)
+                            if stream_chunk:
+                                stream_type = stream_chunk[0]
+                                chunk_data = stream_chunk[1]
+                                if stream_type == "values" and "files" in chunk_data:
+                                    files_map = {**files_map, **chunk_data["files"]}
+                                if stream_type == "values" and "todos" in chunk_data:
+                                    todos_list = chunk_data["todos"]
+                                data = ujson.dumps(stream_chunk)
+                                log_to_file(str(data), agent.model) and APP_LOG_LEVEL == "DEBUG"
+                                logger.debug(f"data: {str(data)}")
+                                yield f"data: {data}\n\n"
+                    except Exception as fallback_err:
+                        logger.exception("Fallback also failed in stream_generator: %s", fallback_err)
+                        error_msg = ujson.dumps(("error", str(fallback_err)))
+                        yield f"data: {error_msg}\n\n"
+                else:
+                    logger.exception("Error in stream_generator: %s", e)
+                    error_msg = ujson.dumps(("error", str(e)))
+                    yield f"data: {error_msg}\n\n"
+            else:
+                # Non-Daytona error: original behavior
+                logger.exception("Error in stream_generator: %s", e)
+                error_msg = ujson.dumps(("error", str(e)))
+                yield f"data: {error_msg}\n\n"
         finally:
             try:
                 if service_context.user_id and checkpointer and agent:

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -202,6 +202,8 @@ async def _execute_agent_stream(
         construct_agent,
         resolve_sandbox_backend,
         prepare_memory_files,
+        is_daytona_error,
+        _create_state_backend,
     )
     from src.utils.stream import handle_multi_mode
     from src.utils.format import get_time
@@ -248,7 +250,7 @@ async def _execute_agent_stream(
         stream_writer=lambda _: None,
         config=config,
     )
-    backend, _sandbox = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
+    backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
 
     agent = await construct_agent(
         instructions=params.instructions,
@@ -278,44 +280,91 @@ async def _execute_agent_stream(
     await redis_client.xadd(stream_key, {"data": metadata_event})
 
     # Stream to Redis using handle_multi_mode for format consistency
-    async for chunk in agent.astream(
-        params.input,
-        stream_mode=["messages", "values"],
-        config=config,
-        context=ctx_schema,
-    ):
-        # Check for abort signal on every chunk for responsive cancellation
-        if await AbortService.check_abort_signal(thread_id, expected_user_id=user_id):
-            logger.info(
-                "task_aborted_by_user",
-                extra={
-                    "event": "task_aborted_by_user",
-                    "thread_id": thread_id,
-                    "user_id": user_id,
-                },
-            )
-            # Send abort acknowledgment to client
-            await redis_client.xadd(
-                stream_key,
-                {"data": ujson.dumps(("aborted", {"reason": "user_requested"}))},
-            )
-            await redis_client.xadd(stream_key, {"done": "true"})
-            await redis_client.expire(stream_key, 300)
-            # Clear abort signal
-            await AbortService.clear_abort_signal(thread_id)
-            return {"status": "aborted", "stream_key": stream_key}
+    try:
+        async for chunk in agent.astream(
+            params.input,
+            stream_mode=["messages", "values"],
+            config=config,
+            context=ctx_schema,
+        ):
+            # Check for abort signal on every chunk for responsive cancellation
+            if await AbortService.check_abort_signal(thread_id, expected_user_id=user_id):
+                logger.info(
+                    "task_aborted_by_user",
+                    extra={
+                        "event": "task_aborted_by_user",
+                        "thread_id": thread_id,
+                        "user_id": user_id,
+                    },
+                )
+                # Send abort acknowledgment to client
+                await redis_client.xadd(
+                    stream_key,
+                    {"data": ujson.dumps(("aborted", {"reason": "user_requested"}))},
+                )
+                await redis_client.xadd(stream_key, {"done": "true"})
+                await redis_client.expire(stream_key, 300)
+                # Clear abort signal
+                await AbortService.clear_abort_signal(thread_id)
+                return {"status": "aborted", "stream_key": stream_key}
 
-        stream_chunk = handle_multi_mode(chunk)
-        if stream_chunk:
-            stream_type = stream_chunk[0]
-            chunk_data = stream_chunk[1]
-            if stream_type == "values" and chunk_data.get("files"):
-                files_map = {**files_map, **chunk_data["files"]}
-            if stream_type == "values" and "todos" in chunk_data:
-                todos_list = chunk_data["todos"]
-            # Serialize to JSON and push to Redis stream
-            data = ujson.dumps(stream_chunk)
-            await redis_client.xadd(stream_key, {"data": data})
+            stream_chunk = handle_multi_mode(chunk)
+            if stream_chunk:
+                stream_type = stream_chunk[0]
+                chunk_data = stream_chunk[1]
+                if stream_type == "values" and chunk_data.get("files"):
+                    files_map = {**files_map, **chunk_data["files"]}
+                if stream_type == "values" and "todos" in chunk_data:
+                    todos_list = chunk_data["todos"]
+                # Serialize to JSON and push to Redis stream
+                data = ujson.dumps(stream_chunk)
+                await redis_client.xadd(stream_key, {"data": data})
+    except Exception as e:
+        if is_daytona_error(e):
+            if default_sandbox == "daytona":
+                # Explicit daytona mode: surface the detailed error
+                logger.error(f"Daytona sandbox error (daytona mode) in worker: {e}")
+                error_msg = ujson.dumps(("error", f"Daytona sandbox error: {e}"))
+                await redis_client.xadd(stream_key, {"data": error_msg})
+                await redis_client.xadd(stream_key, {"done": "true"})
+                await redis_client.expire(stream_key, 300)
+                return {"status": "error", "stream_key": stream_key}
+            elif default_sandbox in (None, "auto") and effective_type == "daytona":
+                # Auto mode: fallback to local StateBackend and retry
+                logger.warning(f"Daytona sandbox error in auto mode worker, falling back to local: {e}")
+                fallback_backend, _ = _create_state_backend(runtime)
+                agent = await construct_agent(
+                    instructions=params.instructions,
+                    system_prompt=params.system_prompt,
+                    tools=params.tools,
+                    model=params.model,
+                    subagents=params.subagents,
+                    checkpointer=checkpointer,
+                    service_context=service_context,
+                    backend=fallback_backend,
+                    memory=memory_sources,
+                    api_key=api_key,
+                )
+                async for chunk in agent.astream(
+                    params.input,
+                    stream_mode=["messages", "values"],
+                    config=config,
+                    context=ctx_schema,
+                ):
+                    stream_chunk = handle_multi_mode(chunk)
+                    if stream_chunk:
+                        stream_type = stream_chunk[0]
+                        chunk_data = stream_chunk[1]
+                        if stream_type == "values" and chunk_data.get("files"):
+                            files_map = {**files_map, **chunk_data["files"]}
+                        if stream_type == "values" and "todos" in chunk_data:
+                            todos_list = chunk_data["todos"]
+                        data = ujson.dumps(stream_chunk)
+                        await redis_client.xadd(stream_key, {"data": data})
+            else:
+                raise
+        else:
+            raise
 
     # Signal completion
     await redis_client.xadd(stream_key, {"done": "true"})

--- a/backend/tests/unit/agents/test_daytona.py
+++ b/backend/tests/unit/agents/test_daytona.py
@@ -95,7 +95,7 @@ class TestResolveSandboxBackend:
         ):
             from src.agents import resolve_sandbox_backend
 
-            backend, sandbox = resolve_sandbox_backend(mock_runtime)
+            backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime)
 
             assert sandbox is mock_sandbox
             assert backend is not None
@@ -119,7 +119,7 @@ class TestResolveSandboxBackend:
         ):
             from src.agents import resolve_sandbox_backend
 
-            result_backend, sandbox = resolve_sandbox_backend(mock_runtime)
+            result_backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime)
 
             assert sandbox is None
             assert result_backend is not None
@@ -136,7 +136,7 @@ class TestResolveSandboxBackend:
         ):
             from src.agents import resolve_sandbox_backend
 
-            result_backend, sandbox = resolve_sandbox_backend(mock_runtime)
+            result_backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime)
 
             assert sandbox is None
             assert result_backend is not None
@@ -162,7 +162,7 @@ class TestResolveSandboxBackend:
             from src.agents import resolve_sandbox_backend
 
             # Should not raise
-            cleanup_backend, sandbox = resolve_sandbox_backend(mock_runtime)
+            cleanup_backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime)
 
             assert sandbox is None
             assert cleanup_backend is not None
@@ -182,7 +182,7 @@ class TestResolveSandboxBackend:
         ):
             from src.agents import resolve_sandbox_backend
 
-            result_backend, sandbox = resolve_sandbox_backend(mock_runtime)
+            result_backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime)
 
             assert sandbox is None
             assert result_backend is not None
@@ -214,7 +214,7 @@ class TestResolveSandboxBackendDispatch:
         ):
             from src.agents import resolve_sandbox_backend
 
-            backend, sandbox = resolve_sandbox_backend(mock_runtime, sandbox_type=None)
+            backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime, sandbox_type=None)
 
             assert sandbox is mock_sandbox
             assert backend is not None
@@ -229,7 +229,7 @@ class TestResolveSandboxBackendDispatch:
         ):
             from src.agents import resolve_sandbox_backend
 
-            backend, sandbox = resolve_sandbox_backend(mock_runtime, sandbox_type=None)
+            backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime, sandbox_type=None)
 
             assert sandbox is None
             assert backend is not None
@@ -244,7 +244,7 @@ class TestResolveSandboxBackendDispatch:
         ) as mock_create_daytona:
             from src.agents import resolve_sandbox_backend
 
-            backend, sandbox = resolve_sandbox_backend(mock_runtime, sandbox_type="state")
+            backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime, sandbox_type="state")
 
             assert sandbox is None
             assert backend is not None
@@ -261,7 +261,7 @@ class TestResolveSandboxBackendDispatch:
         ):
             from src.agents import resolve_sandbox_backend
 
-            backend, sandbox = resolve_sandbox_backend(mock_runtime, sandbox_type="daytona")
+            backend, sandbox, _effective_type = resolve_sandbox_backend(mock_runtime, sandbox_type="daytona")
 
             assert sandbox is None
             assert backend is not None

--- a/backend/tests/unit/agents/test_daytona_error_handling.py
+++ b/backend/tests/unit/agents/test_daytona_error_handling.py
@@ -1,0 +1,75 @@
+"""Tests for Daytona error handling helpers and resolve_sandbox_backend return values."""
+
+from unittest.mock import MagicMock, patch
+
+from src.agents import is_daytona_error, resolve_sandbox_backend
+
+
+class TestIsDaytonaError:
+    """Tests for is_daytona_error() helper."""
+
+    def test_returns_true_for_daytona_error(self):
+        """When DaytonaError class is available, should detect it."""
+        mock_error = type("DaytonaError", (Exception,), {})
+        exc = mock_error("test error")
+        with patch("src.agents.DaytonaError", mock_error):
+            assert is_daytona_error(exc) is True
+
+    def test_returns_false_when_package_not_installed(self):
+        """When DaytonaError is None (not installed), always returns False."""
+        with patch("src.agents.DaytonaError", None):
+            assert is_daytona_error(RuntimeError("anything")) is False
+
+    def test_returns_false_for_non_daytona_exception(self):
+        """Regular exceptions should not be detected as DaytonaError."""
+        mock_error = type("DaytonaError", (Exception,), {})
+        with patch("src.agents.DaytonaError", mock_error):
+            assert is_daytona_error(ValueError("not daytona")) is False
+            assert is_daytona_error(RuntimeError("nope")) is False
+
+
+class TestResolveSandboxBackendReturnType:
+    """Tests that resolve_sandbox_backend returns 3-tuple with effective_type."""
+
+    def test_state_mode_returns_state_type(self):
+        """Explicit 'state' mode should return effective_type='state'."""
+        runtime = MagicMock()
+        backend, sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type="state")
+        assert effective_type == "state"
+        assert sandbox is None
+
+    @patch("src.agents._create_daytona_backend_checked", return_value=None)
+    def test_auto_mode_fallback_returns_state_type(self, _mock):
+        """When Daytona is unavailable in auto mode, should fallback to 'state'."""
+        runtime = MagicMock()
+        backend, sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=None)
+        assert effective_type == "state"
+        assert sandbox is None
+
+    @patch("src.agents._create_daytona_backend_checked")
+    def test_auto_mode_daytona_available_returns_daytona_type(self, mock_checked):
+        """When Daytona succeeds in auto mode, should return 'daytona'."""
+        mock_backend = MagicMock()
+        mock_sandbox = MagicMock()
+        mock_checked.return_value = (mock_backend, mock_sandbox)
+        runtime = MagicMock()
+        backend, sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type="auto")
+        assert effective_type == "daytona"
+        assert sandbox is mock_sandbox
+
+    @patch("src.agents._create_daytona_backend_checked")
+    def test_daytona_mode_success_returns_daytona_type(self, mock_checked):
+        """Explicit 'daytona' mode with success should return 'daytona'."""
+        mock_backend = MagicMock()
+        mock_sandbox = MagicMock()
+        mock_checked.return_value = (mock_backend, mock_sandbox)
+        runtime = MagicMock()
+        backend, sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type="daytona")
+        assert effective_type == "daytona"
+
+    @patch("src.agents._create_daytona_backend_checked", return_value=None)
+    def test_daytona_mode_fallback_returns_state_type(self, _mock):
+        """Explicit 'daytona' mode with Daytona unavailable should fallback to 'state'."""
+        runtime = MagicMock()
+        backend, sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type="daytona")
+        assert effective_type == "state"

--- a/backend/tests/unit/workers/test_worker_model_resolution.py
+++ b/backend/tests/unit/workers/test_worker_model_resolution.py
@@ -116,7 +116,7 @@ class TestWorkerModelResolution:
             patch(_PATCHES["construct_agent"], new_callable=AsyncMock) as mock_construct,
             patch(
                 _PATCHES["init_backend"],
-                return_value=(MagicMock(), None),
+                return_value=(MagicMock(), None, "state"),
             ),
         ):
             instance = MockRepo.return_value
@@ -160,7 +160,7 @@ class TestWorkerModelResolution:
             patch(_PATCHES["construct_agent"], new_callable=AsyncMock) as mock_construct,
             patch(
                 _PATCHES["init_backend"],
-                return_value=(MagicMock(), None),
+                return_value=(MagicMock(), None, "state"),
             ),
         ):
             instance = MockRepo.return_value
@@ -205,7 +205,7 @@ class TestWorkerModelResolution:
             patch(_PATCHES["construct_agent"], new_callable=AsyncMock) as mock_construct,
             patch(
                 _PATCHES["init_backend"],
-                return_value=(MagicMock(), None),
+                return_value=(MagicMock(), None, "state"),
             ),
         ):
             instance = MockRepo.return_value
@@ -250,7 +250,7 @@ class TestWorkerModelResolution:
             patch(_PATCHES["construct_agent"], new_callable=AsyncMock) as mock_construct,
             patch(
                 _PATCHES["init_backend"],
-                return_value=(MagicMock(), None),
+                return_value=(MagicMock(), None, "state"),
             ),
         ):
             instance = MockRepo.return_value
@@ -292,7 +292,7 @@ class TestWorkerModelResolution:
             patch(_PATCHES["construct_agent"], new_callable=AsyncMock) as mock_construct,
             patch(
                 _PATCHES["init_backend"],
-                return_value=(MagicMock(), None),
+                return_value=(MagicMock(), None, "state"),
             ),
         ):
             mock_construct.return_value = _mock_agent(DEFAULT_CHAT_MODEL)

--- a/frontend/src/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/components/chat/ChatComposer.test.tsx
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ChatComposer from "./ChatComposer";
+
+vi.mock("@/components/inputs/ChatInput", () => ({
+	default: () => <div data-testid="chat-input" />,
+}));
+
+vi.mock("@/components/status/ThreadSandboxStatus", () => ({
+	default: () => <div data-testid="thread-sandbox-status" />,
+}));
+
+describe("ChatComposer", () => {
+	it("renders the sandbox status above the chat input when enabled", () => {
+		render(<ChatComposer showAgentMenu={true} showSandboxStatus={true} />);
+
+		const sandboxStatus = screen.getByTestId("thread-sandbox-status");
+		const chatInput = screen.getByTestId("chat-input");
+
+		expect(sandboxStatus).toBeInTheDocument();
+		expect(chatInput).toBeInTheDocument();
+		expect(
+			sandboxStatus.compareDocumentPosition(chatInput) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("omits the sandbox status when disabled", () => {
+		render(<ChatComposer showAgentMenu={true} showSandboxStatus={false} />);
+
+		expect(
+			screen.queryByTestId("thread-sandbox-status"),
+		).not.toBeInTheDocument();
+		expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -1,5 +1,16 @@
 import ChatInput from "@/components/inputs/ChatInput";
 import ThreadSandboxStatus from "@/components/status/ThreadSandboxStatus";
+import { FolderCode, ListTodo, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+	Popover,
+	PopoverTrigger,
+	PopoverContent,
+} from "@/components/ui/popover";
+import { useChatContext } from "@/context/ChatContext";
+import type { Todo } from "@/components/lists/TodoList";
+import { Circle, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface ChatComposerProps {
 	showAgentMenu?: boolean;
@@ -10,11 +21,116 @@ export default function ChatComposer({
 	showAgentMenu = false,
 	showSandboxStatus = false,
 }: ChatComposerProps) {
+	const { viewMode, setViewMode, filesMap, todos } = useChatContext();
+
+	const fileCount = Array.from(filesMap?.values() || []).reduce(
+		(acc: number, files: any) => acc + Object.keys(files || {}).length,
+		0,
+	);
+
+	const completedCount =
+		todos?.filter((t: any) => t.status === "completed").length ?? 0;
+	const inProgressTodo = todos?.find((t: any) => t.status === "in_progress");
+
 	return (
-		<div className="shrink-0 border-t border-border bg-background">
-			<div className="max-w-4xl mx-auto px-4 pt-3 pb-4">
+		<div className="relative shrink-0 bg-background">
+			<div className="pointer-events-none absolute -top-8 left-0 right-0 h-8 bg-gradient-to-b from-transparent to-background" />
+			<div className="max-w-4xl mx-auto px-4 pb-4">
 				<div className="flex flex-col gap-2">
-					{showSandboxStatus && <ThreadSandboxStatus />}
+					{showSandboxStatus && (
+						<div className="flex items-center justify-between">
+							<ThreadSandboxStatus />
+							<div className="flex items-center gap-2">
+								{todos && todos.length > 0 && (
+									<Popover>
+										<PopoverTrigger asChild>
+											<Button
+												variant="ghost"
+												size="sm"
+												className="h-8 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:text-foreground"
+											>
+												{inProgressTodo ? (
+													<Loader2 className="h-3.5 w-3.5 animate-spin" />
+												) : (
+													<ListTodo className="h-3.5 w-3.5" />
+												)}
+												<span>Tasks</span>
+												<span className="text-foreground">
+													{completedCount}/{todos.length}
+												</span>
+											</Button>
+										</PopoverTrigger>
+										<PopoverContent side="top" align="end" className="w-80 p-2">
+											<div className="px-2 pb-2">
+												<p className="text-sm font-medium">Tasks</p>
+												<p className="text-xs text-muted-foreground">
+													{completedCount} of {todos.length} completed
+												</p>
+											</div>
+											<div className="space-y-1">
+												{todos.map((todo: Todo, index: number) => {
+													const isCompleted = todo.status === "completed";
+													const isInProgress = todo.status === "in_progress";
+													return (
+														<div
+															key={`${todo.content}-${index}`}
+															className={cn(
+																"flex items-start gap-3 rounded-lg px-3 py-2 text-left",
+																isInProgress && "bg-accent",
+															)}
+														>
+															{isCompleted ? (
+																<CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+															) : isInProgress ? (
+																<Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-blue-500" />
+															) : (
+																<Circle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+															)}
+															<span className="min-w-0">
+																<span
+																	className={cn(
+																		"block text-sm",
+																		isCompleted &&
+																			"text-muted-foreground line-through",
+																		isInProgress &&
+																			"font-medium text-foreground",
+																	)}
+																>
+																	{todo.content}
+																</span>
+																{isInProgress && todo.activeForm && (
+																	<span className="block text-xs text-blue-500 truncate">
+																		{todo.activeForm}
+																	</span>
+																)}
+															</span>
+														</div>
+													);
+												})}
+											</div>
+										</PopoverContent>
+									</Popover>
+								)}
+								<Button
+									variant="ghost"
+									size="sm"
+									className="h-8 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:text-foreground"
+									onClick={() =>
+										setViewMode(viewMode === "chat" ? "editor" : "chat")
+									}
+									title={
+										viewMode === "editor" ? "Back to Chat" : "Manage Files"
+									}
+								>
+									<FolderCode className="h-3.5 w-3.5" />
+									<span>Files</span>
+									{fileCount > 0 && (
+										<span className="text-foreground">{fileCount}</span>
+									)}
+								</Button>
+							</div>
+						</div>
+					)}
 					<ChatInput showAgentMenu={showAgentMenu} />
 				</div>
 			</div>

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,23 @@
+import ChatInput from "@/components/inputs/ChatInput";
+import ThreadSandboxStatus from "@/components/status/ThreadSandboxStatus";
+
+interface ChatComposerProps {
+	showAgentMenu?: boolean;
+	showSandboxStatus?: boolean;
+}
+
+export default function ChatComposer({
+	showAgentMenu = false,
+	showSandboxStatus = false,
+}: ChatComposerProps) {
+	return (
+		<div className="shrink-0 border-t border-border bg-background">
+			<div className="max-w-4xl mx-auto px-4 pt-3 pb-4">
+				<div className="flex flex-col gap-2">
+					{showSandboxStatus && <ThreadSandboxStatus />}
+					<ChatInput showAgentMenu={showAgentMenu} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/inputs/ChatInput.tsx
+++ b/frontend/src/components/inputs/ChatInput.tsx
@@ -8,12 +8,27 @@ import { useVoiceVisualizer, VoiceVisualizer } from "react-voice-visualizer";
 import BaseToolMenu from "../menus/BaseToolMenu";
 import AgentMenu from "../menus/AgentMenu";
 import { useProjectContext } from "@/context/ProjectContext";
-import { X, Folder, FolderCode } from "lucide-react";
+import { X, Folder, Check } from "lucide-react";
 import { Button } from "../ui/button";
 import QueuePanel from "../panels/QueuePanel";
 import { ModelBadge } from "@/components/badges/ModelBadge";
-import { useNavigate } from "react-router";
-import { getAuthToken } from "@/lib/utils/auth";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import { useModelVisibility } from "@/hooks/useModelVisibility";
+import { patchDefaults } from "@/lib/services/userSettingsService";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 export default function ChatInput({
 	showAgentMenu = false,
@@ -21,8 +36,8 @@ export default function ChatInput({
 	showAgentMenu?: boolean;
 }) {
 	const [isRecording, setIsRecording] = useState(false);
+	const [modelOpen, setModelOpen] = useState(false);
 	const { isLikelyMobile } = useAppHook();
-	const navigate = useNavigate();
 	const { selectedProject, selectProject } = useProjectContext();
 	const {
 		query,
@@ -41,13 +56,30 @@ export default function ChatInput({
 		handleSubmit,
 		metadata,
 		setMetadata,
-		viewMode,
-		setViewMode,
-		filesMap,
 		inputRef,
 		enqueue,
 		displayModel,
+		models,
+		useModelsEffect,
+		setModel,
 	} = useChatContext();
+
+	useModelsEffect?.();
+	const { isModelVisible } = useModelVisibility();
+	const visibleModels = (models?.models || []).filter((m: string) =>
+		isModelVisible(m),
+	);
+
+	const handleModelSelect = async (model: string) => {
+		setModelOpen(false);
+		setModel(model);
+		try {
+			await patchDefaults({ model });
+			toast.success("Default model updated");
+		} catch {
+			toast.error("Failed to update model");
+		}
+	};
 
 	// Helper to enqueue and clear input
 	const handleEnqueue = (q: string, imgs: File[]) => {
@@ -63,16 +95,6 @@ export default function ChatInput({
 			return rest;
 		});
 		localStorage.removeItem("current_project_id");
-	};
-
-	// Count total files across all messages
-	const fileCount = Array.from(filesMap?.values() || []).reduce(
-		(acc: number, files: any) => acc + Object.keys(files || {}).length,
-		0,
-	);
-
-	const toggleViewMode = () => {
-		setViewMode(viewMode === "chat" ? "editor" : "chat");
 	};
 
 	// Initialize the recorder controls using the hook
@@ -143,22 +165,6 @@ export default function ChatInput({
 					<div className="flex gap-1">
 						{/* <ImageUpload /> */}
 						<BaseToolMenu />
-
-						{/* File toggle button */}
-						<Button
-							variant={viewMode === "editor" ? "secondary" : "default"}
-							size="sm"
-							className="rounded-xl h-9 px-2 gap-1 relative w-9 p-0 justify-center"
-							onClick={toggleViewMode}
-							title={viewMode === "editor" ? "Back to Chat" : "Manage Files"}
-						>
-							<FolderCode className="h-4 w-4" />
-							{fileCount > 0 && (
-								<span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-[10px] rounded-full h-4 w-4 flex items-center justify-center">
-									{fileCount}
-								</span>
-							)}
-						</Button>
 						{showAgentMenu && <AgentMenu />}
 					</div>
 
@@ -177,17 +183,43 @@ export default function ChatInput({
 				</div>
 				<div className="flex items-center gap-2">
 					{displayModel && (
-						<button
-							onClick={() => navigate(getAuthToken() ? "/settings" : "/login")}
-							title={
-								getAuthToken()
-									? "Change default model"
-									: "Log in to change model"
-							}
-							className="cursor-pointer hover:opacity-80 transition-opacity"
-						>
-							<ModelBadge model={displayModel} />
-						</button>
+						<Popover open={modelOpen} onOpenChange={setModelOpen}>
+							<PopoverTrigger asChild>
+								<button
+									title="Change default model"
+									className="cursor-pointer hover:opacity-80 transition-opacity"
+								>
+									<ModelBadge model={displayModel} />
+								</button>
+							</PopoverTrigger>
+							<PopoverContent side="top" align="end" className="w-[280px] p-0">
+								<Command>
+									<CommandInput placeholder="Search models..." />
+									<CommandList>
+										<CommandEmpty>No model found.</CommandEmpty>
+										<CommandGroup>
+											{visibleModels.map((modelValue: string) => (
+												<CommandItem
+													key={modelValue}
+													value={modelValue}
+													onSelect={handleModelSelect}
+												>
+													<Check
+														className={cn(
+															"mr-2 h-4 w-4",
+															displayModel === modelValue
+																? "opacity-100"
+																: "opacity-0",
+														)}
+													/>
+													{modelValue.split(":")[1] || modelValue}
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
 					)}
 					<ChatSubmitButton
 						abortQuery={abortQuery}

--- a/frontend/src/components/inputs/ChatInput.tsx
+++ b/frontend/src/components/inputs/ChatInput.tsx
@@ -60,11 +60,9 @@ export default function ChatInput({
 		enqueue,
 		displayModel,
 		models,
-		useModelsEffect,
 		setModel,
 	} = useChatContext();
 
-	useModelsEffect?.();
 	const { isModelVisible } = useModelVisibility();
 	const visibleModels = (models?.models || []).filter((m: string) =>
 		isModelVisible(m),
@@ -72,9 +70,9 @@ export default function ChatInput({
 
 	const handleModelSelect = async (model: string) => {
 		setModelOpen(false);
-		setModel(model);
 		try {
 			await patchDefaults({ model });
+			setModel(model);
 			toast.success("Default model updated");
 		} catch {
 			toast.error("Failed to update model");

--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -8,11 +8,9 @@ import MarkdownCard from "../cards/MarkdownCard";
 import DefaultTool from "../tools/Default";
 import { formatContent } from "@/lib/utils/format";
 import CopyTextButton from "../buttons/CopyTextButton";
-import FileViewer from "../viewers/FileViewer";
 import { latestHumanMessage } from "@/lib/utils/message";
 import ToolTimeline from "../timeline/ToolTimeline";
 import TextSelectionPopover from "../popovers/TextSelectionPopover";
-import TodoList from "./TodoList";
 import { SubagentBadge } from "../badges/SubagentBadge";
 
 export const Message = memo(
@@ -23,8 +21,6 @@ export const Message = memo(
 		streamingRate,
 		handleSubmit,
 		loading,
-		filesMap,
-		viewMode,
 		ttft,
 		displayModel,
 	}: {
@@ -34,8 +30,6 @@ export const Message = memo(
 		streamingRate?: { rate: number; count: number } | null;
 		handleSubmit: (content: string) => Promise<void>;
 		loading: boolean;
-		filesMap: Map<string, any>;
-		viewMode: string;
 		ttft?: number | null;
 		displayModel?: string | null;
 	}) {
@@ -195,7 +189,6 @@ export const Message = memo(
 			);
 		}
 
-		const messageFiles = filesMap.get(message.id);
 		const isSubagent = !!message.agent_name;
 
 		return (
@@ -213,14 +206,6 @@ export const Message = memo(
 							content={formatContent(message.content) || "Invalid message"}
 						/>
 					</div>
-
-					{viewMode === "chat" &&
-						messageFiles &&
-						Object.keys(messageFiles).length > 0 && (
-							<div className="mt-2 px-3">
-								<FileViewer files={messageFiles} />
-							</div>
-						)}
 				</div>
 				<div className="flex justify-start opacity-100 transition-opacity duration-200 mt-1 px-3">
 					<div className="flex gap-1">
@@ -256,8 +241,6 @@ export const Message = memo(
 			prevProps.messages.length === nextProps.messages.length &&
 			prevProps.loading === nextProps.loading &&
 			prevProps.streamingRate === nextProps.streamingRate &&
-			prevProps.viewMode === nextProps.viewMode &&
-			prevProps.filesMap === nextProps.filesMap &&
 			prevProps.ttft === nextProps.ttft &&
 			prevProps.displayModel === nextProps.displayModel
 		);
@@ -269,12 +252,9 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 	const {
 		streamingRate,
 		handleSubmit,
-		filesMap,
-		viewMode,
 		ttft,
 		submitStartTime,
 		appendToQuery,
-		todos,
 		displayModel,
 	} = useChatContext();
 	const [elapsedTime, setElapsedTime] = useState<number | null>(null);
@@ -397,7 +377,7 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 			<div
 				ref={scrollRef}
 				onScroll={handleScroll}
-				className="flex-1 overflow-auto p-1 mb-1"
+				className="flex-1 overflow-auto p-1 pb-8"
 			>
 				<div
 					ref={messagesContainerRef}
@@ -436,8 +416,6 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 									streamingRate={streamingRate}
 									handleSubmit={handleSubmit}
 									loading={loading}
-									filesMap={filesMap}
-									viewMode={viewMode}
 									ttft={ttft}
 									displayModel={displayModel}
 								/>
@@ -445,11 +423,6 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 						);
 					})}
 				</div>
-				{todos && todos.length > 0 && (
-					<div className="max-w-4xl mx-auto px-5 mt-2 mb-2">
-						<TodoList todos={todos} />
-					</div>
-				)}
 				{loading && (
 					<div className="flex justify-start p-3 max-w-4xl mx-auto px-5">
 						<Loader2 className="h-5 w-5 animate-spin mx-2" />

--- a/frontend/src/components/nav/ChatNav.tsx
+++ b/frontend/src/components/nav/ChatNav.tsx
@@ -2,8 +2,7 @@ import { ColorModeButton } from "@/components/buttons/ColorModeButton";
 import NewThreadButton from "../buttons/NewThreadButton";
 import ShareButton from "../buttons/thread-share-button";
 import { SaveAsAssistantDialog } from "@/components/dialogs/SaveAsAssistantDialog";
-import { LayoutGrid, MessageSquare, Save } from "lucide-react";
-import { useChatContext } from "@/context/ChatContext";
+import { Save } from "lucide-react";
 import { useAgentContext } from "@/context/AgentContext";
 import { Button } from "@/components/ui/button";
 import AgentService from "@/lib/services/agentService";
@@ -15,15 +14,10 @@ export function ChatNav({
 }: {
 	sidebarTrigger?: React.ReactNode | undefined;
 }) {
-	const { viewMode, setViewMode, filesMap } = useChatContext();
 	const { agent, handleGetAgents } = useAgentContext();
-	const hasFiles = filesMap.size > 0;
 	const [saveDialogOpen, setSaveDialogOpen] = useState(false);
 
-	const handleSaveAsAssistant = async (
-		name: string,
-		description: string,
-	) => {
+	const handleSaveAsAssistant = async (name: string, description: string) => {
 		try {
 			await AgentService.create({
 				name,
@@ -50,36 +44,8 @@ export function ChatNav({
 					<div className="flex items-center">{sidebarTrigger}</div>
 
 					<div className="flex items-center gap-2">
-						{/* Mode toggle - only visible when files exist */}
-						{hasFiles && (
-							<div className="flex items-center gap-1 border border-border rounded-lg p-1">
-								<Button
-									variant={viewMode === "chat" ? "secondary" : "ghost"}
-									size="sm"
-									onClick={() => setViewMode("chat")}
-									className="h-8 gap-2"
-									aria-label="Switch to chat view"
-									aria-pressed={viewMode === "chat"}
-								>
-									<MessageSquare className="h-4 w-4" />
-									<span className="hidden sm:inline">Chat</span>
-								</Button>
-								<Button
-									variant={viewMode === "editor" ? "secondary" : "ghost"}
-									size="sm"
-									onClick={() => setViewMode("editor")}
-									className="h-8 gap-2"
-									aria-label="Switch to editor view"
-									aria-pressed={viewMode === "editor"}
-								>
-									<LayoutGrid className="h-4 w-4" />
-									<span className="hidden sm:inline">Editor</span>
-								</Button>
-							</div>
-						)}
-
 						<Button
-							variant="ghost"
+							variant="outline"
 							size="icon"
 							className="h-9 w-9"
 							onClick={() => setSaveDialogOpen(true)}

--- a/frontend/src/components/sections/agent-section.tsx
+++ b/frontend/src/components/sections/agent-section.tsx
@@ -21,12 +21,9 @@ export function AgentSection({
 			/>
 			<h1 className="text-4xl font-bold mt-2 italic">{agent.name}</h1>
 			<p className="text-lg text-muted-foreground mb-2">{agent.description}</p>
-			<div className="flex flex-col w-full lg:w-[600px]">
-				<ChatInput showAgentMenu={showAgentMenu} />
-			</div>
 
-			{/* Links intentionally sit beneath Tagline */}
-			<div className="flex flex-row flex-wrap justify-center gap-1 mt-3">
+			{/* Links between subtext and input */}
+			<div className="flex flex-row flex-wrap justify-center gap-1 mb-3">
 				<Button
 					variant="ghost"
 					size="sm"
@@ -87,6 +84,10 @@ export function AgentSection({
 						Slack
 					</a>
 				</Button>
+			</div>
+
+			<div className="flex flex-col w-full lg:w-[600px]">
+				<ChatInput showAgentMenu={showAgentMenu} />
 			</div>
 		</>
 	);

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -14,31 +14,36 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { toast } from "sonner";
-import { getSettings, patchDefaults } from "@/lib/services/userSettingsService";
-
-const SANDBOX_OPTIONS = [
-	{ value: "auto", label: "Auto (Recommended)" },
-	{ value: "daytona", label: "Daytona" },
-	{ value: "state", label: "Local" },
-] as const;
+import {
+	DEFAULT_SANDBOX,
+	SANDBOX_OPTIONS,
+	normalizeSandboxValue,
+	toSandboxPatchValue,
+} from "@/lib/config/sandbox";
+import {
+	type SandboxType,
+	getSettings,
+	patchDefaults,
+} from "@/lib/services/userSettingsService";
 
 export function SandboxSettings() {
-	const [sandbox, setSandbox] = useState<string>("auto");
+	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(false);
 
 	useEffect(() => {
 		getSettings()
-			.then((res) => setSandbox(res.defaults.sandbox ?? "auto"))
+			.then((res) => setSandbox(normalizeSandboxValue(res.defaults.sandbox)))
 			.catch(() => {});
 	}, []);
 
 	const handleChange = async (value: string) => {
+		const nextSandbox = normalizeSandboxValue(value);
 		setLoading(true);
 		try {
 			const res = await patchDefaults({
-				sandbox: value === "auto" ? null : value,
+				sandbox: toSandboxPatchValue(nextSandbox),
 			});
-			setSandbox(res.defaults.sandbox ?? "auto");
+			setSandbox(normalizeSandboxValue(res.defaults.sandbox));
 			toast.success("Default sandbox updated");
 		} catch {
 			toast.error("Failed to update default sandbox");
@@ -64,7 +69,9 @@ export function SandboxSettings() {
 					<SelectContent>
 						{SANDBOX_OPTIONS.map((opt) => (
 							<SelectItem key={opt.value} value={opt.value}>
-								{opt.label}
+								{opt.value === "auto"
+									? `${opt.label} (Recommended)`
+									: opt.label}
 							</SelectItem>
 						))}
 					</SelectContent>

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	Card,
 	CardContent,
@@ -21,6 +21,7 @@ import {
 	toSandboxPatchValue,
 } from "@/lib/config/sandbox";
 import {
+	type ProviderKeyStatus,
 	type SandboxType,
 	getSettings,
 	patchDefaults,
@@ -29,10 +30,25 @@ import {
 export function SandboxSettings() {
 	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(false);
+	const [providerKeys, setProviderKeys] = useState<ProviderKeyStatus[]>([]);
+
+	const visibleOptions = useMemo(
+		() =>
+			SANDBOX_OPTIONS.filter((opt) => {
+				if (opt.value !== "daytona") return true;
+				return providerKeys.some(
+					(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
+				);
+			}),
+		[providerKeys],
+	);
 
 	useEffect(() => {
 		getSettings()
-			.then((res) => setSandbox(normalizeSandboxValue(res.defaults.sandbox)))
+			.then((res) => {
+				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
+				setProviderKeys(res.provider_keys ?? []);
+			})
 			.catch(() => {});
 	}, []);
 
@@ -57,8 +73,7 @@ export function SandboxSettings() {
 			<CardHeader>
 				<CardTitle>Default Sandbox</CardTitle>
 				<CardDescription>
-					Choose the sandbox backend for agent code execution. Auto will try
-					Daytona first, then fall back to local.
+					Choose the sandbox backend for agent code execution.
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
@@ -67,11 +82,9 @@ export function SandboxSettings() {
 						<SelectValue />
 					</SelectTrigger>
 					<SelectContent>
-						{SANDBOX_OPTIONS.map((opt) => (
+						{visibleOptions.map((opt) => (
 							<SelectItem key={opt.value} value={opt.value}>
-								{opt.value === "auto"
-									? `${opt.label} (Recommended)`
-									: opt.label}
+								{opt.label}
 							</SelectItem>
 						))}
 					</SelectContent>

--- a/frontend/src/components/status/ThreadSandboxStatus.test.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.test.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ThreadSandboxStatus from "./ThreadSandboxStatus";
+
+const mockGetSettings = vi.fn();
+const mockPatchDefaults = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("@/lib/services/userSettingsService", () => ({
+	getSettings: () => mockGetSettings(),
+	patchDefaults: (data: unknown) => mockPatchDefaults(data),
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: (message: string) => mockToastSuccess(message),
+		error: (message: string) => mockToastError(message),
+	},
+}));
+
+describe("ThreadSandboxStatus", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetSettings.mockResolvedValue({
+			defaults: {
+				sandbox: "daytona",
+			},
+		});
+	});
+
+	it("loads and displays the current sandbox setting", async () => {
+		render(<ThreadSandboxStatus />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Sandbox: Daytona" }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("updates the sandbox from the popover selection", async () => {
+		mockPatchDefaults.mockResolvedValue({
+			defaults: {
+				sandbox: "state",
+			},
+		});
+
+		render(<ThreadSandboxStatus />);
+
+		await screen.findByRole("button", { name: "Sandbox: Daytona" });
+
+		fireEvent.click(screen.getByRole("button", { name: "Sandbox: Daytona" }));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Select Local sandbox" }),
+		);
+
+		await waitFor(() => {
+			expect(mockPatchDefaults).toHaveBeenCalledWith({ sandbox: "state" });
+			expect(
+				screen.getByRole("button", { name: "Sandbox: Local" }),
+			).toBeInTheDocument();
+		});
+		expect(mockToastSuccess).toHaveBeenCalledWith("Sandbox updated");
+	});
+});

--- a/frontend/src/components/status/ThreadSandboxStatus.test.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.test.tsx
@@ -27,6 +27,7 @@ describe("ThreadSandboxStatus", () => {
 			defaults: {
 				sandbox: "daytona",
 			},
+			provider_keys: [{ provider: "DAYTONA_API_KEY", is_set: true }],
 		});
 	});
 
@@ -45,6 +46,7 @@ describe("ThreadSandboxStatus", () => {
 			defaults: {
 				sandbox: "state",
 			},
+			provider_keys: [{ provider: "DAYTONA_API_KEY", is_set: true }],
 		});
 
 		render(<ThreadSandboxStatus />);
@@ -53,15 +55,45 @@ describe("ThreadSandboxStatus", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "Sandbox: Daytona" }));
 		fireEvent.click(
-			screen.getByRole("button", { name: "Select Local sandbox" }),
+			screen.getByRole("button", {
+				name: "Select State (Default) sandbox",
+			}),
 		);
 
 		await waitFor(() => {
 			expect(mockPatchDefaults).toHaveBeenCalledWith({ sandbox: "state" });
 			expect(
-				screen.getByRole("button", { name: "Sandbox: Local" }),
+				screen.getByRole("button", {
+					name: "Sandbox: State (Default)",
+				}),
 			).toBeInTheDocument();
 		});
 		expect(mockToastSuccess).toHaveBeenCalledWith("Sandbox updated");
+	});
+
+	it("hides Daytona option when DAYTONA_API_KEY is not set", async () => {
+		mockGetSettings.mockResolvedValue({
+			defaults: { sandbox: "state" },
+			provider_keys: [{ provider: "DAYTONA_API_KEY", is_set: false }],
+		});
+
+		render(<ThreadSandboxStatus />);
+
+		await screen.findByRole("button", { name: "Sandbox: State (Default)" });
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Sandbox: State (Default)" }),
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", {
+					name: "Select State (Default) sandbox",
+				}),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Select Daytona sandbox" }),
+			).not.toBeInTheDocument();
+		});
 	});
 });

--- a/frontend/src/components/status/ThreadSandboxStatus.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	Check,
 	ChevronsUpDown,
@@ -21,6 +21,7 @@ import {
 	toSandboxPatchValue,
 } from "@/lib/config/sandbox";
 import {
+	type ProviderKeyStatus,
 	type SandboxType,
 	getSettings,
 	patchDefaults,
@@ -30,7 +31,19 @@ export default function ThreadSandboxStatus() {
 	const [open, setOpen] = useState(false);
 	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(true);
+	const [providerKeys, setProviderKeys] = useState<ProviderKeyStatus[]>([]);
 	const currentOption = getSandboxOption(sandbox);
+
+	const visibleOptions = useMemo(
+		() =>
+			SANDBOX_OPTIONS.filter((opt) => {
+				if (opt.value !== "daytona") return true;
+				return providerKeys.some(
+					(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
+				);
+			}),
+		[providerKeys],
+	);
 
 	useEffect(() => {
 		let isActive = true;
@@ -42,6 +55,7 @@ export default function ThreadSandboxStatus() {
 				}
 
 				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
+				setProviderKeys(res.provider_keys ?? []);
 			})
 			.catch(() => {
 				if (isActive) {
@@ -115,7 +129,7 @@ export default function ThreadSandboxStatus() {
 						</p>
 					</div>
 					<div className="space-y-1">
-						{SANDBOX_OPTIONS.map((option) => {
+						{visibleOptions.map((option) => {
 							const selected = option.value === sandbox;
 
 							return (
@@ -138,7 +152,6 @@ export default function ThreadSandboxStatus() {
 									<span className="min-w-0">
 										<span className="block text-sm font-medium">
 											{option.label}
-											{option.value === "auto" ? " (Recommended)" : ""}
 										</span>
 										<span className="block text-xs text-muted-foreground">
 											{option.description}

--- a/frontend/src/components/status/ThreadSandboxStatus.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import {
+	Check,
+	ChevronsUpDown,
+	LoaderCircle,
+	SquareTerminal,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import {
+	DEFAULT_SANDBOX,
+	SANDBOX_OPTIONS,
+	getSandboxOption,
+	normalizeSandboxValue,
+	toSandboxPatchValue,
+} from "@/lib/config/sandbox";
+import {
+	type SandboxType,
+	getSettings,
+	patchDefaults,
+} from "@/lib/services/userSettingsService";
+
+export default function ThreadSandboxStatus() {
+	const [open, setOpen] = useState(false);
+	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
+	const [loading, setLoading] = useState(true);
+	const currentOption = getSandboxOption(sandbox);
+
+	useEffect(() => {
+		let isActive = true;
+
+		getSettings()
+			.then((res) => {
+				if (!isActive) {
+					return;
+				}
+
+				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
+			})
+			.catch(() => {
+				if (isActive) {
+					setSandbox(DEFAULT_SANDBOX);
+				}
+			})
+			.finally(() => {
+				if (isActive) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			isActive = false;
+		};
+	}, []);
+
+	const handleSelect = async (value: SandboxType) => {
+		if (value === sandbox) {
+			setOpen(false);
+			return;
+		}
+
+		setLoading(true);
+
+		try {
+			const res = await patchDefaults({
+				sandbox: toSandboxPatchValue(value),
+			});
+			setSandbox(normalizeSandboxValue(res.defaults.sandbox));
+			setOpen(false);
+			toast.success("Sandbox updated");
+		} catch {
+			toast.error("Failed to update sandbox");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<div className="flex items-center justify-start">
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-8 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:text-foreground"
+						aria-label={`Sandbox: ${currentOption.label}`}
+						disabled={loading}
+					>
+						<SquareTerminal className="h-3.5 w-3.5" />
+						<span>Sandbox</span>
+						<span className="text-foreground">{currentOption.shortLabel}</span>
+						{loading ? (
+							<LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+						) : (
+							<ChevronsUpDown className="h-3.5 w-3.5" />
+						)}
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent
+					side="top"
+					align="start"
+					className="w-80 p-2"
+					aria-label="Sandbox selection"
+				>
+					<div className="px-2 pb-2">
+						<p className="text-sm font-medium">Execution Sandbox</p>
+						<p className="text-xs text-muted-foreground">
+							Choose which sandbox backend new agent actions should use.
+						</p>
+					</div>
+					<div className="space-y-1">
+						{SANDBOX_OPTIONS.map((option) => {
+							const selected = option.value === sandbox;
+
+							return (
+								<button
+									key={option.value}
+									type="button"
+									onClick={() => handleSelect(option.value)}
+									aria-label={`Select ${option.label} sandbox`}
+									className={cn(
+										"flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent",
+										selected && "bg-accent",
+									)}
+								>
+									<Check
+										className={cn(
+											"mt-0.5 h-4 w-4 text-primary",
+											selected ? "opacity-100" : "opacity-0",
+										)}
+									/>
+									<span className="min-w-0">
+										<span className="block text-sm font-medium">
+											{option.label}
+											{option.value === "auto" ? " (Recommended)" : ""}
+										</span>
+										<span className="block text-xs text-muted-foreground">
+											{option.description}
+										</span>
+									</span>
+								</button>
+							);
+						})}
+					</div>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}

--- a/frontend/src/lib/config/sandbox.ts
+++ b/frontend/src/lib/config/sandbox.ts
@@ -1,0 +1,55 @@
+import type { SandboxType } from "@/lib/services/userSettingsService";
+
+export type SandboxOption = {
+	value: SandboxType;
+	label: string;
+	shortLabel: string;
+	description: string;
+};
+
+export const DEFAULT_SANDBOX: SandboxType = "auto";
+
+export const SANDBOX_OPTIONS: readonly SandboxOption[] = [
+	{
+		value: "auto",
+		label: "Auto",
+		shortLabel: "Auto",
+		description: "Try Daytona first, then fall back to local execution.",
+	},
+	{
+		value: "daytona",
+		label: "Daytona",
+		shortLabel: "Daytona",
+		description: "Run agent code in the Daytona sandbox backend.",
+	},
+	{
+		value: "state",
+		label: "Local",
+		shortLabel: "Local",
+		description: "Run agent code with the local sandbox backend.",
+	},
+] as const;
+
+export function normalizeSandboxValue(
+	value: string | null | undefined,
+): SandboxType {
+	if (value === "daytona" || value === "state") {
+		return value;
+	}
+
+	return DEFAULT_SANDBOX;
+}
+
+export function getSandboxOption(
+	value: string | null | undefined,
+): SandboxOption {
+	return (
+		SANDBOX_OPTIONS.find(
+			(option) => option.value === normalizeSandboxValue(value),
+		) ?? SANDBOX_OPTIONS[0]
+	);
+}
+
+export function toSandboxPatchValue(value: SandboxType): string | null {
+	return value === DEFAULT_SANDBOX ? null : value;
+}

--- a/frontend/src/lib/config/sandbox.ts
+++ b/frontend/src/lib/config/sandbox.ts
@@ -7,14 +7,14 @@ export type SandboxOption = {
 	description: string;
 };
 
-export const DEFAULT_SANDBOX: SandboxType = "auto";
+export const DEFAULT_SANDBOX: SandboxType = "state";
 
 export const SANDBOX_OPTIONS: readonly SandboxOption[] = [
 	{
-		value: "auto",
-		label: "Auto",
-		shortLabel: "Auto",
-		description: "Try Daytona first, then fall back to local execution.",
+		value: "state",
+		label: "State (Default)",
+		shortLabel: "State",
+		description: "Run agent code with the state sandbox backend.",
 	},
 	{
 		value: "daytona",
@@ -22,21 +22,16 @@ export const SANDBOX_OPTIONS: readonly SandboxOption[] = [
 		shortLabel: "Daytona",
 		description: "Run agent code in the Daytona sandbox backend.",
 	},
-	{
-		value: "state",
-		label: "Local",
-		shortLabel: "Local",
-		description: "Run agent code with the local sandbox backend.",
-	},
 ] as const;
 
 export function normalizeSandboxValue(
 	value: string | null | undefined,
 ): SandboxType {
-	if (value === "daytona" || value === "state") {
+	if (value === "daytona") {
 		return value;
 	}
 
+	// "auto", null, undefined, and any unknown value all resolve to "state"
 	return DEFAULT_SANDBOX;
 }
 
@@ -50,6 +45,6 @@ export function getSandboxOption(
 	);
 }
 
-export function toSandboxPatchValue(value: SandboxType): string | null {
-	return value === DEFAULT_SANDBOX ? null : value;
+export function toSandboxPatchValue(value: SandboxType): string {
+	return value;
 }

--- a/frontend/src/lib/services/userSettingsService.ts
+++ b/frontend/src/lib/services/userSettingsService.ts
@@ -1,6 +1,6 @@
 import apiClient from "@/lib/utils/apiClient";
 
-export type SandboxType = "auto" | "daytona" | "state";
+export type SandboxType = "daytona" | "state";
 
 export interface ProviderKeyStatus {
 	provider: string;

--- a/frontend/src/lib/utils/fetchStreamReader.ts
+++ b/frontend/src/lib/utils/fetchStreamReader.ts
@@ -142,7 +142,18 @@ export class FetchStreamReader {
 			case "values":
 				return { type: "values", data: payload };
 			case "error":
-				return { type: "error", data: payload };
+				return {
+					type: "error",
+					data:
+						typeof payload === "object" &&
+						payload !== null &&
+						"error" in payload
+							? payload
+							: {
+									error:
+										typeof payload === "string" ? payload : String(payload),
+								},
+				};
 			default:
 				return null;
 		}
@@ -260,7 +271,18 @@ export class ResponseBodyReader {
 			case "values":
 				return { type: "values", data: payload };
 			case "error":
-				return { type: "error", data: payload };
+				return {
+					type: "error",
+					data:
+						typeof payload === "object" &&
+						payload !== null &&
+						"error" in payload
+							? payload
+							: {
+									error:
+										typeof payload === "string" ? payload : String(payload),
+								},
+				};
 			default:
 				return null;
 		}

--- a/frontend/src/pages/chat/ChatPanel.test.tsx
+++ b/frontend/src/pages/chat/ChatPanel.test.tsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import ChatPanel from "./ChatPanel";
+
+const mockUseChatContext = vi.fn();
+const mockUseAppContext = vi.fn();
+
+vi.mock("@/context/ChatContext", () => ({
+	useChatContext: () => mockUseChatContext(),
+}));
+
+vi.mock("@/context/AppContext", () => ({
+	useAppContext: () => mockUseAppContext(),
+}));
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+	useMediaQuery: () => false,
+}));
+
+vi.mock("@/layouts/ChatLayout", () => ({
+	default: ({ children }: { children: ReactNode }) => (
+		<div data-testid="chat-layout">{children}</div>
+	),
+}));
+
+vi.mock("@/components/sections/agent-section", () => ({
+	default: () => <div data-testid="agent-section" />,
+}));
+
+vi.mock("@/components/chat/ChatComposer", () => ({
+	default: ({
+		showAgentMenu,
+		showSandboxStatus,
+	}: {
+		showAgentMenu?: boolean;
+		showSandboxStatus?: boolean;
+	}) => (
+		<div
+			data-testid="chat-composer"
+			data-show-agent-menu={String(showAgentMenu)}
+			data-show-sandbox-status={String(showSandboxStatus)}
+		/>
+	),
+}));
+
+vi.mock("@/components/lists/ChatMessages", () => ({
+	default: ({ messages }: { messages: any[] }) => (
+		<div data-testid="chat-messages">{messages.length}</div>
+	),
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+	ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizablePanel: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizableHandle: () => <div />,
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+	Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SheetContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+vi.mock("@/components/panels/FileEditorPanel", () => ({
+	default: () => <div data-testid="file-editor-panel" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button {...props}>{children}</button>
+	),
+}));
+
+describe("ChatPanel", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockUseAppContext.mockReturnValue({
+			appVersion: "test-version",
+		});
+
+		mockUseChatContext.mockReturnValue({
+			messages: [{ id: "msg-1", content: "Hello" }],
+			viewMode: "chat",
+			setViewMode: vi.fn(),
+		});
+	});
+
+	it("renders the composer without sandbox status by default", () => {
+		render(<ChatPanel chatNav={<div data-testid="chat-nav" />} />);
+
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-agent-menu",
+			"true",
+		);
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-sandbox-status",
+			"false",
+		);
+	});
+
+	it("renders the composer with sandbox status when enabled", () => {
+		render(
+			<ChatPanel
+				chatNav={<div data-testid="chat-nav" />}
+				showSandboxStatus={true}
+			/>,
+		);
+
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-sandbox-status",
+			"true",
+		);
+	});
+
+	it("passes showAgentMenu through to the composer", () => {
+		render(
+			<ChatPanel
+				chatNav={<div data-testid="chat-nav" />}
+				showAgentMenu={false}
+			/>,
+		);
+
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-agent-menu",
+			"false",
+		);
+	});
+});

--- a/frontend/src/pages/chat/ChatPanel.test.tsx
+++ b/frontend/src/pages/chat/ChatPanel.test.tsx
@@ -133,4 +133,26 @@ describe("ChatPanel", () => {
 			"false",
 		);
 	});
+
+	it("renders ChatComposer on first-load when agent is set and messages are empty", () => {
+		mockUseChatContext.mockReturnValue({
+			messages: [],
+			viewMode: "chat",
+			setViewMode: vi.fn(),
+		});
+
+		render(
+			<ChatPanel
+				agent={{ id: "agent1" }}
+				chatNav={<div data-testid="chat-nav" />}
+				showSandboxStatus={true}
+			/>,
+		);
+
+		const composer = screen.getByTestId("chat-composer");
+		expect(composer).toBeInTheDocument();
+		expect(composer).toHaveAttribute("data-show-agent-menu", "true");
+		expect(composer).toHaveAttribute("data-show-sandbox-status", "true");
+		expect(screen.getByTestId("agent-section")).toBeInTheDocument();
+	});
 });

--- a/frontend/src/pages/chat/ChatPanel.tsx
+++ b/frontend/src/pages/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import ChatInput from "@/components/inputs/ChatInput";
+import ChatComposer from "@/components/chat/ChatComposer";
 import ChatMessages from "@/components/lists/ChatMessages";
 import AgentSection from "@/components/sections/agent-section";
 import { useChatContext } from "@/context/ChatContext";
@@ -21,9 +21,15 @@ interface ChatPanelProps {
 	chatNav?: React.ReactNode | undefined;
 	sidebarTrigger?: React.ReactNode | undefined;
 	showAgentMenu?: boolean;
+	showSandboxStatus?: boolean;
 }
 
-function ChatPanel({ agent, chatNav, showAgentMenu = true }: ChatPanelProps) {
+function ChatPanel({
+	agent,
+	chatNav,
+	showAgentMenu = true,
+	showSandboxStatus = false,
+}: ChatPanelProps) {
 	const { appVersion } = useAppContext();
 	const { messages, viewMode, setViewMode } = useChatContext();
 	const isMobile = useMediaQuery("(max-width: 768px)");
@@ -56,13 +62,10 @@ function ChatPanel({ agent, chatNav, showAgentMenu = true }: ChatPanelProps) {
 					<div className="flex-1 min-h-0">
 						<ChatMessages messages={messages} />
 					</div>
-					<div className="sticky bottom-0 bg-background border-border">
-						<div className="max-w-4xl mx-auto">
-							<div className="flex flex-col gap-2 px-4 pb-4">
-								<ChatInput />
-							</div>
-						</div>
-					</div>
+					<ChatComposer
+						showAgentMenu={showAgentMenu}
+						showSandboxStatus={showSandboxStatus}
+					/>
 				</div>
 			) : (
 				<>
@@ -85,13 +88,10 @@ function ChatPanel({ agent, chatNav, showAgentMenu = true }: ChatPanelProps) {
 								<div className="flex-1 min-h-0">
 									<ChatMessages messages={messages} />
 								</div>
-								<div className="sticky bottom-0 bg-background border-border">
-									<div className="max-w-4xl mx-auto">
-										<div className="flex flex-col gap-2 px-4 pb-4">
-											<ChatInput />
-										</div>
-									</div>
-								</div>
+								<ChatComposer
+									showAgentMenu={showAgentMenu}
+									showSandboxStatus={showSandboxStatus}
+								/>
 							</div>
 						</ResizablePanel>
 					</ResizablePanelGroup>
@@ -104,13 +104,10 @@ function ChatPanel({ agent, chatNav, showAgentMenu = true }: ChatPanelProps) {
 							<div className="flex-1 min-h-0">
 								<ChatMessages messages={messages} />
 							</div>
-							<div className="sticky bottom-0 bg-background border-border">
-								<div className="max-w-4xl mx-auto">
-									<div className="flex flex-col gap-2 px-4 pb-4">
-										<ChatInput />
-									</div>
-								</div>
-							</div>
+							<ChatComposer
+								showAgentMenu={showAgentMenu}
+								showSandboxStatus={showSandboxStatus}
+							/>
 						</div>
 
 						{/* Foreground: Editor Sheet - Only on mobile */}

--- a/frontend/src/pages/chat/ChatPanel.tsx
+++ b/frontend/src/pages/chat/ChatPanel.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/resizable";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import FileEditorPanel from "@/components/panels/FileEditorPanel";
-import { useAppContext } from "@/context/AppContext";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -30,7 +29,6 @@ function ChatPanel({
 	showAgentMenu = true,
 	showSandboxStatus = false,
 }: ChatPanelProps) {
-	const { appVersion } = useAppContext();
 	const { messages, viewMode, setViewMode } = useChatContext();
 	const isMobile = useMediaQuery("(max-width: 768px)");
 
@@ -42,13 +40,10 @@ function ChatPanel({
 				<div className="flex-1 flex flex-col items-center justify-center bg-background p-6">
 					<AgentSection agent={agent} showAgentMenu={showAgentMenu} />
 				</div>
-				<footer className="mt-auto bg-card">
-					<div className="px-4 sm:px-6 lg:px-8 py-4">
-						<p className="text-center text-muted-foreground text-xs">
-							&copy; 2025 Ensō Labs. All rights reserved. v{appVersion}
-						</p>
-					</div>
-				</footer>
+				<ChatComposer
+					showAgentMenu={showAgentMenu}
+					showSandboxStatus={showSandboxStatus}
+				/>
 			</ChatLayout>
 		);
 	}

--- a/frontend/src/pages/chat/chat-v2.tsx
+++ b/frontend/src/pages/chat/chat-v2.tsx
@@ -47,6 +47,7 @@ export function ChatV2Page() {
 			<ChatPanel
 				agent={defaultAgent}
 				chatNav={<ChatNav sidebarTrigger={<SidebarTrigger />} />}
+				showSandboxStatus={true}
 			/>
 		</ChatLayout>
 	);

--- a/frontend/src/pages/threads/ThreadPage.test.tsx
+++ b/frontend/src/pages/threads/ThreadPage.test.tsx
@@ -45,8 +45,20 @@ vi.mock("@/components/nav/ChatNav", () => ({
 	ChatNav: () => <div data-testid="chat-nav" />,
 }));
 
-vi.mock("@/components/inputs/ChatInput", () => ({
-	default: () => <div data-testid="chat-input" />,
+vi.mock("@/components/chat/ChatComposer", () => ({
+	default: ({
+		showAgentMenu,
+		showSandboxStatus,
+	}: {
+		showAgentMenu?: boolean;
+		showSandboxStatus?: boolean;
+	}) => (
+		<div
+			data-testid="chat-composer"
+			data-show-agent-menu={String(showAgentMenu)}
+			data-show-sandbox-status={String(showSandboxStatus)}
+		/>
+	),
 }));
 
 vi.mock("@/components/lists/ChatMessages", () => ({
@@ -208,5 +220,18 @@ describe("ThreadPage", () => {
 			screen.queryByText("No checkpoints found for thread"),
 		).not.toBeInTheDocument();
 		expect(screen.getByTestId("chat-messages")).toHaveTextContent("1");
+	});
+
+	it("renders the composer with sandbox status enabled", () => {
+		renderThreadPage("/thread/live-123");
+
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-agent-menu",
+			"true",
+		);
+		expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+			"data-show-sandbox-status",
+			"true",
+		);
 	});
 });

--- a/frontend/src/pages/threads/ThreadPage.tsx
+++ b/frontend/src/pages/threads/ThreadPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import ChatLayout from "@/layouts/chat-layout-v2";
 import { useChatContext } from "@/context/ChatContext";
 import { ChatNav } from "@/components/nav/ChatNav";
-import ChatInput from "@/components/inputs/ChatInput";
+import ChatComposer from "@/components/chat/ChatComposer";
 import ChatMessages from "@/components/lists/ChatMessages";
 import ChatMessagesSkeleton from "@/components/lists/ChatMessagesSkeleton";
 import { useAppContext } from "@/context/AppContext";
@@ -135,13 +135,7 @@ export default function ThreadPage() {
 								<ChatMessages messages={messages} />
 							)}
 						</div>
-						<div className="sticky bottom-0 bg-background border-border">
-							<div className="max-w-4xl mx-auto">
-								<div className="flex flex-col gap-2 px-4 pb-4">
-									<ChatInput showAgentMenu={true} />
-								</div>
-							</div>
-						</div>
+						<ChatComposer showAgentMenu={true} showSandboxStatus={true} />
 					</div>
 				) : (
 					<>
@@ -166,13 +160,7 @@ export default function ThreadPage() {
 											<ChatMessages messages={messages} />
 										)}
 									</div>
-									<div className="sticky bottom-0 bg-background border-border">
-										<div className="max-w-4xl mx-auto">
-											<div className="flex flex-col gap-2 px-4 pb-4">
-												<ChatInput showAgentMenu={true} />
-											</div>
-										</div>
-									</div>
+									<ChatComposer showAgentMenu={true} showSandboxStatus={true} />
 								</div>
 							</ResizablePanel>
 						</ResizablePanelGroup>
@@ -189,13 +177,7 @@ export default function ThreadPage() {
 										<ChatMessages messages={messages} />
 									)}
 								</div>
-								<div className="sticky bottom-0 bg-background border-border">
-									<div className="max-w-4xl mx-auto">
-										<div className="flex flex-col gap-2 px-4 pb-4">
-											<ChatInput showAgentMenu={true} />
-										</div>
-									</div>
-								</div>
+								<ChatComposer showAgentMenu={true} showSandboxStatus={true} />
 							</div>
 
 							{/* Foreground: Editor Sheet - Only on mobile */}


### PR DESCRIPTION
## Summary
- move the sandbox status control above `ChatInput` via a shared composer component
- apply the updated composer layout to thread pages and authenticated `/chat`
- remove sticky footer overlap for these views so messages do not render behind the composer
- add focused tests for the shared composer, `ChatPanel`, thread page wiring, and sandbox status behavior

## Testing
- `npx eslint src/components/chat/ChatComposer.tsx src/components/chat/ChatComposer.test.tsx src/pages/threads/ThreadPage.tsx src/pages/chat/ChatPanel.tsx src/pages/chat/chat-v2.tsx src/pages/threads/ThreadPage.test.tsx src/pages/chat/ChatPanel.test.tsx src/components/status/ThreadSandboxStatus.tsx src/components/status/ThreadSandboxStatus.test.tsx`
- `npx vitest run src/components/chat/ChatComposer.test.tsx src/pages/chat/ChatPanel.test.tsx src/pages/threads/ThreadPage.test.tsx src/components/status/ThreadSandboxStatus.test.tsx`

Refs #843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox selector in chat threads and panel; model picker available from the input area; a new task/files composer header with todo details and file toggle.

* **Improvements**
  * Chat input and controls consolidated for cleaner layout (links repositioned); simplified editor/message rendering; sandbox selection now sends explicit values to the backend to avoid misrouting.

* **Tests**
  * Added tests for composer, sandbox selector, thread/chat panels, and Daytona error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->