### PR TITLE
feat: thread checkpoint history browsing and fork-to-restore

### DIFF
--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -234,6 +234,7 @@ def init_config(
         configurable={
             "user_id": user_id,
             "thread_id": metadata.get("thread_id"),
+            "checkpoint_id": metadata.get("checkpoint_id"),
             "assistant_id": metadata.get("assistant_id", None),
             "project_id": metadata.get("project_id", None),
             "files": params.input.files or {},

--- a/backend/src/controllers/llm.py
+++ b/backend/src/controllers/llm.py
@@ -22,7 +22,6 @@ from src.agents import Orchestra
 from src.repos.user_settings_repo import UserSettingsRepo
 from src.utils.llm import resolve_api_key
 from src.utils.logger import logger
-from src.utils.format import get_time
 from src.constants.llm import DEFAULT_CHAT_MODEL
 
 
@@ -46,23 +45,24 @@ class LLMController:
         )
 
     async def _update_store(self, agent: Orchestra, config: RunnableConfig) -> None:
-        final_state = await agent.graph.aget_state(config)
+        latest_config = RunnableConfig(configurable={"thread_id": config["configurable"].get("thread_id")})
+        final_state = await agent.graph.aget_state(latest_config)
         configurable = {
-            **final_state.config.get("configurable", {}),
             **config["configurable"],
+            **final_state.config.get("configurable", {}),
         }
         messages = final_state.values.get("messages", [])
+        files = final_state.values.get("files")
+        todos = final_state.values.get("todos")
         self.service_context.store.fields = ["messages", "files"]
-        await self.service_context.thread_service.update(
+        await self.service_context.thread_service.update_checkpoint_snapshot(
             thread_id=configurable.get("thread_id"),
-            data={
-                "thread_id": configurable.get("thread_id"),
-                "checkpoint_id": configurable.get("checkpoint_id"),
-                "assistant_id": configurable.get("assistant_id"),
-                "project_id": configurable.get("project_id"),
-                "messages": messages,
-                "updated_at": get_time(),
-            },
+            checkpoint_id=configurable.get("checkpoint_id"),
+            assistant_id=configurable.get("assistant_id"),
+            project_id=configurable.get("project_id"),
+            messages=messages,
+            files=files,
+            todos=todos,
         )
         logger.info(f"checkpoint: {ujson.dumps(configurable)}")
 
@@ -188,9 +188,8 @@ class LLMController:
                 await self._update_store(agent, config)
             raise e
         finally:
-            if self.service_context.user_id and self.service_context.checkpointer:
-                if agent and config:
-                    await self._update_store(agent, config)
+            if self.service_context.user_id and agent and config:
+                await self._update_store(agent, config)
 
     async def llm_stream(self, params: LLMRequest):
         assistant = await self.service_context.llm_service.assistant(params)

--- a/backend/src/repos/thread_repo.py
+++ b/backend/src/repos/thread_repo.py
@@ -40,6 +40,10 @@ class ThreadRepo(BaseRepo):
             messages=item.value.get("messages", []),
             files=item.value.get("files", []),
             todos=item.value.get("todos", []),
+            assistant_id=item.value.get("assistant_id"),
+            project_id=item.value.get("project_id"),
+            head_checkpoint_id=item.value.get("head_checkpoint_id") or item.value.get("checkpoint_id"),
+            checkpoint_count=item.value.get("checkpoint_count"),
             score=getattr(item, "score", None),
             updated_at=getattr(item, "updated_at", None),
         )

--- a/backend/src/routes/v0/thread.py
+++ b/backend/src/routes/v0/thread.py
@@ -1,12 +1,19 @@
 # https://langchain-ai.github.io/langgraph/reference/checkpoints/#langgraph.checkpoint.postgres.BasePostgresSaver
 import uuid
-from fastapi import APIRouter, Body, HTTPException, Depends, status
+from fastapi import APIRouter, Body, HTTPException, Depends, Query, status
 from fastapi.responses import Response, UJSONResponse, StreamingResponse
 from fastapi_cache.decorator import cache
 from langgraph.graph.state import RunnableConfig
 from src.schemas.entities.store import Thread
 from src.contexts.service import ServiceContext
-from src.schemas.entities import SearchFilter, ThreadSemanticSearchRequest
+from src.schemas.entities import (
+    SearchFilter,
+    ThreadSemanticSearchRequest,
+    ThreadCheckpointListResponse,
+    ThreadCheckpointDetailResponse,
+    ForkCheckpointRequest,
+    ForkCheckpointResponse,
+)
 from src.schemas.entities.hitl import (
     InterruptListResponse,
     ResumeRequest,
@@ -31,6 +38,36 @@ from src.utils.stream import stream_from_redis
 router = APIRouter(tags=["Thread"])
 
 
+async def _get_thread_or_404(service_context: ServiceContext, thread_id: str) -> Thread:
+    thread = await service_context.thread_service.get(thread_id)
+    if not thread:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Thread {thread_id} not found")
+    return thread
+
+
+def _build_checkpoint_service(
+    *,
+    user_id: str,
+    store: AsyncPostgresStore,
+    checkpointer,
+    include_graph: bool = False,
+) -> CheckpointService:
+    graph = None
+    if include_graph:
+        graph = init_graph(
+            tools=[],
+            checkpointer=checkpointer,
+            store=store,
+            middleware=[],
+        )
+    return CheckpointService(
+        user_id=user_id,
+        checkpointer=checkpointer,
+        graph=graph,
+        store=store,
+    )
+
+
 @router.post(
     "/threads/search",
     name="Query Threads in Checkpointer",
@@ -47,10 +84,10 @@ async def search_threads(
         async with get_checkpoint_db() as checkpointer:
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
             if "thread_id" in search_filter.filter and "checkpoint_id" not in search_filter.filter:
+                thread = await _get_thread_or_404(service_context, search_filter.filter["thread_id"])
                 checkpoints = await service_context.checkpoint_service.list_checkpoints(
                     thread_id=search_filter.filter["thread_id"]
                 )
-                thread: Thread = await service_context.thread_service.get(search_filter.filter["thread_id"])
                 if thread and len(checkpoints) > 0:
                     checkpoints[0]["metadata"]["files"] = thread.files
                     checkpoints[0]["metadata"]["todos"] = thread.todos
@@ -68,6 +105,18 @@ async def search_threads(
                                 if msg_id and msg_id in agent_name_map and "agent_name" not in msg:
                                     msg["agent_name"] = agent_name_map[msg_id]
                 return {"checkpoints": checkpoints}
+            if "thread_id" in search_filter.filter and "checkpoint_id" in search_filter.filter:
+                await _get_thread_or_404(service_context, search_filter.filter["thread_id"])
+                checkpoint_service = _build_checkpoint_service(
+                    user_id=user.id,
+                    store=store,
+                    checkpointer=checkpointer,
+                )
+                checkpoint = await checkpoint_service.get_checkpoint_detail(
+                    thread_id=search_filter.filter["thread_id"],
+                    checkpoint_id=search_filter.filter["checkpoint_id"],
+                )
+                return {"checkpoint": checkpoint.model_dump() if checkpoint else None}
 
             threads = await service_context.thread_service.search(search_filter)
             return {"threads": threads}
@@ -113,9 +162,8 @@ async def semantic_search_threads(
                     # Fetch thread data to get title
                     thread_data = await service_context.thread_service.get(thread_id)
                     title = "Untitled Thread"
-                    if thread_data and thread_data.value:
-                        # Try to get title from thread data, fallback to first message
-                        title = thread_data.value.get("title", title)
+                    if thread_data:
+                        title = thread_data.title or title
 
                     enriched_results.append(
                         {
@@ -150,6 +198,7 @@ async def create_thread(
     try:
         async with get_checkpoint_db() as checkpointer:
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
+            thread.metadata = thread.metadata or {}
             assistant_id = thread.metadata.get("assistant_id", None)
             if assistant_id:
                 assistant = await service_context.assistant_service.get(assistant_id)
@@ -161,7 +210,6 @@ async def create_thread(
 
             thread.id = str(uuid.uuid4())
             checkpoint = empty_checkpoint()
-            await service_context.thread_service.update(thread.id, thread.model_dump(exclude_none=True))
             saved = await checkpointer.aput(
                 config=RunnableConfig(
                     configurable={
@@ -180,6 +228,18 @@ async def create_thread(
                     assistant_id=thread.metadata.get("assistant_id", None),
                 ),
                 new_versions=ChannelVersions(),
+            )
+            await service_context.thread_service.update(
+                thread.id,
+                {
+                    **thread.model_dump(exclude_none=True),
+                    "thread_id": thread.id,
+                    "assistant_id": assistant_id,
+                    "project_id": thread.metadata.get("project_id", None) if thread.metadata else None,
+                    "checkpoint_id": saved["configurable"].get("checkpoint_id"),
+                    "head_checkpoint_id": saved["configurable"].get("checkpoint_id"),
+                    "checkpoint_count": 1,
+                },
             )
             return saved["configurable"]
     except HTTPException:
@@ -203,13 +263,131 @@ async def get_thread(
     try:
         async with get_checkpoint_db() as checkpointer:
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
-            thread = await service_context.thread_service.get(thread_id)
+            thread = await _get_thread_or_404(service_context, thread_id)
             return {"thread": thread.model_dump(exclude_none=True)}
     except HTTPException:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Thread not found")
+        raise
     except Exception as e:
         logger.exception(f"Error getting thread: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)) from e
+
+
+@router.get(
+    "/threads/{thread_id}/checkpoints",
+    response_model=ThreadCheckpointListResponse,
+    name="List Thread Checkpoints",
+    operation_id="ruska_list_thread_checkpoints",
+    tags=["Thread"],
+)
+async def list_thread_checkpoints(
+    thread_id: str,
+    limit: int = Query(default=20, ge=1, le=100),
+    before: str | None = Query(default=None),
+    user: ProtectedUser = Depends(verify_credentials),
+    store: AsyncPostgresStore = Depends(get_store),
+):
+    try:
+        async with get_checkpoint_db() as checkpointer:
+            service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
+            thread = await _get_thread_or_404(service_context, thread_id)
+            checkpoint_service = _build_checkpoint_service(
+                user_id=user.id,
+                store=store,
+                checkpointer=checkpointer,
+            )
+            checkpoints = await checkpoint_service.list_checkpoint_summaries(
+                thread_id=thread_id,
+                limit=limit,
+                before=before,
+                head_checkpoint_id=thread.head_checkpoint_id,
+            )
+            return ThreadCheckpointListResponse(checkpoints=checkpoints)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error listing checkpoints for thread {thread_id}: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.get(
+    "/threads/{thread_id}/checkpoints/{checkpoint_id}",
+    response_model=ThreadCheckpointDetailResponse,
+    name="Get Thread Checkpoint",
+    operation_id="ruska_get_thread_checkpoint",
+    tags=["Thread"],
+)
+async def get_thread_checkpoint(
+    thread_id: str,
+    checkpoint_id: str,
+    user: ProtectedUser = Depends(verify_credentials),
+    store: AsyncPostgresStore = Depends(get_store),
+):
+    try:
+        async with get_checkpoint_db() as checkpointer:
+            service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
+            await _get_thread_or_404(service_context, thread_id)
+            checkpoint_service = _build_checkpoint_service(
+                user_id=user.id,
+                store=store,
+                checkpointer=checkpointer,
+            )
+            checkpoint = await checkpoint_service.get_checkpoint_detail(
+                thread_id=thread_id,
+                checkpoint_id=checkpoint_id,
+            )
+            if checkpoint is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Checkpoint {checkpoint_id} not found",
+                )
+            return ThreadCheckpointDetailResponse(checkpoint=checkpoint)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error getting checkpoint {checkpoint_id} for thread {thread_id}: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.post(
+    "/threads/{thread_id}/checkpoints/{checkpoint_id}/fork",
+    response_model=ForkCheckpointResponse,
+    name="Fork Thread Checkpoint",
+    operation_id="ruska_fork_thread_checkpoint",
+    tags=["Thread"],
+)
+async def fork_thread_checkpoint(
+    thread_id: str,
+    checkpoint_id: str,
+    request: ForkCheckpointRequest = Body(default=ForkCheckpointRequest()),
+    user: ProtectedUser = Depends(verify_credentials),
+    store: AsyncPostgresStore = Depends(get_store),
+):
+    try:
+        async with get_checkpoint_db() as checkpointer:
+            service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
+            thread = await _get_thread_or_404(service_context, thread_id)
+            checkpoint_service = _build_checkpoint_service(
+                user_id=user.id,
+                store=store,
+                checkpointer=checkpointer,
+                include_graph=True,
+            )
+            return await checkpoint_service.fork_checkpoint(
+                thread_id=thread_id,
+                checkpoint_id=checkpoint_id,
+                user_id=user.id,
+                source_thread=thread,
+                title=request.title,
+            )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        message = str(e)
+        status_code = status.HTTP_404_NOT_FOUND if "not found" in message.lower() else status.HTTP_409_CONFLICT
+        raise HTTPException(status_code=status_code, detail=message)
+    except Exception as e:
+        logger.exception(f"Error forking checkpoint {checkpoint_id} for thread {thread_id}: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
 
 @router.get(
@@ -319,12 +497,10 @@ async def update_thread(
         async with get_checkpoint_db() as checkpointer:
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
             # Get existing thread data
-            existing = await service_context.thread_service.get(thread_id)
-            if not existing:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Thread not found")
+            existing = await _get_thread_or_404(service_context, thread_id)
 
             # Merge updates with existing data
-            updated_data = {**existing.value, **thread.model_dump(exclude_none=True)}
+            updated_data = {**existing.model_dump(exclude_none=True), **thread.model_dump(exclude_none=True)}
             changed_fields = ", ".join(thread.model_dump(exclude_none=True).keys())
             update_message = f"Thread {thread_id} updated with fields: {changed_fields}"
             logger.info(update_message)
@@ -413,26 +589,12 @@ async def get_thread_interrupts(
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
 
             # First, verify the thread exists
-            thread = await service_context.thread_service.get(thread_id)
-            if not thread:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Thread {thread_id} not found",
-                )
-
-            # Create a minimal graph to query interrupt state
-            # The graph needs the checkpointer to access state
-            graph = init_graph(
-                tools=[],
-                checkpointer=checkpointer,
-                store=store,
-            )
-
-            # Create checkpoint service with the graph
-            checkpoint_service = CheckpointService(
+            await _get_thread_or_404(service_context, thread_id)
+            checkpoint_service = _build_checkpoint_service(
                 user_id=user.id,
+                store=store,
                 checkpointer=checkpointer,
-                graph=graph,
+                include_graph=True,
             )
 
             # Get interrupts from the checkpoint state
@@ -475,25 +637,12 @@ async def resume_thread(
             service_context = ServiceContext(user_id=user.id, store=store, checkpointer=checkpointer)
 
             # First, verify the thread exists
-            thread = await service_context.thread_service.get(thread_id)
-            if not thread:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Thread {thread_id} not found",
-                )
-
-            # Create a minimal graph to interact with the thread state
-            graph = init_graph(
-                tools=[],
-                checkpointer=checkpointer,
-                store=store,
-            )
-
-            # Create checkpoint service with the graph
-            checkpoint_service = CheckpointService(
+            await _get_thread_or_404(service_context, thread_id)
+            checkpoint_service = _build_checkpoint_service(
                 user_id=user.id,
+                store=store,
                 checkpointer=checkpointer,
-                graph=graph,
+                include_graph=True,
             )
 
             # Get current interrupts to validate decision_type

--- a/backend/src/schemas/entities/__init__.py
+++ b/backend/src/schemas/entities/__init__.py
@@ -31,6 +31,14 @@ from src.schemas.entities.hitl import (
     ResumeRequest as ResumeRequest,
     ResumeResponse as ResumeResponse,
 )
+from src.schemas.entities.checkpoint import (
+    ThreadCheckpointSummary as ThreadCheckpointSummary,
+    ThreadCheckpointListResponse as ThreadCheckpointListResponse,
+    ThreadCheckpointDetail as ThreadCheckpointDetail,
+    ThreadCheckpointDetailResponse as ThreadCheckpointDetailResponse,
+    ForkCheckpointRequest as ForkCheckpointRequest,
+    ForkCheckpointResponse as ForkCheckpointResponse,
+)
 from src.constants.examples import (
     ADD_DOCUMENTS_EXAMPLE,
     THREAD_HISTORY_EXAMPLE,

--- a/backend/src/schemas/entities/checkpoint.py
+++ b/backend/src/schemas/entities/checkpoint.py
@@ -1,0 +1,51 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ThreadCheckpointSummary(BaseModel):
+    checkpoint_id: str = Field(..., description="Checkpoint identifier")
+    parent_checkpoint_id: Optional[str] = Field(default=None, description="Parent checkpoint identifier")
+    created_at: Optional[str] = Field(default=None, description="Checkpoint creation timestamp")
+    source: Optional[str] = Field(default=None, description="Checkpoint source metadata")
+    message_preview: Optional[str] = Field(default=None, description="Short preview of the checkpoint contents")
+    model: Optional[str] = Field(default=None, description="Model associated with the checkpoint, if available")
+    has_files: bool = Field(default=False, description="Whether the checkpoint contains files")
+    has_todos: bool = Field(default=False, description="Whether the checkpoint contains todos")
+    has_interrupts: bool = Field(default=False, description="Whether the checkpoint has pending interrupts")
+    is_restorable: bool = Field(default=False, description="Whether the checkpoint can be restored by forking")
+    is_head: bool = Field(default=False, description="Whether this checkpoint is the current thread head")
+
+
+class ThreadCheckpointListResponse(BaseModel):
+    checkpoints: list[ThreadCheckpointSummary] = Field(default_factory=list)
+
+
+class ThreadCheckpointDetail(BaseModel):
+    thread_id: str = Field(..., description="Owning thread identifier")
+    checkpoint_id: str = Field(..., description="Checkpoint identifier")
+    parent_checkpoint_id: Optional[str] = Field(default=None, description="Parent checkpoint identifier")
+    created_at: Optional[str] = Field(default=None, description="Checkpoint creation timestamp")
+    source: Optional[str] = Field(default=None, description="Checkpoint source metadata")
+    model: Optional[str] = Field(default=None, description="Model associated with the checkpoint, if available")
+    messages: list[dict[str, Any]] = Field(default_factory=list, description="Normalized checkpoint messages")
+    files: dict[str, Any] = Field(default_factory=dict, description="Checkpoint files")
+    todos: list[Any] = Field(default_factory=list, description="Checkpoint todos")
+    has_interrupts: bool = Field(default=False, description="Whether the checkpoint has pending interrupts")
+    is_restorable: bool = Field(default=False, description="Whether the checkpoint can be restored by forking")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Raw checkpoint metadata")
+
+
+class ThreadCheckpointDetailResponse(BaseModel):
+    checkpoint: ThreadCheckpointDetail
+
+
+class ForkCheckpointRequest(BaseModel):
+    title: Optional[str] = Field(default=None, description="Optional title for the forked thread")
+
+
+class ForkCheckpointResponse(BaseModel):
+    thread_id: str = Field(..., description="New forked thread identifier")
+    head_checkpoint_id: str = Field(..., description="Head checkpoint identifier for the forked thread")
+    source_thread_id: str = Field(..., description="Source thread identifier")
+    source_checkpoint_id: str = Field(..., description="Source checkpoint identifier")

--- a/backend/src/schemas/entities/store.py
+++ b/backend/src/schemas/entities/store.py
@@ -46,4 +46,8 @@ class Thread(BaseEntity):
     messages: list[Union[BaseMessage, dict]] = Field(default_factory=list)
     files: Optional[Any] = None
     todos: Optional[Any] = None
+    assistant_id: Optional[str] = None
+    project_id: Optional[str] = None
+    head_checkpoint_id: Optional[str] = None
+    checkpoint_count: Optional[int] = None
     score: float | None = None

--- a/backend/src/services/checkpoint.py
+++ b/backend/src/services/checkpoint.py
@@ -10,10 +10,14 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.types import StateSnapshot, Command
 from langchain_core.messages import BaseMessage
+from langgraph.store.base import BaseStore
+from uuid import uuid4
 from src.utils.logger import logger
 from src.utils.messages import from_message_to_dict
 from src.utils.retry import retry_db_operation
 from src.services.errors import is_retryable_error, CheckpointConnectionError
+from src.schemas.entities.checkpoint import ThreadCheckpointSummary, ThreadCheckpointDetail, ForkCheckpointResponse
+from src.schemas.entities.store import Thread
 import psycopg
 
 
@@ -32,6 +36,8 @@ from src.schemas.entities.hitl import (
     HumanDecision,
     ResumeResponse,
 )
+from src.services.thread import ThreadService
+from src.utils.format import format_content
 
 
 IN_MEMORY_CHECKPOINTER = InMemorySaver()
@@ -43,10 +49,13 @@ class CheckpointService:
         user_id: str = None,
         checkpointer: BaseCheckpointSaver = None,
         graph: CompiledStateGraph = None,
+        store: BaseStore = None,
     ):
         self.user_id = user_id
         self.checkpointer: BaseCheckpointSaver = checkpointer or IN_MEMORY_CHECKPOINTER
         self.graph = graph
+        self.store = store
+        self.thread_service = ThreadService(user_id=user_id, store=store) if store is not None else None
 
     @staticmethod
     def _collect_messages(checkpoint: CheckpointTuple) -> list[BaseMessage]:
@@ -67,6 +76,254 @@ class CheckpointService:
             messages = channel_values.get("messages", []) or []
 
         return messages if messages else []
+
+    @staticmethod
+    def _extract_value(payload: object, key: str, default: object):
+        if hasattr(payload, key):
+            return getattr(payload, key)
+        if isinstance(payload, dict):
+            return payload.get(key, default)
+        return default
+
+    @staticmethod
+    def _get_channel_value(checkpoint: CheckpointTuple, key: str, default: object):
+        channel_values = checkpoint.checkpoint.get("channel_values", {})
+        if key in channel_values:
+            return channel_values.get(key, default)
+
+        start_value = channel_values.get("__start__")
+        return CheckpointService._extract_value(start_value, key, default)
+
+    @staticmethod
+    def _latest_message_preview(messages: list[dict]) -> str | None:
+        for message in reversed(messages):
+            if message.get("type") in {"tool", "tool_use"}:
+                continue
+            content = format_content(message.get("content", ""))
+            if content:
+                return content[:140]
+        return None
+
+    @staticmethod
+    def _resolve_model(messages: list[dict]) -> str | None:
+        for message in reversed(messages):
+            model = message.get("model")
+            if model:
+                return model
+        return None
+
+    @staticmethod
+    def _checkpoint_id_from_config(config: RunnableConfig | None) -> str | None:
+        if not config:
+            return None
+        return config.get("configurable", {}).get("checkpoint_id")
+
+    async def _get_state_snapshot(self, thread_id: str, checkpoint_id: str | None = None) -> StateSnapshot | None:
+        if self.graph is None:
+            return None
+        config = RunnableConfig(configurable={"thread_id": thread_id, "checkpoint_id": checkpoint_id})
+        try:
+            return await self.graph.aget_state(config)
+        except Exception as e:
+            logger.warning(
+                f"Failed to load state snapshot for thread {thread_id} checkpoint {checkpoint_id or 'latest'}: {e}"
+            )
+            return None
+
+    async def _get_checkpoint_tuple(self, thread_id: str, checkpoint_id: str | None = None) -> CheckpointTuple | None:
+        config = RunnableConfig(configurable={"thread_id": thread_id, "checkpoint_id": checkpoint_id})
+        return await self.checkpointer.aget_tuple(config)
+
+    def _checkpoint_values(self, checkpoint: CheckpointTuple) -> dict:
+        values: dict = {}
+
+        messages = self._collect_messages(checkpoint)
+        if messages:
+            values["messages"] = messages
+
+        files = self._get_channel_value(checkpoint, "files", None)
+        if files is not None:
+            values["files"] = files
+
+        todos = self._get_channel_value(checkpoint, "todos", None)
+        if todos is not None:
+            values["todos"] = todos
+
+        return values
+
+    async def _build_checkpoint_detail(
+        self,
+        thread_id: str,
+        checkpoint: CheckpointTuple,
+        *,
+        state: StateSnapshot | None = None,
+    ) -> ThreadCheckpointDetail:
+        messages = from_message_to_dict(self._collect_messages(checkpoint))
+        state_values = state.values if state is not None else self._checkpoint_values(checkpoint)
+        files = state_values.get("files") or self._get_channel_value(checkpoint, "files", {}) or {}
+        todos = state_values.get("todos") or self._get_channel_value(checkpoint, "todos", []) or []
+        checkpoint_id = self._checkpoint_id_from_config(checkpoint.config) or checkpoint.checkpoint.get("id")
+        parent_checkpoint_id = self._checkpoint_id_from_config(checkpoint.parent_config)
+        has_interrupts = bool(getattr(state, "interrupts", None))
+        is_restorable = self.is_restorable(checkpoint, state=state)
+
+        return ThreadCheckpointDetail(
+            thread_id=thread_id,
+            checkpoint_id=checkpoint_id,
+            parent_checkpoint_id=parent_checkpoint_id,
+            created_at=checkpoint.checkpoint.get("ts"),
+            source=checkpoint.metadata.get("source") if checkpoint.metadata else None,
+            model=self._resolve_model(messages),
+            messages=messages,
+            files=files,
+            todos=todos,
+            has_interrupts=has_interrupts,
+            is_restorable=is_restorable,
+            metadata=dict(checkpoint.metadata or {}),
+        )
+
+    async def list_checkpoint_summaries(
+        self,
+        thread_id: str,
+        limit: int = 20,
+        before: str | None = None,
+        *,
+        head_checkpoint_id: str | None = None,
+    ) -> list[ThreadCheckpointSummary]:
+        before_config = None
+        before_timestamp = None
+        if before:
+            if "T" in before:
+                before_timestamp = before
+            else:
+                before_config = RunnableConfig(configurable={"thread_id": thread_id, "checkpoint_id": before})
+
+        config = RunnableConfig(configurable={"thread_id": thread_id})
+        summaries: list[ThreadCheckpointSummary] = []
+        async for checkpoint in self.checkpointer.alist(config, before=before_config, limit=limit * 3):
+            created_at = checkpoint.checkpoint.get("ts")
+            if before_timestamp and created_at and created_at >= before_timestamp:
+                continue
+
+            checkpoint_id = self._checkpoint_id_from_config(checkpoint.config) or checkpoint.checkpoint.get("id")
+            state = await self._get_state_snapshot(thread_id, checkpoint_id)
+            detail = await self._build_checkpoint_detail(
+                thread_id,
+                checkpoint,
+                state=state,
+            )
+            summaries.append(
+                ThreadCheckpointSummary(
+                    checkpoint_id=detail.checkpoint_id,
+                    parent_checkpoint_id=detail.parent_checkpoint_id,
+                    created_at=detail.created_at,
+                    source=detail.source,
+                    message_preview=self._latest_message_preview(detail.messages),
+                    model=detail.model,
+                    has_files=bool(detail.files),
+                    has_todos=bool(detail.todos),
+                    has_interrupts=detail.has_interrupts,
+                    is_restorable=detail.is_restorable,
+                    is_head=detail.checkpoint_id == head_checkpoint_id,
+                )
+            )
+            if len(summaries) >= limit:
+                break
+
+        return summaries
+
+    async def get_checkpoint_detail(self, thread_id: str, checkpoint_id: str) -> ThreadCheckpointDetail | None:
+        checkpoint = await self._get_checkpoint_tuple(thread_id, checkpoint_id)
+        if checkpoint is None:
+            return None
+        state = await self._get_state_snapshot(thread_id, checkpoint_id)
+        return await self._build_checkpoint_detail(thread_id, checkpoint, state=state)
+
+    def is_restorable(self, checkpoint_tuple: CheckpointTuple, *, state: StateSnapshot | None = None) -> bool:
+        if checkpoint_tuple.pending_writes:
+            return False
+
+        if checkpoint_tuple.checkpoint.get("pending_sends"):
+            return False
+
+        if state is None:
+            return True
+
+        if getattr(state, "interrupts", None):
+            return False
+        if getattr(state, "tasks", None):
+            return False
+        if getattr(state, "next", None):
+            return False
+        return True
+
+    async def fork_checkpoint(
+        self,
+        thread_id: str,
+        checkpoint_id: str,
+        user_id: str,
+        *,
+        source_thread: Thread | None = None,
+        title: str | None = None,
+    ) -> ForkCheckpointResponse:
+        if self.graph is None:
+            raise ValueError("No graph configured for checkpoint fork")
+        if self.thread_service is None:
+            raise ValueError("No thread store configured for checkpoint fork")
+
+        checkpoint_tuple = await self._get_checkpoint_tuple(thread_id, checkpoint_id)
+        if checkpoint_tuple is None:
+            raise ValueError(f"Checkpoint {checkpoint_id} not found")
+
+        source_state = await self._get_state_snapshot(thread_id, checkpoint_id)
+        if not self.is_restorable(checkpoint_tuple, state=source_state):
+            raise ValueError("Checkpoint is not restorable")
+        source_values = source_state.values if source_state is not None else self._checkpoint_values(checkpoint_tuple)
+
+        new_thread_id = str(uuid4())
+        seed_config = await self.graph.aupdate_state(
+            RunnableConfig(
+                configurable={
+                    "thread_id": new_thread_id,
+                    "assistant_id": source_thread.assistant_id if source_thread else None,
+                    "project_id": source_thread.project_id if source_thread else None,
+                }
+            ),
+            source_values,
+        )
+
+        new_head_checkpoint_id = self._checkpoint_id_from_config(seed_config)
+        detail = await self._build_checkpoint_detail(thread_id, checkpoint_tuple, state=source_state)
+        source_metadata = source_thread.metadata if source_thread and source_thread.metadata else {}
+
+        await self.thread_service.update(
+            new_thread_id,
+            {
+                "thread_id": new_thread_id,
+                "title": title or getattr(source_thread, "title", None),
+                "messages": source_values.get("messages", []),
+                "files": detail.files,
+                "todos": detail.todos,
+                "assistant_id": source_thread.assistant_id if source_thread else None,
+                "project_id": source_thread.project_id if source_thread else None,
+                "checkpoint_id": new_head_checkpoint_id,
+                "head_checkpoint_id": new_head_checkpoint_id,
+                "checkpoint_count": 1,
+                "metadata": {
+                    **source_metadata,
+                    "forked_from_thread_id": thread_id,
+                    "forked_from_checkpoint_id": checkpoint_id,
+                    "forked_by_user_id": user_id,
+                },
+            },
+        )
+
+        return ForkCheckpointResponse(
+            thread_id=new_thread_id,
+            head_checkpoint_id=new_head_checkpoint_id,
+            source_thread_id=thread_id,
+            source_checkpoint_id=checkpoint_id,
+        )
 
     async def list_checkpoints_from_graph(self, thread_id: str):
         config = RunnableConfig(configurable={"thread_id": thread_id})

--- a/backend/src/services/schedule.py
+++ b/backend/src/services/schedule.py
@@ -8,11 +8,11 @@ from apscheduler.triggers.interval import IntervalTrigger
 from src.schemas.contexts import ContextSchema
 from src.utils.logger import logger
 import ujson
+from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
 from src.services.db import DB_URI, get_store_in_memory
 from src.schemas.entities.schedule import JobTrigger, Job, Schedule
-from src.utils.format import get_time
 
 jobstores = {"default": SQLAlchemyJobStore(url=DB_URI, tablename="schedules")}
 SCHEDULER = AsyncIOScheduler(jobstores=jobstores)
@@ -127,26 +127,23 @@ async def scheduled_llm_invoke(task_dict: dict, user_id: str, title: str = None)
             raise
         finally:
             if service_context.user_id and service_context.checkpointer:
-                final_state = await agent.graph.aget_state(config)
+                latest_config = RunnableConfig(configurable={"thread_id": config["configurable"].get("thread_id")})
+                final_state = await agent.graph.aget_state(latest_config)
                 configurable = {
-                    **final_state.config.get("configurable", {}),
                     **config["configurable"],
+                    **final_state.config.get("configurable", {}),
                 }
                 messages = final_state.values.get("messages", [])
                 messages[-1].model = agent.model
                 service_context.store.fields = ["messages", "files"]
-                await service_context.thread_service.update(
+                await service_context.thread_service.update_checkpoint_snapshot(
                     thread_id=configurable.get("thread_id"),
-                    data={
-                        "thread_id": configurable.get("thread_id"),
-                        "checkpoint_id": configurable.get("checkpoint_id"),
-                        "assistant_id": configurable.get("assistant_id"),
-                        "project_id": configurable.get("project_id"),
-                        "messages": messages,
-                        "todos": todos_list,
-                        "files": files_map,
-                        "updated_at": get_time(),
-                    },
+                    checkpoint_id=configurable.get("checkpoint_id"),
+                    assistant_id=configurable.get("assistant_id"),
+                    project_id=configurable.get("project_id"),
+                    messages=messages,
+                    todos=todos_list,
+                    files=files_map,
                 )
                 logger.info(f"checkpoint: {ujson.dumps(configurable)}")
 

--- a/backend/src/services/thread.py
+++ b/backend/src/services/thread.py
@@ -5,6 +5,7 @@ from src.schemas.entities import SearchFilter
 from src.constants import TEST_USER_ID
 from src.repos.thread_repo import ThreadRepo
 from src.schemas.entities.store import Thread
+from src.utils.format import get_time
 
 
 class ThreadService:
@@ -28,6 +29,48 @@ class ThreadService:
         return await self.thread_repo.create(thread)
 
     async def update(self, thread_id: str, data: dict):
+        return await self.thread_repo.update(thread_id, data)
+
+    async def update_checkpoint_snapshot(
+        self,
+        thread_id: str,
+        *,
+        messages: list[Any],
+        checkpoint_id: str | None,
+        assistant_id: str | None = None,
+        project_id: str | None = None,
+        files: Any = None,
+        todos: Any = None,
+        title: str | None = None,
+        checkpoint_count: int | None = None,
+    ) -> bool:
+        existing = await self.get(thread_id)
+        existing_data = existing.model_dump(exclude_none=True) if existing else {}
+        existing_count = existing.checkpoint_count if existing else None
+
+        if checkpoint_count is None:
+            checkpoint_count = (existing_count + 1) if existing_count is not None else None
+
+        data = {
+            **existing_data,
+            "thread_id": thread_id,
+            "checkpoint_id": checkpoint_id,
+            "head_checkpoint_id": checkpoint_id,
+            "assistant_id": assistant_id,
+            "project_id": project_id,
+            "messages": messages,
+            "updated_at": get_time(),
+        }
+
+        if title is not None:
+            data["title"] = title
+        if files is not None:
+            data["files"] = files
+        if todos is not None:
+            data["todos"] = todos
+        if checkpoint_count is not None:
+            data["checkpoint_count"] = checkpoint_count
+
         return await self.thread_repo.update(thread_id, data)
 
     async def get(self, thread_id: str) -> Any:

--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -28,7 +28,6 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from src.utils.logger import log_to_file, logger
-from src.utils.format import get_time
 
 # Configurable stream timeout (default 60 seconds)
 STREAM_TIMEOUT_MS = int(os.getenv("STREAM_TIMEOUT_MS", "60000"))
@@ -346,27 +345,24 @@ async def stream_generator(
         finally:
             try:
                 if service_context.user_id and checkpointer and agent:
-                    final_state = await agent.graph.aget_state(config)
+                    latest_config = RunnableConfig(configurable={"thread_id": config["configurable"].get("thread_id")})
+                    final_state = await agent.graph.aget_state(latest_config)
                     configurable = {
-                        **final_state.config.get("configurable", {}),
                         **config["configurable"],
+                        **final_state.config.get("configurable", {}),
                     }
                     messages = final_state.values.get("messages", [])
 
                     # Update the store with the final messages and files
                     service_context.store.fields = ["messages", "files"]
-                    await service_context.thread_service.update(
+                    await service_context.thread_service.update_checkpoint_snapshot(
                         thread_id=configurable.get("thread_id"),
-                        data={
-                            "thread_id": configurable.get("thread_id"),
-                            "checkpoint_id": configurable.get("checkpoint_id"),
-                            "assistant_id": configurable.get("assistant_id"),
-                            "project_id": configurable.get("project_id"),
-                            "messages": messages,
-                            "todos": todos_list,
-                            "files": files_map,
-                            "updated_at": get_time(),
-                        },
+                        checkpoint_id=configurable.get("checkpoint_id"),
+                        assistant_id=configurable.get("assistant_id"),
+                        project_id=configurable.get("project_id"),
+                        messages=messages,
+                        todos=todos_list,
+                        files=files_map,
                     )
                     # Log the update for debugging
                     logger.info(f"checkpoint: {ujson.dumps(configurable)}")

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -17,6 +17,7 @@ When CHECKPOINT_USE_RESILIENT is enabled:
 
 import ujson
 import redis.asyncio as redis
+from langchain_core.runnables import RunnableConfig
 from src.contexts.service import ServiceContext
 from src.schemas.entities import LLMRequest
 from src.workers.broker import broker, REDIS_URL
@@ -206,7 +207,6 @@ async def _execute_agent_stream(
         _create_state_backend,
     )
     from src.utils.stream import handle_multi_mode
-    from src.utils.format import get_time
     from src.utils.logger import logger
     from src.services.errors import CheckpointConnectionError
     from src.services.abort import AbortService
@@ -375,32 +375,29 @@ async def _execute_agent_stream(
     # Update thread state with graceful checkpoint error handling
     if service_context.user_id and checkpointer:
         try:
-            final_state = await agent.graph.aget_state(config)
+            latest_config = RunnableConfig(configurable={"thread_id": config["configurable"].get("thread_id")})
+            final_state = await agent.graph.aget_state(latest_config)
 
             if not final_state or not final_state.values.get("messages"):
                 logger.warning(f"Checkpoint update resulted in empty state for thread {thread_id}")
 
             configurable = {
-                **final_state.config.get("configurable", {}),
                 **config["configurable"],
+                **final_state.config.get("configurable", {}),
             }
             messages = final_state.values.get("messages", [])
             if messages:
                 messages[-1].model = agent.model
 
             service_context.store.fields = ["messages", "files"]
-            await service_context.thread_service.update(
+            await service_context.thread_service.update_checkpoint_snapshot(
                 thread_id=configurable.get("thread_id"),
-                data={
-                    "thread_id": configurable.get("thread_id"),
-                    "checkpoint_id": configurable.get("checkpoint_id"),
-                    "assistant_id": configurable.get("assistant_id"),
-                    "project_id": configurable.get("project_id"),
-                    "messages": messages,
-                    "todos": todos_list,
-                    "files": files_map,
-                    "updated_at": get_time(),
-                },
+                checkpoint_id=configurable.get("checkpoint_id"),
+                assistant_id=configurable.get("assistant_id"),
+                project_id=configurable.get("project_id"),
+                messages=messages,
+                todos=todos_list,
+                files=files_map,
             )
             logger.info(f"checkpoint: {ujson.dumps(configurable)}")
         except CheckpointConnectionError as e:

--- a/backend/tests/unit/routes/test_thread_checkpoints.py
+++ b/backend/tests/unit/routes/test_thread_checkpoints.py
@@ -1,0 +1,137 @@
+"""Unit tests for checkpoint history routes in thread.py."""
+
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException, status
+
+from src.schemas.entities.checkpoint import (
+    ForkCheckpointResponse,
+    ThreadCheckpointSummary,
+)
+from src.schemas.models import ProtectedUser
+
+
+def make_mock_user():
+    return ProtectedUser(
+        id="test-user-123",
+        email="test@example.com",
+        username="testuser",
+        name="Test User",
+        created_at=datetime.now(),
+    )
+
+
+class TestThreadCheckpointRoutes(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.user = make_mock_user()
+        self.store = MagicMock()
+        self.context_manager = MagicMock()
+        self.checkpointer = MagicMock()
+        self.context_manager.__aenter__ = AsyncMock(return_value=self.checkpointer)
+        self.context_manager.__aexit__ = AsyncMock(return_value=None)
+        self.thread = MagicMock()
+        self.thread.head_checkpoint_id = "cp-head"
+
+    async def test_list_thread_checkpoints_returns_summaries(self):
+        from src.routes.v0.thread import list_thread_checkpoints
+
+        summary = ThreadCheckpointSummary(
+            checkpoint_id="cp-head",
+            created_at="2026-03-08T12:00:00Z",
+            has_files=False,
+            has_todos=False,
+            has_interrupts=False,
+            is_restorable=True,
+            is_head=True,
+        )
+
+        with (
+            patch("src.routes.v0.thread.get_checkpoint_db", return_value=self.context_manager),
+            patch("src.routes.v0.thread.ServiceContext") as mock_service_context_cls,
+            patch("src.routes.v0.thread._build_checkpoint_service") as mock_build_checkpoint_service,
+        ):
+            mock_service_context = MagicMock()
+            mock_service_context.thread_service.get = AsyncMock(return_value=self.thread)
+            mock_service_context_cls.return_value = mock_service_context
+
+            checkpoint_service = MagicMock()
+            checkpoint_service.list_checkpoint_summaries = AsyncMock(return_value=[summary])
+            mock_build_checkpoint_service.return_value = checkpoint_service
+
+            result = await list_thread_checkpoints("thread-123", 20, None, self.user, self.store)
+
+            self.assertEqual(len(result.checkpoints), 1)
+            self.assertEqual(result.checkpoints[0].checkpoint_id, "cp-head")
+            checkpoint_service.list_checkpoint_summaries.assert_awaited_once()
+
+    async def test_get_thread_checkpoint_returns_404_when_missing(self):
+        from src.routes.v0.thread import get_thread_checkpoint
+
+        with (
+            patch("src.routes.v0.thread.get_checkpoint_db", return_value=self.context_manager),
+            patch("src.routes.v0.thread.ServiceContext") as mock_service_context_cls,
+            patch("src.routes.v0.thread._build_checkpoint_service") as mock_build_checkpoint_service,
+        ):
+            mock_service_context = MagicMock()
+            mock_service_context.thread_service.get = AsyncMock(return_value=self.thread)
+            mock_service_context_cls.return_value = mock_service_context
+
+            checkpoint_service = MagicMock()
+            checkpoint_service.get_checkpoint_detail = AsyncMock(return_value=None)
+            mock_build_checkpoint_service.return_value = checkpoint_service
+
+            with self.assertRaises(HTTPException) as context:
+                await get_thread_checkpoint("thread-123", "cp-missing", self.user, self.store)
+
+            self.assertEqual(context.exception.status_code, status.HTTP_404_NOT_FOUND)
+
+    async def test_fork_thread_checkpoint_returns_fork_response(self):
+        from src.routes.v0.thread import fork_thread_checkpoint
+
+        fork_response = ForkCheckpointResponse(
+            thread_id="fork-123",
+            head_checkpoint_id="fork-cp-1",
+            source_thread_id="thread-123",
+            source_checkpoint_id="cp-1",
+        )
+
+        with (
+            patch("src.routes.v0.thread.get_checkpoint_db", return_value=self.context_manager),
+            patch("src.routes.v0.thread.ServiceContext") as mock_service_context_cls,
+            patch("src.routes.v0.thread._build_checkpoint_service") as mock_build_checkpoint_service,
+        ):
+            mock_service_context = MagicMock()
+            mock_service_context.thread_service.get = AsyncMock(return_value=self.thread)
+            mock_service_context_cls.return_value = mock_service_context
+
+            checkpoint_service = MagicMock()
+            checkpoint_service.fork_checkpoint = AsyncMock(return_value=fork_response)
+            mock_build_checkpoint_service.return_value = checkpoint_service
+
+            result = await fork_thread_checkpoint("thread-123", "cp-1", MagicMock(title=None), self.user, self.store)
+
+            self.assertEqual(result.thread_id, "fork-123")
+            checkpoint_service.fork_checkpoint.assert_awaited_once()
+
+    async def test_fork_thread_checkpoint_returns_409_for_non_restorable_checkpoint(self):
+        from src.routes.v0.thread import fork_thread_checkpoint
+
+        with (
+            patch("src.routes.v0.thread.get_checkpoint_db", return_value=self.context_manager),
+            patch("src.routes.v0.thread.ServiceContext") as mock_service_context_cls,
+            patch("src.routes.v0.thread._build_checkpoint_service") as mock_build_checkpoint_service,
+        ):
+            mock_service_context = MagicMock()
+            mock_service_context.thread_service.get = AsyncMock(return_value=self.thread)
+            mock_service_context_cls.return_value = mock_service_context
+
+            checkpoint_service = MagicMock()
+            checkpoint_service.fork_checkpoint = AsyncMock(side_effect=ValueError("Checkpoint is not restorable"))
+            mock_build_checkpoint_service.return_value = checkpoint_service
+
+            with self.assertRaises(HTTPException) as context:
+                await fork_thread_checkpoint("thread-123", "cp-1", MagicMock(title=None), self.user, self.store)
+
+            self.assertEqual(context.exception.status_code, status.HTTP_409_CONFLICT)

--- a/backend/tests/unit/services/test_checkpoint_history.py
+++ b/backend/tests/unit/services/test_checkpoint_history.py
@@ -1,0 +1,106 @@
+"""Unit tests for checkpoint history and forking service methods."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langgraph.checkpoint.base import CheckpointTuple
+
+from src.services.checkpoint import CheckpointService
+from src.schemas.entities.store import Thread
+
+
+class TestCheckpointHistory(unittest.IsolatedAsyncioTestCase):
+    def _make_checkpoint_tuple(self, checkpoint_id: str = "cp-1") -> CheckpointTuple:
+        return CheckpointTuple(
+            config={"configurable": {"thread_id": "thread-123", "checkpoint_id": checkpoint_id}},
+            checkpoint={
+                "id": checkpoint_id,
+                "ts": "2026-03-08T12:00:00Z",
+                "channel_values": {
+                    "messages": [{"id": "msg-1", "type": "human", "content": "Hello", "model": "openai:gpt-4.1-mini"}],
+                    "files": {"notes.md": {"content": ["Hello"]}},
+                    "todos": [{"content": "Ship it", "status": "completed"}],
+                },
+                "pending_sends": [],
+            },
+            metadata={"source": "input"},
+            parent_config=None,
+            pending_writes=[],
+        )
+
+    async def test_is_restorable_false_when_interrupts_present(self):
+        service = CheckpointService()
+        checkpoint_tuple = self._make_checkpoint_tuple()
+        state = SimpleNamespace(interrupts=["interrupt"], tasks=[], next=[])
+
+        self.assertFalse(service.is_restorable(checkpoint_tuple, state=state))
+
+    async def test_get_checkpoint_detail_returns_normalized_payload(self):
+        checkpoint_tuple = self._make_checkpoint_tuple()
+        state = SimpleNamespace(
+            values={
+                "files": {"notes.md": {"content": ["Hello"]}},
+                "todos": [{"content": "Ship it", "status": "completed"}],
+            },
+            interrupts=[],
+            tasks=[],
+            next=[],
+        )
+
+        service = CheckpointService(graph=MagicMock())
+        service._get_checkpoint_tuple = AsyncMock(return_value=checkpoint_tuple)
+        service._get_state_snapshot = AsyncMock(return_value=state)
+
+        detail = await service.get_checkpoint_detail("thread-123", "cp-1")
+
+        self.assertEqual(detail.checkpoint_id, "cp-1")
+        self.assertEqual(detail.source, "input")
+        self.assertEqual(detail.messages[0]["content"], "Hello")
+        self.assertTrue(detail.is_restorable)
+        self.assertIn("notes.md", detail.files)
+
+    async def test_fork_checkpoint_creates_new_thread_head(self):
+        checkpoint_tuple = self._make_checkpoint_tuple()
+        state = SimpleNamespace(
+            values={
+                "messages": [{"id": "msg-1", "type": "human", "content": "Hello"}],
+                "files": {"notes.md": {"content": ["Hello"]}},
+                "todos": [{"content": "Ship it", "status": "completed"}],
+            },
+            interrupts=[],
+            tasks=[],
+            next=[],
+        )
+        graph = MagicMock()
+        graph.aupdate_state = AsyncMock(
+            return_value={"configurable": {"thread_id": "fork-123", "checkpoint_id": "fork-cp-1"}}
+        )
+
+        service = CheckpointService(
+            user_id="user-123",
+            graph=graph,
+            store=MagicMock(),
+        )
+        service._get_checkpoint_tuple = AsyncMock(return_value=checkpoint_tuple)
+        service._get_state_snapshot = AsyncMock(return_value=state)
+        service.thread_service.update = AsyncMock(return_value=True)
+
+        with patch("src.services.checkpoint.uuid4", return_value="fork-123"):
+            response = await service.fork_checkpoint(
+                thread_id="thread-123",
+                checkpoint_id="cp-1",
+                user_id="user-123",
+                source_thread=Thread(
+                    id="thread-123",
+                    title="Source thread",
+                    assistant_id="assistant-123",
+                    project_id="project-123",
+                ),
+                title="Forked title",
+            )
+
+        self.assertEqual(response.thread_id, "fork-123")
+        self.assertEqual(response.head_checkpoint_id, "fork-cp-1")
+        graph.aupdate_state.assert_awaited_once()
+        service.thread_service.update.assert_awaited_once()

--- a/backend/tests/unit/services/test_schedule_dispatch.py
+++ b/backend/tests/unit/services/test_schedule_dispatch.py
@@ -91,6 +91,8 @@ async def test_in_process_when_not_distributed(task_dict_with_thread):
         mock_svc_ctx.checkpointer = mock_cp_instance
         mock_svc_ctx.llm_service.assistant = AsyncMock(return_value=mock_params)
         mock_svc_ctx.thread_service.update = AsyncMock()
+        mock_svc_ctx.thread_service.update_checkpoint_snapshot = AsyncMock()
+        mock_svc_ctx.thread_service.get = AsyncMock(return_value=None)
         mock_svc_ctx.store = mock_store_instance
         mock_svc_ctx.store.fields = []
         mock_ctx.return_value = mock_svc_ctx

--- a/backend/tests/unit/workers/test_worker_model_resolution.py
+++ b/backend/tests/unit/workers/test_worker_model_resolution.py
@@ -55,6 +55,8 @@ def _make_service_context(store=None, user_id="user-1"):
     ctx.llm_service.assistant = AsyncMock(side_effect=lambda p: p)
     ctx.memory_service = MagicMock()
     ctx.thread_service.update = AsyncMock()
+    ctx.thread_service.update_checkpoint_snapshot = AsyncMock()
+    ctx.thread_service.get = AsyncMock(return_value=None)
     return ctx
 
 

--- a/frontend/src/components/buttons/ChatSubmitButton.tsx
+++ b/frontend/src/components/buttons/ChatSubmitButton.tsx
@@ -12,6 +12,7 @@ interface ChatSubmitButtonProps {
 	handleSubmit?: (query: string, images: File[]) => void;
 	onRecordingChange?: (isRecording: boolean) => void;
 	recorderControls?: any;
+	disabled?: boolean;
 }
 
 function ChatSubmitButton({
@@ -19,6 +20,7 @@ function ChatSubmitButton({
 	handleSubmit: _handleSubmit,
 	onRecordingChange,
 	recorderControls,
+	disabled = false,
 }: ChatSubmitButtonProps) {
 	// _handleSubmit is kept for backward compatibility but enqueue from context is used instead
 	void _handleSubmit;
@@ -27,6 +29,7 @@ function ChatSubmitButton({
 
 	// Helper to enqueue and clear input
 	const handleEnqueue = () => {
+		if (disabled) return;
 		enqueue(query, images);
 		setQuery("");
 		setImages([]);
@@ -79,7 +82,7 @@ function ChatSubmitButton({
 				event.preventDefault();
 
 				// Only allow recording when query is empty
-				if (query.trim() === "" && images.length === 0) {
+				if (!disabled && query.trim() === "" && images.length === 0) {
 					if (isRecordingInProgress) {
 						handleStopRecording();
 					} else {
@@ -140,6 +143,19 @@ function ChatSubmitButton({
 					</Button>
 				</MainToolTip>
 			</div>
+		);
+	}
+
+	if (disabled) {
+		return (
+			<MainToolTip
+				content="Checkpoint preview is read-only"
+				delayDuration={500}
+			>
+				<Button disabled size="icon" className="w-10 h-10 rounded-full m-1">
+					<ArrowUp className="h-7 w-7" />
+				</Button>
+			</MainToolTip>
 		);
 	}
 

--- a/frontend/src/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/components/chat/ChatComposer.test.tsx
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ChatComposer from "./ChatComposer";
+
+const mockUseChatContext = vi.fn();
+
+vi.mock("@/context/ChatContext", () => ({
+	useChatContext: () => mockUseChatContext(),
+}));
 
 vi.mock("@/components/inputs/ChatInput", () => ({
 	default: () => <div data-testid="chat-input" />,
@@ -12,6 +18,16 @@ vi.mock("@/components/status/ThreadSandboxStatus", () => ({
 }));
 
 describe("ChatComposer", () => {
+	beforeEach(() => {
+		mockUseChatContext.mockReturnValue({
+			viewMode: "chat",
+			setViewMode: vi.fn(),
+			filesMap: new Map(),
+			todos: [],
+			threadViewMode: "latest",
+		});
+	});
+
 	it("renders the sandbox status above the chat input when enabled", () => {
 		render(<ChatComposer showAgentMenu={true} showSandboxStatus={true} />);
 
@@ -33,5 +49,21 @@ describe("ChatComposer", () => {
 			screen.queryByTestId("thread-sandbox-status"),
 		).not.toBeInTheDocument();
 		expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+	});
+
+	it("shows a read-only notice during checkpoint preview", () => {
+		mockUseChatContext.mockReturnValue({
+			viewMode: "chat",
+			setViewMode: vi.fn(),
+			filesMap: new Map(),
+			todos: [],
+			threadViewMode: "checkpoint_preview",
+		});
+
+		render(<ChatComposer showAgentMenu={true} showSandboxStatus={false} />);
+
+		expect(
+			screen.getByText(/Checkpoint preview is read-only/i),
+		).toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -21,7 +21,9 @@ export default function ChatComposer({
 	showAgentMenu = false,
 	showSandboxStatus = false,
 }: ChatComposerProps) {
-	const { viewMode, setViewMode, filesMap, todos } = useChatContext();
+	const { viewMode, setViewMode, filesMap, todos, threadViewMode } =
+		useChatContext();
+	const isCheckpointPreview = threadViewMode === "checkpoint_preview";
 
 	const fileCount = Array.from(filesMap?.values() || []).reduce(
 		(acc: number, files: any) => acc + Object.keys(files || {}).length,
@@ -130,6 +132,12 @@ export default function ChatComposer({
 								</Button>
 							</div>
 						</div>
+					)}
+					{isCheckpointPreview && (
+						<p className="px-1 text-xs text-muted-foreground">
+							Checkpoint preview is read-only. Return to the latest thread or
+							restore this checkpoint as a new thread to continue chatting.
+						</p>
 					)}
 					<ChatInput showAgentMenu={showAgentMenu} />
 				</div>

--- a/frontend/src/components/inputs/ChatInput.tsx
+++ b/frontend/src/components/inputs/ChatInput.tsx
@@ -61,7 +61,9 @@ export default function ChatInput({
 		displayModel,
 		models,
 		setModel,
+		threadViewMode,
 	} = useChatContext();
+	const isCheckpointPreview = threadViewMode === "checkpoint_preview";
 
 	const { isModelVisible } = useModelVisibility();
 	const visibleModels = (models?.models || []).filter((m: string) =>
@@ -81,6 +83,7 @@ export default function ChatInput({
 
 	// Helper to enqueue and clear input
 	const handleEnqueue = (q: string, imgs: File[]) => {
+		if (isCheckpointPreview) return;
 		enqueue(q, imgs);
 		setQuery("");
 		setImages([]);
@@ -138,9 +141,14 @@ export default function ChatInput({
 			<textarea
 				ref={inputRef}
 				className={`w-full resize-none overflow-y-auto min-h-[48px] max-h-[200px] p-4 pr-14 bg-background border border-input ${isRecording ? "rounded-none" : "rounded-t-3xl"} focus:outline-none border-b-0`}
-				placeholder="How can I help you be more productive?"
+				placeholder={
+					isCheckpointPreview
+						? "Checkpoint preview is read-only"
+						: "How can I help you be more productive?"
+				}
 				rows={1}
 				value={query}
+				disabled={isCheckpointPreview}
 				onChange={handleTextareaResize}
 				onPaste={handlePaste}
 				onDrop={handleDrop}
@@ -150,6 +158,7 @@ export default function ChatInput({
 						e.key === "Enter" &&
 						!e.shiftKey &&
 						!isRecording &&
+						!isCheckpointPreview &&
 						query.length > 0
 					) {
 						e.preventDefault();
@@ -185,6 +194,7 @@ export default function ChatInput({
 							<PopoverTrigger asChild>
 								<button
 									title="Change default model"
+									disabled={isCheckpointPreview}
 									className="cursor-pointer hover:opacity-80 transition-opacity"
 								>
 									<ModelBadge model={displayModel} />
@@ -224,6 +234,7 @@ export default function ChatInput({
 						handleSubmit={handleSubmit}
 						onRecordingChange={setIsRecording}
 						recorderControls={recorderControls}
+						disabled={isCheckpointPreview}
 					/>
 				</div>
 			</div>

--- a/frontend/src/components/nav/ChatNav.test.tsx
+++ b/frontend/src/components/nav/ChatNav.test.tsx
@@ -1,20 +1,24 @@
 import "@testing-library/jest-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
 
-// Mock useChatContext
 const mockUseChatContext = vi.fn();
 vi.mock("@/context/ChatContext", () => ({
 	useChatContext: () => mockUseChatContext(),
 }));
 
-// Mock useAgentContext
 const mockUseAgentContext = vi.fn();
 vi.mock("@/context/AgentContext", () => ({
 	useAgentContext: () => mockUseAgentContext(),
 }));
 
-// Mock child components to isolate ChatNav
+const mockForkThreadCheckpoint = vi.fn();
+vi.mock("@/lib/services/threadService", () => ({
+	forkThreadCheckpoint: (...args: any[]) => mockForkThreadCheckpoint(...args),
+}));
+
 vi.mock("@/components/buttons/ColorModeButton", () => ({
 	ColorModeButton: () => <button data-testid="color-mode-button" />,
 }));
@@ -24,13 +28,42 @@ vi.mock("../buttons/NewThreadButton", () => ({
 vi.mock("../buttons/thread-share-button", () => ({
 	default: () => <button data-testid="share-button" />,
 }));
+vi.mock("@/components/dialogs/SaveAsAssistantDialog", () => ({
+	SaveAsAssistantDialog: () => null,
+}));
+vi.mock("@/components/ui/sheet", () => ({
+	Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SheetContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
 
 import { ChatNav } from "./ChatNav";
 
 const defaultContext = {
-	viewMode: "chat" as const,
-	setViewMode: vi.fn(),
-	filesMap: new Map(),
+	metadata: { thread_id: "thread-123" },
+	checkpoints: [
+		{
+			checkpoint_id: "cp-1",
+			created_at: "2026-03-08T12:00:00Z",
+			source: "input",
+			message_preview: "First turn",
+			model: "openai:gpt-4.1-mini",
+			has_files: false,
+			has_todos: false,
+			has_interrupts: false,
+			is_restorable: true,
+			is_head: true,
+		},
+	],
+	checkpointsLoading: false,
+	checkpointsError: null,
+	threadViewMode: "latest" as const,
+	previewCheckpoint: null,
+	activeCheckpointId: "cp-1",
+	currentThread: { head_checkpoint_id: "cp-1" },
 };
 
 describe("ChatNav", () => {
@@ -48,28 +81,63 @@ describe("ChatNav", () => {
 			},
 			handleGetAgents: vi.fn(),
 		});
+		mockForkThreadCheckpoint.mockResolvedValue({
+			thread_id: "fork-123",
+			head_checkpoint_id: "fork-cp-1",
+			source_thread_id: "thread-123",
+			source_checkpoint_id: "cp-0",
+		});
 	});
 
-	it("does not render ModelBadge (moved to ChatInput)", () => {
-		render(<ChatNav />);
-		expect(screen.queryByTestId("model-badge")).not.toBeInTheDocument();
-	});
+	it("renders core nav elements and a history button", () => {
+		render(
+			<MemoryRouter>
+				<ChatNav />
+			</MemoryRouter>,
+		);
 
-	it("does not render SelectModel", () => {
-		render(<ChatNav />);
-		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-	});
-
-	it("does not accept showModelBadge prop (removed)", () => {
-		// ChatNav no longer has showModelBadge prop
-		render(<ChatNav />);
-		expect(screen.queryByTestId("model-badge")).not.toBeInTheDocument();
-	});
-
-	it("renders core nav elements", () => {
-		render(<ChatNav />);
 		expect(screen.getByTestId("color-mode-button")).toBeInTheDocument();
 		expect(screen.getByTestId("new-thread-button")).toBeInTheDocument();
 		expect(screen.getByTestId("share-button")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /history/i }),
+		).toBeInTheDocument();
+	});
+
+	it("shows the preview banner when a checkpoint preview is active", () => {
+		mockUseChatContext.mockReturnValue({
+			...defaultContext,
+			threadViewMode: "checkpoint_preview",
+			previewCheckpoint: {
+				checkpoint_id: "cp-0",
+				created_at: "2026-03-08T11:00:00Z",
+				is_restorable: true,
+			},
+			activeCheckpointId: "cp-0",
+		});
+
+		render(
+			<MemoryRouter>
+				<ChatNav />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText(/Viewing checkpoint from/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /Restore as New Thread/i }),
+		).toBeInTheDocument();
+	});
+
+	it("renders checkpoint history entries when the history sheet opens", () => {
+		render(
+			<MemoryRouter>
+				<ChatNav />
+			</MemoryRouter>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /history/i }));
+
+		expect(screen.getByText("Checkpoint History")).toBeInTheDocument();
+		expect(screen.getByText("First turn")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/nav/ChatNav.tsx
+++ b/frontend/src/components/nav/ChatNav.tsx
@@ -2,12 +2,34 @@ import { ColorModeButton } from "@/components/buttons/ColorModeButton";
 import NewThreadButton from "../buttons/NewThreadButton";
 import ShareButton from "../buttons/thread-share-button";
 import { SaveAsAssistantDialog } from "@/components/dialogs/SaveAsAssistantDialog";
-import { Save } from "lucide-react";
+import { History, Loader2, RotateCcw, Save, Sparkles } from "lucide-react";
 import { useAgentContext } from "@/context/AgentContext";
+import { useChatContext } from "@/context/ChatContext";
 import { Button } from "@/components/ui/button";
 import AgentService from "@/lib/services/agentService";
+import { forkThreadCheckpoint } from "@/lib/services/threadService";
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
 import { toast } from "sonner";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+
+const formatCheckpointTime = (value?: string | null) => {
+	if (!value) return "Unknown time";
+
+	try {
+		return new Intl.DateTimeFormat(undefined, {
+			dateStyle: "medium",
+			timeStyle: "short",
+		}).format(new Date(value));
+	} catch {
+		return value;
+	}
+};
 
 export function ChatNav({
 	sidebarTrigger,
@@ -15,7 +37,28 @@ export function ChatNav({
 	sidebarTrigger?: React.ReactNode | undefined;
 }) {
 	const { agent, handleGetAgents } = useAgentContext();
+	const {
+		metadata,
+		checkpoints,
+		checkpointsLoading,
+		checkpointsError,
+		threadViewMode,
+		previewCheckpoint,
+		activeCheckpointId,
+		currentThread,
+	} = useChatContext();
+	const { agentId, projectId } = useParams();
+	const navigate = useNavigate();
+	const [searchParams, setSearchParams] = useSearchParams();
 	const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+	const [historyOpen, setHistoryOpen] = useState(false);
+	const [isForking, setIsForking] = useState(false);
+	const threadId = metadata?.thread_id;
+
+	const activePreviewLabel = useMemo(
+		() => formatCheckpointTime(previewCheckpoint?.created_at),
+		[previewCheckpoint?.created_at],
+	);
 
 	const handleSaveAsAssistant = async (name: string, description: string) => {
 		try {
@@ -37,36 +80,222 @@ export function ChatNav({
 		}
 	};
 
-	return (
-		<header className="bg-transparent mb-1">
-			<div className="mx-auto px-4 sm:px-6 lg:px-4 pt-4">
-				<div className="flex items-center justify-between">
-					<div className="flex items-center">{sidebarTrigger}</div>
+	const handleSelectCheckpoint = (checkpointId: string) => {
+		const next = new URLSearchParams(searchParams);
+		next.set("checkpointId", checkpointId);
+		setSearchParams(next);
+		setHistoryOpen(false);
+	};
 
-					<div className="flex items-center gap-2">
-						<Button
-							variant="outline"
-							size="icon"
-							className="h-9 w-9"
-							onClick={() => setSaveDialogOpen(true)}
-							aria-label="Save as Assistant"
-							title="Save as Assistant"
-						>
-							<Save className="h-4 w-4" />
-						</Button>
-						<ShareButton />
-						<NewThreadButton />
-						<div className="w-9">
-							<ColorModeButton />
+	const handleBackToLatest = () => {
+		const next = new URLSearchParams(searchParams);
+		next.delete("checkpointId");
+		setSearchParams(next);
+	};
+
+	const handleRestore = async () => {
+		if (!threadId || !previewCheckpoint) return;
+
+		setIsForking(true);
+		try {
+			const fork = await forkThreadCheckpoint(
+				threadId,
+				previewCheckpoint.checkpoint_id,
+			);
+			setHistoryOpen(false);
+
+			if (agentId) {
+				navigate(`/assistant/${agentId}/thread/${fork.thread_id}`);
+			} else if (projectId) {
+				navigate(`/p/${projectId}/t/${fork.thread_id}`);
+			} else {
+				navigate(`/thread/${fork.thread_id}`);
+			}
+		} catch (error: any) {
+			toast.error(error.message || "Failed to restore checkpoint");
+		} finally {
+			setIsForking(false);
+		}
+	};
+
+	return (
+		<>
+			<header className="bg-transparent mb-1">
+				<div className="mx-auto px-4 sm:px-6 lg:px-4 pt-4">
+					<div className="flex items-center justify-between gap-3">
+						<div className="flex items-center">{sidebarTrigger}</div>
+
+						<div className="flex items-center gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-9 gap-2"
+								onClick={() => setHistoryOpen(true)}
+								disabled={!threadId}
+							>
+								<History className="h-4 w-4" />
+								<span className="hidden sm:inline">History</span>
+							</Button>
+							<Button
+								variant="outline"
+								size="icon"
+								className="h-9 w-9"
+								onClick={() => setSaveDialogOpen(true)}
+								aria-label="Save as Assistant"
+								title="Save as Assistant"
+							>
+								<Save className="h-4 w-4" />
+							</Button>
+							<ShareButton />
+							<NewThreadButton />
+							<div className="w-9">
+								<ColorModeButton />
+							</div>
 						</div>
 					</div>
+
+					{threadViewMode === "checkpoint_preview" && previewCheckpoint && (
+						<div className="mt-3 flex flex-col gap-3 rounded-2xl border border-amber-300/60 bg-amber-50/80 px-4 py-3 text-sm text-amber-950 dark:border-amber-700/60 dark:bg-amber-950/30 dark:text-amber-100">
+							<div className="flex items-center gap-2 font-medium">
+								<History className="h-4 w-4" />
+								<span>Viewing checkpoint from {activePreviewLabel}</span>
+							</div>
+							<div className="flex flex-wrap gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									className="gap-2"
+									onClick={handleBackToLatest}
+								>
+									<RotateCcw className="h-4 w-4" />
+									<span>Back to Latest</span>
+								</Button>
+								<Button
+									size="sm"
+									className="gap-2"
+									onClick={handleRestore}
+									disabled={!previewCheckpoint.is_restorable || isForking}
+									title={
+										previewCheckpoint.is_restorable
+											? "Create a new thread from this checkpoint"
+											: "This checkpoint cannot be restored because it is not in a stable state"
+									}
+								>
+									{isForking ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : (
+										<Sparkles className="h-4 w-4" />
+									)}
+									<span>Restore as New Thread</span>
+								</Button>
+							</div>
+						</div>
+					)}
 				</div>
-			</div>
-			<SaveAsAssistantDialog
-				isOpen={saveDialogOpen}
-				onClose={() => setSaveDialogOpen(false)}
-				onSave={handleSaveAsAssistant}
-			/>
-		</header>
+				<SaveAsAssistantDialog
+					isOpen={saveDialogOpen}
+					onClose={() => setSaveDialogOpen(false)}
+					onSave={handleSaveAsAssistant}
+				/>
+			</header>
+
+			<Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
+				<SheetContent side="right" className="w-full sm:max-w-xl">
+					<SheetHeader>
+						<SheetTitle>Checkpoint History</SheetTitle>
+					</SheetHeader>
+					<div className="mt-6 flex h-[calc(100%-3rem)] flex-col gap-3 overflow-hidden">
+						{checkpointsLoading && (
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Loader2 className="h-4 w-4 animate-spin" />
+								<span>Loading checkpoints...</span>
+							</div>
+						)}
+
+						{!checkpointsLoading && checkpointsError && (
+							<p className="text-sm text-destructive">{checkpointsError}</p>
+						)}
+
+						{!checkpointsLoading &&
+							!checkpointsError &&
+							checkpoints.length === 0 && (
+								<p className="text-sm text-muted-foreground">
+									No checkpoints found for this thread.
+								</p>
+							)}
+
+						<div className="flex-1 space-y-3 overflow-y-auto pr-1">
+							{checkpoints.map((item: any) => {
+								const isActive = item.checkpoint_id === activeCheckpointId;
+								const isHead =
+									item.is_head ||
+									item.checkpoint_id === currentThread?.head_checkpoint_id;
+
+								return (
+									<button
+										key={item.checkpoint_id}
+										type="button"
+										onClick={() => handleSelectCheckpoint(item.checkpoint_id)}
+										className={`w-full rounded-2xl border p-4 text-left transition-colors ${
+											isActive
+												? "border-primary bg-primary/5"
+												: "border-border hover:bg-accent/50"
+										}`}
+									>
+										<div className="flex items-start justify-between gap-3">
+											<div>
+												<p className="text-sm font-medium">
+													{formatCheckpointTime(item.created_at)}
+												</p>
+												<p className="mt-1 text-xs text-muted-foreground">
+													{item.source || "checkpoint"}
+												</p>
+											</div>
+											<div className="flex flex-wrap justify-end gap-1">
+												{isHead && (
+													<span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+														Latest
+													</span>
+												)}
+												{item.has_files && (
+													<span className="rounded-full bg-secondary px-2 py-0.5 text-[11px]">
+														Files
+													</span>
+												)}
+												{item.has_todos && (
+													<span className="rounded-full bg-secondary px-2 py-0.5 text-[11px]">
+														Todos
+													</span>
+												)}
+												{item.has_interrupts && (
+													<span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
+														Interrupts
+													</span>
+												)}
+												{!item.is_restorable && (
+													<span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+														Preview Only
+													</span>
+												)}
+											</div>
+										</div>
+										{item.message_preview && (
+											<p className="mt-3 line-clamp-2 text-sm text-foreground/85">
+												{item.message_preview}
+											</p>
+										)}
+										{item.model && (
+											<p className="mt-3 text-xs text-muted-foreground">
+												{item.model}
+											</p>
+										)}
+									</button>
+								);
+							})}
+						</div>
+					</div>
+				</SheetContent>
+			</Sheet>
+		</>
 	);
 }

--- a/frontend/src/hooks/useThread.test.tsx
+++ b/frontend/src/hooks/useThread.test.tsx
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import useThread from "./useThread";
 
 const mockSearchThreads = vi.fn();
+const mockGetThread = vi.fn();
+const mockGetThreadCheckpoint = vi.fn();
 
 vi.mock("@/lib/services/threadService", () => ({
 	searchThreads: (...args: any[]) => mockSearchThreads(...args),
+	getThread: (...args: any[]) => mockGetThread(...args),
+	getThreadCheckpoint: (...args: any[]) => mockGetThreadCheckpoint(...args),
+	listThreadCheckpoints: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/lib/utils/format", () => ({
@@ -34,25 +39,31 @@ type ThreadCallbacks = {
 function UseLoadThreadEffectHarness({
 	threadId,
 	enabled,
+	checkpointId,
 	onStateChange,
 	callbacks,
 }: {
 	threadId: string;
 	enabled: boolean;
+	checkpointId?: string;
 	onStateChange: (state: HookState) => void;
 	callbacks?: ThreadCallbacks;
 }) {
 	const thread = useThread();
-	const threadCallbacks = callbacks || {
+	const defaultCallbacksRef = useRef<ThreadCallbacks>({
 		setCheckpoints: vi.fn(),
 		setMessages: vi.fn(),
 		setMetadata: vi.fn(),
 		setFilesMap: vi.fn(),
 		setTodos: vi.fn(),
 		setModel: vi.fn(),
-	};
+	});
+	const threadCallbacks = callbacks || defaultCallbacksRef.current;
 
-	thread.useLoadThreadEffect(threadId, threadCallbacks, { enabled });
+	thread.useLoadThreadEffect(threadId, threadCallbacks, {
+		enabled,
+		checkpointId,
+	});
 
 	useEffect(() => {
 		onStateChange({
@@ -67,10 +78,14 @@ function UseLoadThreadEffectHarness({
 describe("useThread", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockSearchThreads.mockResolvedValue([]);
 	});
 
 	it("clears stale thread errors and loading state when hydration is disabled", async () => {
-		mockSearchThreads.mockResolvedValueOnce([]);
+		mockGetThread.mockResolvedValueOnce({
+			id: "thread-123",
+			head_checkpoint_id: null,
+		});
 
 		const state: HookState = {
 			threadLoading: false,
@@ -103,12 +118,99 @@ describe("useThread", () => {
 		});
 	});
 
+	it("loads the latest checkpoint when no checkpointId is provided", async () => {
+		mockGetThread.mockResolvedValueOnce({
+			id: "thread-123",
+			head_checkpoint_id: "cp-head",
+			assistant_id: "assistant-123",
+		});
+		mockGetThreadCheckpoint.mockResolvedValueOnce({
+			thread_id: "thread-123",
+			checkpoint_id: "cp-head",
+			messages: [{ id: "msg-1", role: "user", content: "Hello" }],
+			files: {},
+			todos: [],
+			metadata: {},
+		});
+
+		const callbacks: ThreadCallbacks = {
+			setCheckpoints: vi.fn(),
+			setMessages: vi.fn(),
+			setMetadata: vi.fn(),
+			setFilesMap: vi.fn(),
+			setTodos: vi.fn(),
+			setModel: vi.fn(),
+		};
+
+		render(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={true}
+				callbacks={callbacks}
+				onStateChange={() => undefined}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(mockGetThreadCheckpoint).toHaveBeenCalledWith(
+				"thread-123",
+				"cp-head",
+			);
+			expect(callbacks.setMetadata).toHaveBeenCalledWith(
+				expect.objectContaining({
+					thread_id: "thread-123",
+					checkpoint_id: "cp-head",
+					head_checkpoint_id: "cp-head",
+				}),
+			);
+		});
+	});
+
+	it("loads checkpoint preview when checkpointId is present", async () => {
+		mockGetThread.mockResolvedValueOnce({
+			id: "thread-123",
+			head_checkpoint_id: "cp-head",
+		});
+		mockGetThreadCheckpoint.mockResolvedValueOnce({
+			thread_id: "thread-123",
+			checkpoint_id: "cp-old",
+			messages: [{ id: "msg-1", role: "user", content: "Hello" }],
+			files: {},
+			todos: [],
+			metadata: {},
+		});
+
+		render(
+			<UseLoadThreadEffectHarness
+				threadId="thread-123"
+				enabled={true}
+				checkpointId="cp-old"
+				onStateChange={() => undefined}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(mockGetThreadCheckpoint).toHaveBeenCalledWith(
+				"thread-123",
+				"cp-old",
+			);
+		});
+	});
+
 	it("does not apply late thread hydration after the effect is disabled", async () => {
-		let resolveSearch: (value: any[]) => void = () => undefined;
-		mockSearchThreads.mockImplementationOnce(
+		let resolveThread: (value: any) => void = () => undefined;
+		let resolveCheckpoint: (value: any) => void = () => undefined;
+
+		mockGetThread.mockImplementationOnce(
 			() =>
-				new Promise<any[]>((resolve) => {
-					resolveSearch = resolve;
+				new Promise((resolve) => {
+					resolveThread = resolve;
+				}),
+		);
+		mockGetThreadCheckpoint.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveCheckpoint = resolve;
 				}),
 		);
 
@@ -140,18 +242,18 @@ describe("useThread", () => {
 		);
 
 		await act(async () => {
-			resolveSearch([
-				{
-					metadata: {
-						thread_id: "thread-123",
-						files: {},
-						todos: [],
-					},
-					values: {
-						messages: [{ id: "msg-1", role: "user", content: "Hello" }],
-					},
-				},
-			]);
+			resolveThread({
+				id: "thread-123",
+				head_checkpoint_id: "cp-head",
+			});
+			resolveCheckpoint({
+				thread_id: "thread-123",
+				checkpoint_id: "cp-head",
+				messages: [{ id: "msg-1", role: "user", content: "Hello" }],
+				files: {},
+				todos: [],
+				metadata: {},
+			});
 			await Promise.resolve();
 		});
 

--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -1,46 +1,76 @@
-import { useEffect, useState, useCallback } from "react";
-import { searchThreads } from "@/lib/services/threadService";
+import { useEffect, useState, useCallback, useRef } from "react";
+import {
+	searchThreads,
+	getThread,
+	listThreadCheckpoints,
+	getThreadCheckpoint,
+} from "@/lib/services/threadService";
 import { formatMessages } from "@/lib/utils/format";
 import { latestHumanMessage } from "@/lib/utils/message";
 import type { Todo } from "@/components/lists/TodoList";
+import type {
+	ThreadCheckpointDetail,
+	ThreadCheckpointSummary,
+	ThreadRecord,
+	ThreadViewMode,
+} from "@/lib/entities";
 
 const LIMIT = 20;
 
 export type ThreadData = {
-	checkpoints: any[];
+	thread: ThreadRecord;
+	checkpoints: ThreadCheckpointSummary[];
 	messages: any[];
 	metadata: any;
 	todos: Todo[];
 	filesMap: Map<string, any>;
 	model: string;
+	threadViewMode: ThreadViewMode;
+	activeCheckpointId: string | null;
+	checkpointDetail: ThreadCheckpointDetail;
 };
 
 export type ThreadContextType = {
 	threads: any[];
 	setThreads: (threads: any[]) => void;
-	checkpoints: any[];
-	setCheckpoints: (checkpoints: any[]) => void;
-	checkpoint: any;
-	setCheckpoint: (checkpoint: any) => void;
+	checkpoints: ThreadCheckpointSummary[];
+	setCheckpoints: (checkpoints: ThreadCheckpointSummary[]) => void;
+	checkpoint: ThreadCheckpointDetail | null;
+	setCheckpoint: (checkpoint: ThreadCheckpointDetail | null) => void;
 	searchThreads: (
 		action: "list_threads" | "list_checkpoints" | "get_checkpoint",
 		metadata: { thread_id?: string; checkpoint_id?: string },
 	) => void;
-	useListThreadsEffect: (trigger?: boolean) => void;
-	useListCheckpointsEffect: (
-		trigger?: boolean,
-		metadata?: { thread_id?: string },
-	) => void;
+	useListThreadsEffect: (trigger?: boolean, filter?: any) => void;
+	useListCheckpointsEffect: (trigger?: boolean, threadId?: string) => void;
 	loadMoreThreads: (filter?: any) => Promise<void>;
 	hasMoreThreads: boolean;
 	isLoadingMoreThreads: boolean;
-	loadThread: (threadId: string) => Promise<ThreadData | null>;
+	loadThread: (
+		threadId: string,
+		checkpointId?: string,
+	) => Promise<ThreadData | null>;
+	loadLatestThread: (threadId: string) => Promise<ThreadData | null>;
+	loadCheckpointPreview: (
+		threadId: string,
+		checkpointId: string,
+	) => Promise<ThreadData | null>;
 	threadLoading: boolean;
 	threadError: string | null;
+	checkpointsLoading: boolean;
+	checkpointsError: string | null;
+	threadViewMode: ThreadViewMode;
+	setThreadViewMode: (mode: ThreadViewMode) => void;
+	activeCheckpointId: string | null;
+	setActiveCheckpointId: (checkpointId: string | null) => void;
+	previewCheckpoint: ThreadCheckpointDetail | null;
+	setPreviewCheckpoint: (checkpoint: ThreadCheckpointDetail | null) => void;
+	currentThread: ThreadRecord | null;
+	setCurrentThread: (thread: ThreadRecord | null) => void;
 	useLoadThreadEffect: (
 		threadId: string | undefined,
 		callbacks: {
-			setCheckpoints: (checkpoints: any[]) => void;
+			setCheckpoints: (checkpoints: ThreadCheckpointSummary[]) => void;
 			setMessages: (messages: any[]) => void;
 			setMetadata: (metadata: any) => void;
 			setFilesMap: (filesMap: Map<string, any>) => void;
@@ -49,86 +79,115 @@ export type ThreadContextType = {
 		},
 		options?: {
 			enabled?: boolean;
+			checkpointId?: string;
 		},
 	) => void;
 };
 
+const buildFilesMap = (
+	checkpointDetail: ThreadCheckpointDetail,
+	messages: any[],
+): Map<string, any> => {
+	const filesMap = new Map<string, any>();
+	if (
+		!checkpointDetail.files ||
+		Object.keys(checkpointDetail.files).length === 0
+	) {
+		return filesMap;
+	}
+
+	const latestAiMessage = messages
+		.slice()
+		.reverse()
+		.find((msg: any) => ["ai", "assistant"].includes(msg.role));
+
+	filesMap.set(
+		latestAiMessage?.id || checkpointDetail.checkpoint_id,
+		checkpointDetail.files,
+	);
+	return filesMap;
+};
+
 export default function useThread(): ThreadContextType {
 	const [threads, setThreads] = useState<any[]>([]);
-	const [checkpoints, setCheckpoints] = useState<any[]>([]);
-	const [checkpoint, setCheckpoint] = useState<any>(null);
+	const [checkpoints, setCheckpoints] = useState<ThreadCheckpointSummary[]>([]);
+	const [checkpoint, setCheckpoint] = useState<ThreadCheckpointDetail | null>(
+		null,
+	);
 	const [cursor, setCursor] = useState<string | null>(null);
 	const [hasMoreThreads, setHasMoreThreads] = useState<boolean>(true);
 	const [isLoadingMoreThreads, setIsLoadingMoreThreads] =
 		useState<boolean>(false);
 	const [threadLoading, setThreadLoading] = useState<boolean>(false);
 	const [threadError, setThreadError] = useState<string | null>(null);
+	const [checkpointsLoading, setCheckpointsLoading] = useState<boolean>(false);
+	const [checkpointsError, setCheckpointsError] = useState<string | null>(null);
+	const [threadViewMode, setThreadViewMode] =
+		useState<ThreadViewMode>("latest");
+	const [activeCheckpointId, setActiveCheckpointId] = useState<string | null>(
+		null,
+	);
+	const [previewCheckpoint, setPreviewCheckpoint] =
+		useState<ThreadCheckpointDetail | null>(null);
+	const [currentThread, setCurrentThread] = useState<ThreadRecord | null>(null);
 
-	useEffect(() => {
-		console.log(
-			checkpoints?.filter(
-				(checkpoint: any) => checkpoint.metadata.source === "input",
-			),
-		);
-	}, [checkpoints]);
-
-	const loadThread = useCallback(
-		async (threadId: string): Promise<ThreadData | null> => {
+	const hydrateThread = useCallback(
+		async (
+			threadId: string,
+			checkpointId?: string,
+		): Promise<ThreadData | null> => {
 			if (!threadId) return null;
 
 			setThreadLoading(true);
 			setThreadError(null);
 
 			try {
-				// Load checkpoints directly for this specific thread
-				// Backend returns checkpoints when thread_id is passed
-				const checkpointsData = await searchThreads("list_checkpoints", {
-					thread_id: threadId,
-				});
+				const thread = await getThread(threadId);
+				const targetCheckpointId = checkpointId || thread.head_checkpoint_id;
 
-				if (!checkpointsData || checkpointsData.length === 0) {
+				if (!targetCheckpointId) {
 					setThreadError("No checkpoints found for thread");
 					return null;
 				}
 
-				// Get thread data from the first checkpoint
-				const latestCheckpoint = checkpointsData[0];
-				const threadData = latestCheckpoint.metadata || {};
-
-				// Extract todos (backend sends as array)
-				const todos: Todo[] = Array.isArray(threadData.todos)
-					? threadData.todos
+				const checkpointDetail = await getThreadCheckpoint(
+					threadId,
+					targetCheckpointId,
+				);
+				const messages = formatMessages(checkpointDetail.messages);
+				const todos: Todo[] = Array.isArray(checkpointDetail.todos)
+					? checkpointDetail.todos
 					: [];
+				const metadata = {
+					...thread,
+					...checkpointDetail.metadata,
+					thread_id: threadId,
+					checkpoint_id: checkpointDetail.checkpoint_id,
+					head_checkpoint_id: thread.head_checkpoint_id,
+				};
+				const resolvedViewMode: ThreadViewMode = checkpointId
+					? "checkpoint_preview"
+					: "latest";
 
-				// Build filesMap
-				const filesMap = new Map<string, any>();
-				if (threadData.files && Object.keys(threadData.files).length > 0) {
-					const formattedMsgs = formatMessages(
-						checkpointsData[0].values.messages,
-					);
-					const latestAiMessage = formattedMsgs
-						.slice()
-						.reverse()
-						.find((msg: any) => ["ai", "assistant"].includes(msg.role));
-
-					if (latestAiMessage) {
-						filesMap.set(latestAiMessage.id, threadData.files);
-					}
-				}
-
-				// Format messages
-				const messages = formatMessages(checkpointsData[0].values.messages);
-
-				// Build metadata including thread_id
-				const metadata = { ...threadData, thread_id: threadId };
+				setCurrentThread(thread);
+				setCheckpoint(checkpointDetail);
+				setActiveCheckpointId(checkpointDetail.checkpoint_id);
+				setThreadViewMode(resolvedViewMode);
+				setPreviewCheckpoint(
+					resolvedViewMode === "checkpoint_preview" ? checkpointDetail : null,
+				);
 
 				return {
-					checkpoints: checkpointsData,
+					thread,
+					checkpoints,
 					messages,
 					metadata,
 					todos,
-					filesMap,
+					filesMap: buildFilesMap(checkpointDetail, messages),
 					model: latestHumanMessage(messages)?.model,
+					threadViewMode: resolvedViewMode,
+					activeCheckpointId: checkpointDetail.checkpoint_id,
+					checkpointDetail,
 				};
 			} catch (err) {
 				console.error("Failed to load thread:", err);
@@ -138,13 +197,40 @@ export default function useThread(): ThreadContextType {
 				setThreadLoading(false);
 			}
 		},
-		[],
+		[checkpoints],
+	);
+
+	const loadLatestThread = useCallback(
+		async (threadId: string): Promise<ThreadData | null> =>
+			hydrateThread(threadId),
+		[hydrateThread],
+	);
+
+	const loadCheckpointPreview = useCallback(
+		async (
+			threadId: string,
+			checkpointId: string,
+		): Promise<ThreadData | null> => hydrateThread(threadId, checkpointId),
+		[hydrateThread],
+	);
+
+	const loadThread = useCallback(
+		async (
+			threadId: string,
+			checkpointId?: string,
+		): Promise<ThreadData | null> => {
+			if (checkpointId) {
+				return loadCheckpointPreview(threadId, checkpointId);
+			}
+			return loadLatestThread(threadId);
+		},
+		[loadCheckpointPreview, loadLatestThread],
 	);
 
 	const useLoadThreadEffect = (
 		threadId: string | undefined,
 		callbacks: {
-			setCheckpoints: (checkpoints: any[]) => void;
+			setCheckpoints: (checkpoints: ThreadCheckpointSummary[]) => void;
 			setMessages: (messages: any[]) => void;
 			setMetadata: (metadata: any) => void;
 			setFilesMap: (filesMap: Map<string, any>) => void;
@@ -153,9 +239,16 @@ export default function useThread(): ThreadContextType {
 		},
 		options: {
 			enabled?: boolean;
+			checkpointId?: string;
 		} = {},
 	) => {
 		const enabled = options.enabled ?? true;
+		const checkpointId = options.checkpointId;
+		const callbacksRef = useRef(callbacks);
+
+		useEffect(() => {
+			callbacksRef.current = callbacks;
+		}, [callbacks]);
 
 		useEffect(() => {
 			if (!enabled) {
@@ -169,20 +262,17 @@ export default function useThread(): ThreadContextType {
 			const fetchThread = async () => {
 				if (!threadId) return;
 
-				const data = await loadThread(threadId);
+				const data = await loadThread(threadId, checkpointId);
 				if (!isActive || !data) {
 					return;
 				}
 
-				if (data) {
-					callbacks.setCheckpoints(data.checkpoints);
-					callbacks.setMessages(data.messages);
-					callbacks.setMetadata(data.metadata);
-					callbacks.setFilesMap(data.filesMap);
-					// Always set todos to clear stale data when switching threads
-					callbacks.setTodos(data.todos);
-					callbacks.setModel(data.model);
-				}
+				callbacksRef.current.setCheckpoints(data.checkpoints);
+				callbacksRef.current.setMessages(data.messages);
+				callbacksRef.current.setMetadata(data.metadata);
+				callbacksRef.current.setFilesMap(data.filesMap);
+				callbacksRef.current.setTodos(data.todos);
+				callbacksRef.current.setModel(data.model);
 			};
 
 			fetchThread();
@@ -190,7 +280,7 @@ export default function useThread(): ThreadContextType {
 			return () => {
 				isActive = false;
 			};
-		}, [threadId, enabled]);
+		}, [threadId, enabled, checkpointId, loadThread]);
 	};
 
 	const fetchThreads = async (
@@ -201,17 +291,14 @@ export default function useThread(): ThreadContextType {
 			metadata?: { assistant_id?: string; project_id?: string };
 		} = {},
 	) => {
-		// Always pass limit and offset (defaults: 20, 0) to searchThreads
 		const data = await searchThreads(action, filter, LIMIT, 0);
 
 		if (action === "list_threads") {
 			setThreads(data);
-			// Extract cursor from last thread for pagination
 			if (data.length > 0) {
 				const lastThread = data[data.length - 1];
 				setCursor(lastThread.updated_at);
 			}
-			// Set hasMore based on whether we got a full page
 			setHasMoreThreads(data.length === LIMIT);
 		} else if (action === "list_checkpoints") {
 			setCheckpoints(data);
@@ -228,14 +315,11 @@ export default function useThread(): ThreadContextType {
 		try {
 			setIsLoadingMoreThreads(true);
 
-			// Build filter with cursor for pagination
 			const paginationFilter = { ...filter };
 			if (cursor) {
-				// Use cursor-based pagination: fetch threads older than cursor
 				paginationFilter.updated_at = { $lt: cursor };
 			}
 
-			// Fetch threads with limit (offset=0 since we use cursor-based pagination)
 			const newThreads = await searchThreads(
 				"list_threads",
 				paginationFilter,
@@ -245,7 +329,6 @@ export default function useThread(): ThreadContextType {
 
 			setThreads((prev) => [...prev, ...newThreads]);
 
-			// Extract cursor from last thread for next page
 			if (newThreads.length > 0) {
 				const lastThread = newThreads[newThreads.length - 1];
 				setCursor(lastThread.updated_at);
@@ -264,22 +347,42 @@ export default function useThread(): ThreadContextType {
 		filter: { metadata?: { [key: string]: any } } = {},
 	) => {
 		useEffect(() => {
-			// Reset pagination state for fresh load
+			if (trigger === false) return;
 			setCursor(null);
 			setHasMoreThreads(true);
-			// Don't clear threads immediately - let fetchThreads replace them
-			// This prevents breaking checkpoint fetching that may run concurrently
 			fetchThreads("list_threads", filter);
 		}, [trigger]);
 	};
 
-	const useListCheckpointsEffect = (
-		trigger?: boolean,
-		metadata: { thread_id?: string } = {},
-	) => {
+	const useListCheckpointsEffect = (trigger?: boolean, threadId?: string) => {
 		useEffect(() => {
-			fetchThreads("list_checkpoints", metadata);
-		}, [trigger]);
+			if (trigger === false || !threadId) {
+				return;
+			}
+
+			let isActive = true;
+			setCheckpointsLoading(true);
+			setCheckpointsError(null);
+
+			listThreadCheckpoints(threadId, { limit: LIMIT })
+				.then((items) => {
+					if (!isActive) return;
+					setCheckpoints(items);
+				})
+				.catch((error) => {
+					console.error("Failed to load checkpoints:", error);
+					if (!isActive) return;
+					setCheckpointsError("Failed to load checkpoints");
+				})
+				.finally(() => {
+					if (!isActive) return;
+					setCheckpointsLoading(false);
+				});
+
+			return () => {
+				isActive = false;
+			};
+		}, [trigger, threadId]);
 	};
 
 	return {
@@ -296,8 +399,20 @@ export default function useThread(): ThreadContextType {
 		hasMoreThreads,
 		isLoadingMoreThreads,
 		loadThread,
+		loadLatestThread,
+		loadCheckpointPreview,
 		threadLoading,
 		threadError,
+		checkpointsLoading,
+		checkpointsError,
+		threadViewMode,
+		setThreadViewMode,
+		activeCheckpointId,
+		setActiveCheckpointId,
+		previewCheckpoint,
+		setPreviewCheckpoint,
+		currentThread,
+		setCurrentThread,
 		useLoadThreadEffect,
 	};
 }

--- a/frontend/src/lib/entities/thread.ts
+++ b/frontend/src/lib/entities/thread.ts
@@ -6,6 +6,58 @@ export interface ThreadSearchResult {
 	updated_at: string | null;
 }
 
+export interface ThreadRecord {
+	id: string;
+	title?: string | null;
+	messages: any[];
+	files?: Record<string, any> | null;
+	todos?: any[] | null;
+	assistant_id?: string | null;
+	project_id?: string | null;
+	head_checkpoint_id?: string | null;
+	checkpoint_count?: number | null;
+	updated_at?: string | null;
+	created_at?: string | null;
+}
+
+export interface ThreadCheckpointSummary {
+	checkpoint_id: string;
+	parent_checkpoint_id?: string | null;
+	created_at?: string | null;
+	source?: string | null;
+	message_preview?: string | null;
+	model?: string | null;
+	has_files: boolean;
+	has_todos: boolean;
+	has_interrupts: boolean;
+	is_restorable: boolean;
+	is_head: boolean;
+}
+
+export interface ThreadCheckpointDetail {
+	thread_id: string;
+	checkpoint_id: string;
+	parent_checkpoint_id?: string | null;
+	created_at?: string | null;
+	source?: string | null;
+	model?: string | null;
+	messages: any[];
+	files: Record<string, any>;
+	todos: any[];
+	has_interrupts: boolean;
+	is_restorable: boolean;
+	metadata: Record<string, any>;
+}
+
+export interface ForkCheckpointResponse {
+	thread_id: string;
+	head_checkpoint_id: string;
+	source_thread_id: string;
+	source_checkpoint_id: string;
+}
+
+export type ThreadViewMode = "latest" | "checkpoint_preview";
+
 export interface ThreadSearchRequest {
 	query: string;
 	limit?: number;

--- a/frontend/src/lib/services/threadService.ts
+++ b/frontend/src/lib/services/threadService.ts
@@ -1,6 +1,10 @@
 import apiClient from "@/lib/utils/apiClient";
 import {
 	SemanticThread,
+	ThreadRecord,
+	ThreadCheckpointSummary,
+	ThreadCheckpointDetail,
+	ForkCheckpointResponse,
 	ThreadPayload,
 	ThreadSearchRequest,
 } from "@/lib/entities";
@@ -44,6 +48,67 @@ export const findThread = async (threadId: string) => {
 	} catch (error: any) {
 		console.error("Error finding thread:", error);
 		throw new Error(error.response?.data?.detail || "Failed to find thread");
+	}
+};
+
+export const getThread = async (threadId: string): Promise<ThreadRecord> => {
+	try {
+		const response = await apiClient.get(`/threads/${threadId}`);
+		return response.data.thread;
+	} catch (error: any) {
+		console.error("Error getting thread:", error);
+		throw new Error(error.response?.data?.detail || "Failed to get thread");
+	}
+};
+
+export const listThreadCheckpoints = async (
+	threadId: string,
+	params: { limit?: number; before?: string } = {},
+): Promise<ThreadCheckpointSummary[]> => {
+	try {
+		const response = await apiClient.get(`/threads/${threadId}/checkpoints`, {
+			params,
+		});
+		return response.data.checkpoints || [];
+	} catch (error: any) {
+		console.error("Error listing checkpoints:", error);
+		throw new Error(
+			error.response?.data?.detail || "Failed to list checkpoints",
+		);
+	}
+};
+
+export const getThreadCheckpoint = async (
+	threadId: string,
+	checkpointId: string,
+): Promise<ThreadCheckpointDetail> => {
+	try {
+		const response = await apiClient.get(
+			`/threads/${threadId}/checkpoints/${checkpointId}`,
+		);
+		return response.data.checkpoint;
+	} catch (error: any) {
+		console.error("Error getting checkpoint:", error);
+		throw new Error(error.response?.data?.detail || "Failed to get checkpoint");
+	}
+};
+
+export const forkThreadCheckpoint = async (
+	threadId: string,
+	checkpointId: string,
+	payload: { title?: string } = {},
+): Promise<ForkCheckpointResponse> => {
+	try {
+		const response = await apiClient.post(
+			`/threads/${threadId}/checkpoints/${checkpointId}/fork`,
+			payload,
+		);
+		return response.data;
+	} catch (error: any) {
+		console.error("Error forking checkpoint:", error);
+		throw new Error(
+			error.response?.data?.detail || "Failed to restore checkpoint",
+		);
 	}
 };
 
@@ -217,6 +282,13 @@ export const searchThreads = async (
 	limit: number = 20,
 	offset: number = 0,
 ) => {
+	if (action === "list_checkpoints" && filter.thread_id) {
+		return listThreadCheckpoints(filter.thread_id, { limit });
+	}
+	if (action === "get_checkpoint" && filter.thread_id && filter.checkpoint_id) {
+		return getThreadCheckpoint(filter.thread_id, filter.checkpoint_id);
+	}
+
 	let payload;
 	if (action === "list_threads") {
 		payload = {
@@ -224,21 +296,8 @@ export const searchThreads = async (
 			offset: offset,
 			filter: filter,
 		};
-	} else if (action === "list_checkpoints") {
-		payload = {
-			limit: limit,
-			offset: offset,
-			filter: { thread_id: filter.thread_id },
-		};
-	} else if (action === "get_checkpoint") {
-		payload = {
-			limit: limit,
-			offset: offset,
-			filter: {
-				thread_id: filter.thread_id,
-				checkpoint_id: filter.checkpoint_id,
-			},
-		};
+	} else {
+		throw new Error(`Unsupported search action: ${action}`);
 	}
 	const response = await apiClient.post(`/threads/search`, payload, {
 		headers: {
@@ -249,10 +308,6 @@ export const searchThreads = async (
 
 	if (action === "list_threads") {
 		return data.threads;
-	} else if (action === "list_checkpoints") {
-		return data.checkpoints;
-	} else if (action === "get_checkpoint") {
-		return data.checkpoint;
 	}
 };
 

--- a/frontend/src/pages/agents/thread.tsx
+++ b/frontend/src/pages/agents/thread.tsx
@@ -17,12 +17,15 @@ const DEFAULT_TAB = "assistant";
 
 function AgentThreadPage() {
 	const { agentId, threadId } = useParams();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const checkpointId = searchParams.get("checkpointId") || undefined;
 	const { agent, setAgent, useEffectGetAgent, useEffectGetAgents } =
 		useAgentContext();
 	const { setModel, useModelsEffect } = useModel();
 	useModelsEffect();
 	const {
 		useListThreadsEffect,
+		useListCheckpointsEffect,
 		messages,
 		useEffectUpdateAssistantId,
 		useLoadThreadEffect,
@@ -33,23 +36,38 @@ function AgentThreadPage() {
 		setTodos,
 		fromBackendFormat,
 		clearFileSystem,
+		threadViewMode,
+		activeCheckpointId,
 	} = useChatContext();
+	const hasLiveThreadState =
+		threadId &&
+		messages.length > 0 &&
+		(checkpointId
+			? threadViewMode === "checkpoint_preview" &&
+				activeCheckpointId === checkpointId
+			: threadViewMode === "latest");
 
 	useEffectGetAgent(agentId!);
 	useEffectGetAgents();
 
 	// Load thread data using modularized hook
-	useLoadThreadEffect(threadId, {
-		setCheckpoints,
-		setMessages,
-		setMetadata,
-		setFilesMap,
-		setTodos,
-		setModel,
-	});
+	useLoadThreadEffect(
+		threadId,
+		{
+			setCheckpoints,
+			setMessages,
+			setMetadata,
+			setFilesMap,
+			setTodos,
+			setModel,
+		},
+		{
+			enabled: !hasLiveThreadState,
+			checkpointId,
+		},
+	);
 
 	const [activeTab, setActiveTab] = useQueryState("tab");
-	const [, setSearchParams] = useSearchParams();
 
 	useEffectUpdateAssistantId();
 
@@ -58,6 +76,7 @@ function AgentThreadPage() {
 	};
 
 	useListThreadsEffect(null, { assistant_id: agentId });
+	useListCheckpointsEffect(true, threadId);
 
 	useEffect(() => {
 		// Only clear search params if there are none on init

--- a/frontend/src/pages/chat/chat-v2.tsx
+++ b/frontend/src/pages/chat/chat-v2.tsx
@@ -27,7 +27,7 @@ export function ChatV2Page() {
 	useEffectUpdateAssistantId();
 
 	useListThreadsEffect(!loading);
-	useListCheckpointsEffect(!loading, metadata);
+	useListCheckpointsEffect(!loading, metadata?.thread_id);
 	useInitialThreadRedirect({
 		threadId: metadata?.thread_id,
 		hasMessages: messages.length > 0,

--- a/frontend/src/pages/projects/ProjectPage.tsx
+++ b/frontend/src/pages/projects/ProjectPage.tsx
@@ -55,7 +55,7 @@ export default function ProjectPage() {
 	useEffectGetAgents();
 	useEffectUpdateAssistantId();
 	useListThreadsEffect(!loading);
-	useListCheckpointsEffect(!loading, metadata);
+	useListCheckpointsEffect(!loading, metadata?.thread_id);
 
 	// Fetch project data
 	useEffect(() => {

--- a/frontend/src/pages/threads/ThreadPage.test.tsx
+++ b/frontend/src/pages/threads/ThreadPage.test.tsx
@@ -131,6 +131,8 @@ describe("ThreadPage", () => {
 		useLoadThreadEffect: mockUseLoadThreadEffect,
 		threadLoading: false,
 		threadError: null,
+		threadViewMode: "latest",
+		activeCheckpointId: null,
 	};
 
 	beforeEach(() => {
@@ -170,7 +172,7 @@ describe("ThreadPage", () => {
 		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
 			"live-123",
 			expect.any(Object),
-			{ enabled: false },
+			{ enabled: false, checkpointId: undefined },
 		);
 	});
 
@@ -186,7 +188,7 @@ describe("ThreadPage", () => {
 		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
 			"live-123",
 			expect.any(Object),
-			{ enabled: true },
+			{ enabled: true, checkpointId: undefined },
 		);
 	});
 
@@ -202,7 +204,7 @@ describe("ThreadPage", () => {
 		expect(mockUseLoadThreadEffect).toHaveBeenCalledWith(
 			"live-123",
 			expect.any(Object),
-			{ enabled: true },
+			{ enabled: true, checkpointId: undefined },
 		);
 	});
 

--- a/frontend/src/pages/threads/ThreadPage.tsx
+++ b/frontend/src/pages/threads/ThreadPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import ChatLayout from "@/layouts/chat-layout-v2";
 import { useChatContext } from "@/context/ChatContext";
 import { ChatNav } from "@/components/nav/ChatNav";
@@ -27,6 +27,8 @@ export default function ThreadPage() {
 		threadId: string;
 		projectId?: string;
 	}>();
+	const [searchParams] = useSearchParams();
+	const checkpointId = searchParams.get("checkpointId") || undefined;
 	const navigate = useNavigate();
 	const { loading } = useAppContext();
 	const { useEffectGetAgents } = useAgentContext();
@@ -49,10 +51,17 @@ export default function ThreadPage() {
 		useLoadThreadEffect,
 		threadLoading,
 		threadError,
+		threadViewMode,
+		activeCheckpointId,
 	} = useChatContext();
 	const isMobile = useMediaQuery("(max-width: 768px)");
 	const hasLiveThreadState =
-		metadata?.thread_id === threadId && messages.length > 0;
+		metadata?.thread_id === threadId &&
+		messages.length > 0 &&
+		(checkpointId
+			? threadViewMode === "checkpoint_preview" &&
+				activeCheckpointId === checkpointId
+			: threadViewMode === "latest");
 	const effectiveThreadLoading = !hasLiveThreadState && threadLoading;
 	const effectiveThreadError = !hasLiveThreadState ? threadError : null;
 
@@ -60,7 +69,7 @@ export default function ThreadPage() {
 	useEffectGetAgents();
 	useEffectUpdateAssistantId();
 	useListThreadsEffect(!loading);
-	useListCheckpointsEffect(!loading, metadata);
+	useListCheckpointsEffect(!loading, threadId);
 
 	// Load thread data using modularized hook
 	useLoadThreadEffect(
@@ -75,6 +84,7 @@ export default function ThreadPage() {
 		},
 		{
 			enabled: !hasLiveThreadState,
+			checkpointId,
 		},
 	);
 

--- a/frontend/src/tests/services/threadService.test.ts
+++ b/frontend/src/tests/services/threadService.test.ts
@@ -1,51 +1,89 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { findThread } from "@/lib/services/threadService";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+	getThread,
+	listThreadCheckpoints,
+	getThreadCheckpoint,
+	forkThreadCheckpoint,
+} from "@/lib/services/threadService";
 import apiClient from "@/lib/utils/apiClient";
-import { mockThread } from "@/tests/mocks/thread";
 
-// Mock the apiClient
 vi.mock("../../lib/utils/apiClient", () => ({
 	default: {
 		get: vi.fn(),
+		post: vi.fn(),
 	},
 }));
 
 describe("threadService", () => {
 	beforeEach(() => {
-		// Clear mock calls before each test
 		vi.clearAllMocks();
 	});
 
-	afterEach(() => {
-		// Reset mocks after each test
-		vi.resetAllMocks();
+	it("fetches a thread record from the dedicated endpoint", async () => {
+		(apiClient.get as any).mockResolvedValueOnce({
+			data: { thread: { id: "thread-123", head_checkpoint_id: "cp-1" } },
+		});
+
+		const result = await getThread("thread-123");
+
+		expect(apiClient.get).toHaveBeenCalledWith("/threads/thread-123");
+		expect(result).toEqual({ id: "thread-123", head_checkpoint_id: "cp-1" });
 	});
 
-	describe.skip("findThread", () => {
-		it("should fetch thread successfully", async () => {
-			// Setup mock response
-			(apiClient.get as any).mockResolvedValue({ data: mockThread });
-
-			// Call the function
-			const result = await findThread("thread-123");
-
-			// Assertions
-			expect(apiClient.get).toHaveBeenCalledWith("/thread/thread-123");
-			expect(apiClient.get).toHaveBeenCalledTimes(1);
-			expect(result).toEqual(mockThread);
+	it("lists checkpoint summaries from the checkpoint endpoint", async () => {
+		(apiClient.get as any).mockResolvedValueOnce({
+			data: { checkpoints: [{ checkpoint_id: "cp-1", is_head: true }] },
 		});
 
-		it("should propagate errors from the API", async () => {
-			// Setup mock error
-			const mockError = new Error("Thread not found");
-			(apiClient.get as any).mockRejectedValue(mockError);
+		const result = await listThreadCheckpoints("thread-123", { limit: 10 });
 
-			// Call and verify error is thrown
-			await expect(findThread("invalid-id")).rejects.toThrow(
-				"Thread not found",
-			);
-			expect(apiClient.get).toHaveBeenCalledWith("/thread/invalid-id");
-			expect(apiClient.get).toHaveBeenCalledTimes(1);
+		expect(apiClient.get).toHaveBeenCalledWith(
+			"/threads/thread-123/checkpoints",
+			{ params: { limit: 10 } },
+		);
+		expect(result).toEqual([{ checkpoint_id: "cp-1", is_head: true }]);
+	});
+
+	it("fetches checkpoint detail from the checkpoint endpoint", async () => {
+		(apiClient.get as any).mockResolvedValueOnce({
+			data: {
+				checkpoint: {
+					thread_id: "thread-123",
+					checkpoint_id: "cp-9",
+					messages: [],
+					files: {},
+					todos: [],
+					metadata: {},
+				},
+			},
 		});
+
+		const result = await getThreadCheckpoint("thread-123", "cp-9");
+
+		expect(apiClient.get).toHaveBeenCalledWith(
+			"/threads/thread-123/checkpoints/cp-9",
+		);
+		expect(result.checkpoint_id).toBe("cp-9");
+	});
+
+	it("forks a checkpoint using the restore endpoint", async () => {
+		(apiClient.post as any).mockResolvedValueOnce({
+			data: {
+				thread_id: "fork-123",
+				head_checkpoint_id: "fork-cp-1",
+				source_thread_id: "thread-123",
+				source_checkpoint_id: "cp-9",
+			},
+		});
+
+		const result = await forkThreadCheckpoint("thread-123", "cp-9", {
+			title: "Forked thread",
+		});
+
+		expect(apiClient.post).toHaveBeenCalledWith(
+			"/threads/thread-123/checkpoints/cp-9/fork",
+			{ title: "Forked thread" },
+		);
+		expect(result.thread_id).toBe("fork-123");
 	});
 });


### PR DESCRIPTION
## Summary

- Add backend APIs for listing checkpoint summaries, viewing checkpoint details, and forking threads from any checkpoint
- Add `update_checkpoint_snapshot` service method to persist head checkpoint metadata to thread store
- Extend `Thread` model with `head_checkpoint_id`, `checkpoint_count`, `assistant_id`, `project_id`
- Add frontend history sidebar panel in ChatNav with checkpoint timeline
- Add checkpoint preview mode (URL param `?checkpointId=...`) with disabled chat input
- Add fork-to-restore flow that creates a new thread and navigates to it
- Update `useThread` hook with typed entities, checkpoint loading, and view mode state
- Fix existing test mocks for `update_checkpoint_snapshot` in schedule dispatch and worker tests

## Test plan

- [ ] Backend: `GET /threads/{id}/checkpoints` returns paginated checkpoint summaries
- [ ] Backend: `GET /threads/{id}/checkpoints/{checkpoint_id}` returns full checkpoint detail
- [ ] Backend: `POST /threads/{id}/checkpoints/{checkpoint_id}/fork` creates a new forked thread
- [ ] Frontend: History button opens sidebar with checkpoint timeline
- [ ] Frontend: Clicking a checkpoint shows preview with messages from that point
- [ ] Frontend: "Restore" forks and navigates to new thread
- [ ] Frontend: Chat input disabled during checkpoint preview
- [ ] All backend tests pass (`make test`)
- [ ] All frontend tests pass (`npm run test`)

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)