### PR TITLE
FROM fix/855-files-map-not-persisted-across-threads  TO development

### DIFF
--- a/frontend/src/components/buttons/NewThreadButton.test.tsx
+++ b/frontend/src/components/buttons/NewThreadButton.test.tsx
@@ -55,6 +55,7 @@ describe("NewThreadButton", () => {
 			messages: [{ id: "msg-1" }],
 			clearMessages: vi.fn(),
 			metadata: { assistant_id: "assistant-1" },
+			abortQuery: vi.fn(),
 			resetToDefault: vi.fn(),
 			loadPersistentContextFiles: vi.fn(),
 			clearThreadScopedFiles: vi.fn(),
@@ -68,12 +69,46 @@ describe("NewThreadButton", () => {
 		fireEvent.click(screen.getByTitle("New Chat"));
 
 		const context = mockUseChatContext.mock.results[0].value;
+		expect(context.abortQuery).toHaveBeenCalledTimes(1);
 		expect(context.clearMessages).toHaveBeenCalledTimes(1);
 		expect(context.clearThreadScopedFiles).toHaveBeenCalledTimes(1);
 		expect(context.clearBackendSyncFiles).toHaveBeenCalledTimes(1);
 		expect(context.resetToDefault).toHaveBeenCalledTimes(1);
 		expect(context.loadPersistentContextFiles).toHaveBeenCalledTimes(1);
-		expect(mockNavigate).toHaveBeenCalledWith("/chat");
+		expect(mockNavigate).toHaveBeenCalledWith("/chat", {
+			state: { staleThreadId: undefined },
+		});
+	});
+
+	it("aborts the active stream before clearing messages", () => {
+		mockUseChatContext.mockReturnValue({
+			messages: [{ id: "msg-1" }],
+			clearMessages: vi.fn(),
+			metadata: { thread_id: "thread-1", assistant_id: "assistant-1" },
+			abortQuery: vi.fn(),
+			resetToDefault: vi.fn(),
+			loadPersistentContextFiles: vi.fn(),
+			clearThreadScopedFiles: vi.fn(),
+			clearBackendSyncFiles: vi.fn(),
+		});
+
+		renderAt("/thread/thread-1");
+
+		fireEvent.click(screen.getByTitle("New Chat"));
+
+		const context = mockUseChatContext.mock.results[0].value;
+		expect(context.abortQuery).toHaveBeenCalledTimes(1);
+		expect(context.clearMessages).toHaveBeenCalledTimes(1);
+
+		// Verify abort was called before clearMessages
+		const abortOrder = context.abortQuery.mock.invocationCallOrder[0];
+		const clearOrder = context.clearMessages.mock.invocationCallOrder[0];
+		expect(abortOrder).toBeLessThan(clearOrder);
+
+		// Verify staleThreadId is passed
+		expect(mockNavigate).toHaveBeenCalledWith("/chat", {
+			state: { staleThreadId: "thread-1" },
+		});
 	});
 
 	it("navigates assistant thread resets back to the assistant route", () => {
@@ -89,6 +124,7 @@ describe("NewThreadButton", () => {
 			messages: [],
 			clearMessages: vi.fn(),
 			metadata: {},
+			abortQuery: vi.fn(),
 			resetToDefault: vi.fn(),
 			loadPersistentContextFiles: vi.fn(),
 			clearThreadScopedFiles: vi.fn(),
@@ -97,5 +133,26 @@ describe("NewThreadButton", () => {
 
 		const { container } = renderAt("/chat");
 		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("passes staleThreadId when falling back from a project route to /chat", () => {
+		mockUseChatContext.mockReturnValue({
+			messages: [{ id: "msg-1" }],
+			clearMessages: vi.fn(),
+			metadata: { thread_id: "proj-thread-1" },
+			abortQuery: vi.fn(),
+			resetToDefault: vi.fn(),
+			loadPersistentContextFiles: vi.fn(),
+			clearThreadScopedFiles: vi.fn(),
+			clearBackendSyncFiles: vi.fn(),
+		});
+
+		renderAt("/p/project-1");
+
+		fireEvent.click(screen.getByTitle("New Chat"));
+
+		expect(mockNavigate).toHaveBeenCalledWith("/chat", {
+			state: { staleThreadId: "proj-thread-1" },
+		});
 	});
 });

--- a/frontend/src/components/buttons/NewThreadButton.tsx
+++ b/frontend/src/components/buttons/NewThreadButton.tsx
@@ -1,4 +1,5 @@
 import { useChatContext } from "@/context/ChatContext";
+import { removeActiveStreamRecovery } from "@/lib/utils/activeStreamRecovery";
 import { Button } from "../ui/button";
 import { Plus } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -8,6 +9,7 @@ function NewThreadButton() {
 		messages,
 		clearMessages,
 		metadata,
+		abortQuery,
 		resetToDefault,
 		loadPersistentContextFiles,
 		clearThreadScopedFiles,
@@ -20,28 +22,44 @@ function NewThreadButton() {
 		if (e.ctrlKey) {
 			window.open(window.location.href, "_blank");
 		} else {
+			// Abort active stream BEFORE clearing to prevent race condition
+			// where SSE handler re-populates stale thread_id after clear
+			abortQuery();
+			if (metadata?.thread_id) {
+				removeActiveStreamRecovery(metadata.thread_id);
+			}
+
+			// Capture navigation values before clearing metadata
+			const pathname = location.pathname;
+			const threadId = metadata?.thread_id;
+			const assistantId = metadata?.assistant_id;
+			const projectId = metadata?.project_id;
+
+			// Clear state eagerly. React may batch these updates, so the
+			// destination page also guards against stale state via the
+			// staleThreadId navigation state.
 			clearMessages();
 			clearThreadScopedFiles?.();
 			clearBackendSyncFiles?.();
 			// Reset model to user's default for new conversations
 			resetToDefault?.();
 			loadPersistentContextFiles?.();
-			const pathname = location.pathname;
 
-			// Handle thread routes
+			// Navigate — pass staleThreadId so the destination page can
+			// force-clear any lingering messages that survived batching.
 			if (pathname.startsWith("/thread/")) {
-				// On /thread/:threadId - go back to chat
-				navigate("/chat");
+				navigate("/chat", {
+					state: { staleThreadId: threadId },
+				});
 			} else if (pathname.startsWith("/assistant/")) {
-				// On /assistant/:agentId/thread/:threadId - go to agent thread page
-				navigate(`/assistant/${metadata?.assistant_id}`);
+				navigate(`/assistant/${assistantId}`);
 			} else if (pathname.match(/^\/p\/[^/]+\/t\//)) {
-				// On /p/:projectId/t/:threadId - extract projectId and go to project page
-				const projectId = pathname.split("/")[2];
-				navigate(`/p/${projectId}`);
-			} else if (pathname.startsWith("/p/") && !metadata?.project_id) {
-				// On project page but no project_id in metadata - go to chat
-				navigate("/chat");
+				const pathProjectId = pathname.split("/")[2];
+				navigate(`/p/${pathProjectId}`);
+			} else if (pathname.startsWith("/p/") && !projectId) {
+				navigate("/chat", {
+					state: { staleThreadId: threadId },
+				});
 			}
 		}
 	};

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -261,6 +261,10 @@ export default function useChat(): ChatContextType {
 		const threadId = distributedStream?.getThreadId() ?? metadata?.thread_id;
 
 		stream.onEvent((event: StreamEvent) => {
+			// Bail out if the stream was aborted (prevents stale SSE events from
+			// re-populating messages/metadata after clearMessages)
+			if (controller.signal.aborted) return;
+
 			if (distributedStream) {
 				updateDistributedRecoveryCursor(distributedStream, options.route);
 			}

--- a/frontend/src/hooks/useInitialThreadRedirect.test.tsx
+++ b/frontend/src/hooks/useInitialThreadRedirect.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import useInitialThreadRedirect from "./useInitialThreadRedirect";
 
 const mockNavigate = vi.fn();
+const mockUseLocation = vi.fn();
 
 vi.mock("react-router-dom", async () => {
 	const actual =
@@ -13,12 +14,15 @@ vi.mock("react-router-dom", async () => {
 	return {
 		...actual,
 		useNavigate: () => mockNavigate,
+		useLocation: () => mockUseLocation(),
 	};
 });
 
 describe("useInitialThreadRedirect", () => {
 	beforeEach(() => {
 		mockNavigate.mockReset();
+		mockUseLocation.mockReset();
+		mockUseLocation.mockReturnValue({ state: null });
 	});
 
 	it("does not navigate when threadId is missing", () => {
@@ -96,6 +100,85 @@ describe("useInitialThreadRedirect", () => {
 
 		expect(mockNavigate).toHaveBeenCalledTimes(2);
 		expect(mockNavigate).toHaveBeenLastCalledWith("/thread/thread-456", {
+			replace: true,
+		});
+	});
+
+	it("suppresses the initial redirect when threadId matches staleThreadId", () => {
+		mockUseLocation.mockReturnValue({
+			state: { staleThreadId: "thread-123" },
+		});
+
+		renderHook(() =>
+			useInitialThreadRedirect({
+				threadId: "thread-123",
+				hasMessages: true,
+			}),
+		);
+
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+
+	it("redirects when threadId differs from staleThreadId", () => {
+		mockUseLocation.mockReturnValue({
+			state: { staleThreadId: "stale-thread" },
+		});
+
+		const { rerender } = renderHook(
+			({
+				threadId,
+				hasMessages,
+			}: {
+				threadId?: string;
+				hasMessages: boolean;
+			}) => useInitialThreadRedirect({ threadId, hasMessages }),
+			{
+				initialProps: {
+					threadId: "stale-thread" as string | undefined,
+					hasMessages: true,
+				},
+			},
+		);
+
+		// First render: suppressed (threadId matches staleThreadId)
+		expect(mockNavigate).not.toHaveBeenCalled();
+
+		// New thread arrives — different from staleThreadId, should redirect
+		rerender({ threadId: "new-thread", hasMessages: true });
+		expect(mockNavigate).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).toHaveBeenCalledWith("/thread/new-thread", {
+			replace: true,
+		});
+	});
+
+	it("re-enables redirects after the stale thread clears and a new thread arrives", () => {
+		mockUseLocation.mockReturnValue({
+			state: { staleThreadId: "thread-123" },
+		});
+
+		const { rerender } = renderHook(
+			({
+				threadId,
+				hasMessages,
+			}: {
+				threadId?: string;
+				hasMessages: boolean;
+			}) => useInitialThreadRedirect({ threadId, hasMessages }),
+			{
+				initialProps: {
+					threadId: "thread-123" as string | undefined,
+					hasMessages: true,
+				},
+			},
+		);
+
+		expect(mockNavigate).not.toHaveBeenCalled();
+
+		rerender({ threadId: undefined, hasMessages: false });
+		rerender({ threadId: "thread-456", hasMessages: true });
+
+		expect(mockNavigate).toHaveBeenCalledTimes(1);
+		expect(mockNavigate).toHaveBeenCalledWith("/thread/thread-456", {
 			replace: true,
 		});
 	});

--- a/frontend/src/hooks/useInitialThreadRedirect.ts
+++ b/frontend/src/hooks/useInitialThreadRedirect.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 type UseInitialThreadRedirectOptions = {
 	threadId?: string;
@@ -11,6 +11,10 @@ export default function useInitialThreadRedirect({
 	hasMessages,
 }: UseInitialThreadRedirectOptions): void {
 	const navigate = useNavigate();
+	const location = useLocation();
+	const staleThreadId = (
+		location.state as { staleThreadId?: string } | null | undefined
+	)?.staleThreadId;
 	const lastNavigatedThreadIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
@@ -23,11 +27,16 @@ export default function useInitialThreadRedirect({
 			return;
 		}
 
+		// Skip redirect when the threadId matches the stale one we just left
+		if (threadId === staleThreadId) {
+			return;
+		}
+
 		if (lastNavigatedThreadIdRef.current === threadId) {
 			return;
 		}
 
 		lastNavigatedThreadIdRef.current = threadId;
 		navigate(`/thread/${threadId}`, { replace: true });
-	}, [hasMessages, navigate, threadId]);
+	}, [hasMessages, navigate, staleThreadId, threadId]);
 }

--- a/frontend/src/pages/chat/chat-v2.tsx
+++ b/frontend/src/pages/chat/chat-v2.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import ChatLayout from "@/layouts/chat-layout-v2";
 import ChatPanel from "./ChatPanel";
 import { useAgentContext } from "@/context/AgentContext";
@@ -18,7 +20,22 @@ export function ChatV2Page() {
 		metadata,
 		messages,
 		useModelsEffect,
+		clearMessages,
 	} = useChatContext();
+	const location = useLocation();
+	const staleThreadId = (
+		location.state as { staleThreadId?: string } | null | undefined
+	)?.staleThreadId;
+
+	// When navigating here from NewThreadButton with a staleThreadId,
+	// force-clear any lingering messages/metadata from the previous thread.
+	// This handles the case where clearMessages() in the button's onClick
+	// didn't fully flush before the route change.
+	useEffect(() => {
+		if (staleThreadId && (messages.length > 0 || metadata?.thread_id)) {
+			clearMessages();
+		}
+	}, [staleThreadId]);
 
 	useModelsEffect();
 	useEffectGetAgents();

--- a/frontend/src/tests/integration/newChatThreadRedirect.test.tsx
+++ b/frontend/src/tests/integration/newChatThreadRedirect.test.tsx
@@ -1,0 +1,159 @@
+import "@testing-library/jest-dom";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+	useEffect,
+	useMemo,
+	useState,
+	type Dispatch,
+	type SetStateAction,
+} from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import NewThreadButton from "@/components/buttons/NewThreadButton";
+import { useChatContext } from "@/context/ChatContext";
+import useInitialThreadRedirect from "@/hooks/useInitialThreadRedirect";
+
+const mockUseChatContext = vi.fn();
+let currentChatContextValue: ReturnType<typeof buildChatContextValue> | null =
+	null;
+
+vi.mock("@/context/ChatContext", () => ({
+	useChatContext: () => mockUseChatContext(),
+}));
+
+function buildChatContextValue(
+	messages: Array<{ id: string; content: string }>,
+	metadata: { thread_id?: string },
+	setResetPending: Dispatch<SetStateAction<boolean>>,
+) {
+	return {
+		messages,
+		metadata,
+		clearMessages: () => setResetPending(true),
+		abortQuery: vi.fn(),
+		resetToDefault: vi.fn(),
+		loadPersistentContextFiles: vi.fn(),
+		clearThreadScopedFiles: vi.fn(),
+		clearBackendSyncFiles: vi.fn(),
+	};
+}
+
+function LocationDisplay() {
+	const location = useLocation();
+
+	return <div data-testid="location">{location.pathname}</div>;
+}
+
+function ThreadRoute() {
+	return <NewThreadButton />;
+}
+
+function ChatRoute({ onCreateThread }: { onCreateThread: () => void }) {
+	const { metadata, messages } = useChatContext();
+
+	useInitialThreadRedirect({
+		threadId: metadata?.thread_id,
+		hasMessages: messages.length > 0,
+	});
+
+	return <button onClick={onCreateThread}>Create Thread</button>;
+}
+
+function RegressionHarness() {
+	const [messages, setMessages] = useState([{ id: "msg-1", content: "hello" }]);
+	const [metadata, setMetadata] = useState<{ thread_id?: string }>({
+		thread_id: "thread-123",
+	});
+	const [resetPending, setResetPending] = useState(false);
+
+	useEffect(() => {
+		if (!resetPending) {
+			return;
+		}
+
+		let cancelled = false;
+
+		void Promise.resolve().then(() => {
+			if (cancelled) {
+				return;
+			}
+
+			setMessages([]);
+			setMetadata({});
+			setResetPending(false);
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [resetPending]);
+
+	const chatContextValue = useMemo(
+		() => buildChatContextValue(messages, metadata, setResetPending),
+		[messages, metadata, setResetPending],
+	);
+
+	currentChatContextValue = chatContextValue;
+
+	return (
+		<MemoryRouter initialEntries={["/thread/thread-123"]}>
+			<LocationDisplay />
+			<Routes>
+				<Route path="/thread/:threadId" element={<ThreadRoute />} />
+				<Route
+					path="/chat"
+					element={
+						<ChatRoute
+							onCreateThread={() => {
+								setMetadata({ thread_id: "thread-456" });
+								setMessages([{ id: "msg-2", content: "new thread" }]);
+							}}
+						/>
+					}
+				/>
+			</Routes>
+		</MemoryRouter>
+	);
+}
+
+describe("new chat thread redirect regression", () => {
+	beforeEach(() => {
+		currentChatContextValue = null;
+		mockUseChatContext.mockReset();
+		mockUseChatContext.mockImplementation(() => currentChatContextValue);
+	});
+
+	it("stays on /chat after New Chat clears stale state, then redirects for the next real thread id", async () => {
+		render(<RegressionHarness />);
+
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/thread/thread-123",
+		);
+
+		fireEvent.click(screen.getByTitle("New Chat"));
+
+		await waitFor(() =>
+			expect(screen.getByTestId("location")).toHaveTextContent("/chat"),
+		);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(screen.getByTestId("location")).toHaveTextContent("/chat");
+
+		fireEvent.click(screen.getByRole("button", { name: "Create Thread" }));
+
+		await waitFor(() =>
+			expect(screen.getByTestId("location")).toHaveTextContent(
+				"/thread/thread-456",
+			),
+		);
+	});
+});


### PR DESCRIPTION
Prevents race condition where SSE events from a previous thread repopulate messages/metadata after clicking New Thread. Aborts the stream controller, passes staleThreadId via navigation state, and adds a force-clear guard on the chat page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented race conditions when starting a new chat by properly aborting active streaming queries.
  * Eliminated data leakage between chat threads through improved state cleanup and recovery.
  * Enhanced redirect behavior and navigation logic when switching between threads.

* **Tests**
  * Added comprehensive test coverage for thread creation, state management, and navigation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->