### PR TITLE
fix: resolve worker stability & SSE streaming issues

### DIFF
--- a/backend/src/routes/v0/llm.py
+++ b/backend/src/routes/v0/llm.py
@@ -147,7 +147,11 @@ async def llm_stream(
         return StreamingResponse(
             assistant,
             media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
         )
     except Exception as e:
         logger.exception(f"Error in llm_stream: {e}")

--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import os
 from langchain.agents.middleware import PIIDetectionError
@@ -433,8 +434,16 @@ async def stream_from_redis(thread_id: str, run_id: str, after: str = "0"):
     last_id = after or "0"
 
     try:
-        if not await redis_client.exists(stream_key):
-            raise FileNotFoundError(f"Distributed stream not found for thread={thread_id} run={run_id}")
+        # Wait for stream to appear (worker may still be initializing)
+        max_wait_seconds = 30
+        poll_interval = 1.0
+        waited = 0.0
+        while not await redis_client.exists(stream_key):
+            if waited >= max_wait_seconds:
+                raise FileNotFoundError(f"Distributed stream not found for thread={thread_id} run={run_id}")
+            yield ": waiting\n\n"
+            await asyncio.sleep(poll_interval)
+            waited += poll_interval
 
         while True:
             # Block for configurable time waiting for messages (default 60s)

--- a/backend/src/workers/broker.py
+++ b/backend/src/workers/broker.py
@@ -7,8 +7,13 @@ Environment Variables:
     REDIS_URL: Redis connection URL (default: redis://localhost:6379/0)
 """
 
+import asyncio
 import os
+
+from redis.exceptions import ConnectionError
 from taskiq_redis import RedisStreamBroker, RedisAsyncResultBackend
+
+from src.utils.logger import logger
 
 # Redis connection URL from environment
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -19,8 +24,30 @@ result_backend = RedisAsyncResultBackend(
     result_ex_time=300,  # 5 minute TTL for results
 )
 
+
+class ResilientRedisStreamBroker(RedisStreamBroker):
+    """RedisStreamBroker with ConnectionError retry handling.
+
+    The upstream RedisStreamBroker.listen() does not catch ConnectionError,
+    so a Redis restart or network blip kills the worker process. This
+    subclass wraps listen() with a reconnect loop, matching the pattern
+    already used by ListQueueBroker.
+    """
+
+    async def listen(self):
+        """Listen with automatic reconnect on ConnectionError."""
+        while True:
+            try:
+                async for message in super().listen():
+                    yield message
+            except ConnectionError as exc:
+                logger.warning("Redis connection error in broker listen: %s. Reconnecting...", exc)
+                await asyncio.sleep(1)
+                continue
+
+
 # Redis Stream broker for task distribution
-broker = RedisStreamBroker(
+broker = ResilientRedisStreamBroker(
     url=REDIS_URL,
     queue_name="orchestra_tasks",
 ).with_result_backend(result_backend)
@@ -32,7 +59,7 @@ async def on_startup():
     """Initialize worker state on startup.
 
     This hook is called when a TaskIQ worker process starts.
-    It initializes the shared checkpointer instance that will be
+    It initializes the shared checkpointer and store instances that will be
     reused across all task executions in this worker.
     """
     from src.workers.state import WorkerState
@@ -47,7 +74,7 @@ async def on_shutdown():
     """Cleanup worker state on shutdown.
 
     This hook is called when a TaskIQ worker process is shutting down.
-    It properly closes the checkpointer connection and releases resources.
+    It properly closes the checkpointer and store connections and releases resources.
     """
     from src.workers.state import WorkerState
     from src.constants import CHECKPOINT_USE_RESILIENT

--- a/backend/src/workers/broker.py
+++ b/backend/src/workers/broker.py
@@ -9,8 +9,10 @@ Environment Variables:
 
 import asyncio
 import os
+from collections.abc import AsyncGenerator
 
 from redis.exceptions import ConnectionError
+from taskiq.acks import AckableMessage
 from taskiq_redis import RedisStreamBroker, RedisAsyncResultBackend
 
 from src.utils.logger import logger
@@ -34,7 +36,7 @@ class ResilientRedisStreamBroker(RedisStreamBroker):
     already used by ListQueueBroker.
     """
 
-    async def listen(self):
+    async def listen(self) -> AsyncGenerator[AckableMessage, None]:
         """Listen with automatic reconnect on ConnectionError."""
         while True:
             try:

--- a/backend/src/workers/state.py
+++ b/backend/src/workers/state.py
@@ -45,6 +45,7 @@ class WorkerState:
     Thread Safety:
     - TaskIQ workers are single-threaded by default
     - Async lock in ResilientAsyncPostgresSaver handles concurrent coroutines
+    - _init_lock serializes concurrent initialize() calls from lazy-init paths
 
     Usage:
         # On worker startup
@@ -63,6 +64,7 @@ class WorkerState:
     _store: Optional[AsyncPostgresStore] = None
     _store_exit_stack: Optional[contextlib.AsyncExitStack] = None
     _initialized: bool = False
+    _init_lock: asyncio.Lock = asyncio.Lock()
 
     @classmethod
     def get_instance(cls) -> "WorkerState":
@@ -76,78 +78,72 @@ class WorkerState:
         """Initialize worker state (called on worker startup).
 
         Creates the shared checkpointer and store instances and establishes
-        the initial database connections.
+        the initial database connections. Uses an asyncio.Lock to serialize
+        concurrent callers and cleans up partial resources on failure.
         """
         instance = cls.get_instance()
-        if instance._initialized:
-            logger.debug("Worker state already initialized, skipping")
-            return
 
-        logger.info(
-            "worker_state_initializing",
-            extra={
-                "event": "worker_state_initializing",
-            },
-        )
+        async with instance._init_lock:
+            # Re-check after acquiring lock (another caller may have completed init)
+            if instance._initialized:
+                logger.debug("Worker state already initialized, skipping")
+                return
 
-        # Create and connect checkpointer
-        instance._checkpointer = ResilientAsyncPostgresSaver(
-            connection_string=DB_URI_SESSION,
-            max_retries=CHECKPOINT_MAX_RETRIES,
-            base_delay=CHECKPOINT_RETRY_DELAY,
-            max_delay=CHECKPOINT_MAX_DELAY,
-            jitter=CHECKPOINT_JITTER,
-            enable_fallback=CHECKPOINT_ENABLE_FALLBACK,
-            health_check_interval=CHECKPOINT_HEALTH_CHECK_INTERVAL,
-            keepalives=1,
-            keepalives_idle=DB_KEEPALIVE_IDLE,
-            keepalives_interval=DB_KEEPALIVE_INTERVAL,
-            keepalives_count=DB_KEEPALIVE_COUNT,
-        )
-        await instance._checkpointer.connect()
+            logger.info(
+                "worker_state_initializing",
+                extra={
+                    "event": "worker_state_initializing",
+                },
+            )
 
-        # Ensure checkpoint tables exist
-        await instance._checkpointer.setup()
+            try:
+                # Create and connect checkpointer
+                instance._checkpointer = ResilientAsyncPostgresSaver(
+                    connection_string=DB_URI_SESSION,
+                    max_retries=CHECKPOINT_MAX_RETRIES,
+                    base_delay=CHECKPOINT_RETRY_DELAY,
+                    max_delay=CHECKPOINT_MAX_DELAY,
+                    jitter=CHECKPOINT_JITTER,
+                    enable_fallback=CHECKPOINT_ENABLE_FALLBACK,
+                    health_check_interval=CHECKPOINT_HEALTH_CHECK_INTERVAL,
+                    keepalives=1,
+                    keepalives_idle=DB_KEEPALIVE_IDLE,
+                    keepalives_interval=DB_KEEPALIVE_INTERVAL,
+                    keepalives_count=DB_KEEPALIVE_COUNT,
+                )
+                await instance._checkpointer.connect()
 
-        # Create singleton store via AsyncExitStack to manage the context manager
-        from src.services.db import get_store_db
+                # Ensure checkpoint tables exist
+                await instance._checkpointer.setup()
 
-        instance._store_exit_stack = contextlib.AsyncExitStack()
-        instance._store = await instance._store_exit_stack.enter_async_context(get_store_db())
+                # Create singleton store via AsyncExitStack to manage the context manager
+                from src.services.db import get_store_db
 
-        instance._initialized = True
-        logger.info(
-            "worker_state_initialized",
-            extra={
-                "event": "worker_state_initialized",
-                "status": "success",
-            },
-        )
+                instance._store_exit_stack = contextlib.AsyncExitStack()
+                instance._store = await instance._store_exit_stack.enter_async_context(get_store_db())
+
+                instance._initialized = True
+                logger.info(
+                    "worker_state_initialized",
+                    extra={
+                        "event": "worker_state_initialized",
+                        "status": "success",
+                    },
+                )
+            except Exception:
+                # Clean up any partially-created resources
+                logger.exception("worker_state_init_failed")
+                await cls._cleanup_resources(instance)
+                raise
 
     @classmethod
-    async def shutdown(cls) -> None:
-        """Cleanup worker state (called on worker shutdown).
-
-        Closes the checkpointer and store connections and releases resources.
-        """
-        instance = cls.get_instance()
-        if not instance._initialized:
-            logger.debug("Worker state not initialized, nothing to shutdown")
-            return
-
-        logger.info(
-            "worker_state_shutting_down",
-            extra={
-                "event": "worker_state_shutting_down",
-            },
-        )
-
-        # Shutdown store via exit stack (calls __aexit__)
+    async def _cleanup_resources(cls, instance: "WorkerState") -> None:
+        """Release any resources on the instance, regardless of _initialized state."""
         if instance._store_exit_stack:
             try:
                 await instance._store_exit_stack.aclose()
             except Exception as e:
-                logger.warning("Error closing store exit stack: %s", e)
+                logger.warning("Error closing store exit stack during cleanup: %s", e)
             instance._store_exit_stack = None
 
         # Defense-in-depth: cancel store's internal batch loop task
@@ -162,10 +158,43 @@ class WorkerState:
         instance._store = None
 
         if instance._checkpointer:
-            await instance._checkpointer.close()
+            try:
+                await instance._checkpointer.close()
+            except Exception as e:
+                logger.warning("Error closing checkpointer during cleanup: %s", e)
             instance._checkpointer = None
 
         instance._initialized = False
+
+    @classmethod
+    async def shutdown(cls) -> None:
+        """Cleanup worker state (called on worker shutdown).
+
+        Closes the checkpointer and store connections and releases resources.
+        Attempts cleanup even if _initialized is False to release any
+        partially-created resources from a failed initialize().
+        """
+        instance = cls.get_instance()
+
+        has_resources = (
+            instance._initialized
+            or instance._checkpointer is not None
+            or instance._store is not None
+            or instance._store_exit_stack is not None
+        )
+        if not has_resources:
+            logger.debug("Worker state has no resources, nothing to shutdown")
+            return
+
+        logger.info(
+            "worker_state_shutting_down",
+            extra={
+                "event": "worker_state_shutting_down",
+            },
+        )
+
+        await cls._cleanup_resources(instance)
+
         logger.info(
             "worker_state_shutdown_complete",
             extra={

--- a/backend/src/workers/state.py
+++ b/backend/src/workers/state.py
@@ -4,8 +4,8 @@ This module provides singleton instances that persist across task executions
 within a single worker process. This pattern avoids the overhead of creating
 new database connections for every task.
 
-The checkpointer instance is created once when the worker starts and reused
-for all tasks processed by that worker.
+The checkpointer and store instances are created once when the worker starts
+and reused for all tasks processed by that worker.
 
 Design Rationale:
 - TaskIQ workers are single-threaded by default
@@ -13,7 +13,11 @@ Design Rationale:
 - Async lock in ResilientAsyncPostgresSaver handles concurrent coroutines
 """
 
+import asyncio
+import contextlib
 from typing import Optional
+
+from langgraph.store.postgres import AsyncPostgresStore
 
 from src.services.checkpoint_resilient import ResilientAsyncPostgresSaver
 from src.constants import (
@@ -36,6 +40,7 @@ class WorkerState:
 
     Holds shared resources that should persist across task executions:
     - Checkpointer: Resilient PostgresSaver for LangGraph state
+    - Store: AsyncPostgresStore for LangGraph store operations
 
     Thread Safety:
     - TaskIQ workers are single-threaded by default
@@ -47,6 +52,7 @@ class WorkerState:
 
         # In task execution
         checkpointer = WorkerState.get_checkpointer()
+        store = WorkerState.get_store()
 
         # On worker shutdown
         await WorkerState.shutdown()
@@ -54,6 +60,8 @@ class WorkerState:
 
     _instance: Optional["WorkerState"] = None
     _checkpointer: Optional[ResilientAsyncPostgresSaver] = None
+    _store: Optional[AsyncPostgresStore] = None
+    _store_exit_stack: Optional[contextlib.AsyncExitStack] = None
     _initialized: bool = False
 
     @classmethod
@@ -67,8 +75,8 @@ class WorkerState:
     async def initialize(cls) -> None:
         """Initialize worker state (called on worker startup).
 
-        Creates the shared checkpointer instance and establishes
-        the initial database connection.
+        Creates the shared checkpointer and store instances and establishes
+        the initial database connections.
         """
         instance = cls.get_instance()
         if instance._initialized:
@@ -101,6 +109,12 @@ class WorkerState:
         # Ensure checkpoint tables exist
         await instance._checkpointer.setup()
 
+        # Create singleton store via AsyncExitStack to manage the context manager
+        from src.services.db import get_store_db
+
+        instance._store_exit_stack = contextlib.AsyncExitStack()
+        instance._store = await instance._store_exit_stack.enter_async_context(get_store_db())
+
         instance._initialized = True
         logger.info(
             "worker_state_initialized",
@@ -114,7 +128,7 @@ class WorkerState:
     async def shutdown(cls) -> None:
         """Cleanup worker state (called on worker shutdown).
 
-        Closes the checkpointer connection and releases resources.
+        Closes the checkpointer and store connections and releases resources.
         """
         instance = cls.get_instance()
         if not instance._initialized:
@@ -127,6 +141,25 @@ class WorkerState:
                 "event": "worker_state_shutting_down",
             },
         )
+
+        # Shutdown store via exit stack (calls __aexit__)
+        if instance._store_exit_stack:
+            try:
+                await instance._store_exit_stack.aclose()
+            except Exception as e:
+                logger.warning("Error closing store exit stack: %s", e)
+            instance._store_exit_stack = None
+
+        # Defense-in-depth: cancel store's internal batch loop task
+        if instance._store and hasattr(instance._store, "_task"):
+            task = instance._store._task
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await asyncio.wait_for(task, timeout=5.0)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pass
+        instance._store = None
 
         if instance._checkpointer:
             await instance._checkpointer.close()
@@ -157,6 +190,24 @@ class WorkerState:
                 "is called on worker startup via TaskIQ lifecycle hooks."
             )
         return instance._checkpointer
+
+    @classmethod
+    def get_store(cls) -> AsyncPostgresStore:
+        """Get the shared store instance.
+
+        Returns:
+            The worker's shared AsyncPostgresStore instance
+
+        Raises:
+            RuntimeError: If worker state not initialized
+        """
+        instance = cls.get_instance()
+        if not instance._initialized or not instance._store:
+            raise RuntimeError(
+                "Worker state not initialized. Ensure WorkerState.initialize() "
+                "is called on worker startup via TaskIQ lifecycle hooks."
+            )
+        return instance._store
 
     @classmethod
     def is_initialized(cls) -> bool:
@@ -202,3 +253,24 @@ async def get_worker_checkpointer() -> ResilientAsyncPostgresSaver:
         )
         await WorkerState.initialize()
     return WorkerState.get_checkpointer()
+
+
+async def get_worker_store() -> AsyncPostgresStore:
+    """Get the worker's shared store instance.
+
+    Convenience function for use in tasks. Will lazily initialize
+    the worker state if not already initialized.
+
+    Returns:
+        The worker's shared AsyncPostgresStore instance
+    """
+    if not WorkerState.is_initialized():
+        logger.info(
+            "worker_state_lazy_init",
+            extra={
+                "event": "worker_state_lazy_init",
+                "reason": "lifecycle_hooks_not_fired",
+            },
+        )
+        await WorkerState.initialize()
+    return WorkerState.get_store()

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -23,6 +23,34 @@ from src.workers.broker import broker, REDIS_URL
 from src.utils.stream import get_distributed_stream_key, STREAM_KEY_TTL_SECONDS
 
 
+class _RunScopedStore:
+    """Thin proxy around a shared store that isolates mutable attributes per-run.
+
+    The singleton ``AsyncPostgresStore`` in ``WorkerState`` is shared across
+    concurrent task executions.  Downstream code (``ThreadRepo``, ``LLMController``)
+    mutates ``store.fields`` to control which columns are returned.  Without
+    isolation those mutations leak across tasks.
+
+    This proxy captures ``fields`` on a per-run basis while delegating every
+    other attribute access to the underlying store.
+    """
+
+    __slots__ = ("_store", "fields")
+
+    def __init__(self, store):
+        object.__setattr__(self, "_store", store)
+        object.__setattr__(self, "fields", getattr(store, "fields", []))
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_store"), name)
+
+    def __setattr__(self, name, value):
+        if name in ("fields",):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(object.__getattribute__(self, "_store"), name, value)
+
+
 def _build_stream_metadata(
     *,
     run_id: str,
@@ -105,39 +133,37 @@ async def run_agent_stream(
     stream_key = get_distributed_stream_key(thread_id, run_id)
     redis_client = redis.from_url(REDIS_URL)
 
-    # Write initializing event immediately so clients waiting for the stream
-    # see activity before the heavy init work (model loading, DB connections, etc.)
-    await redis_client.xadd(stream_key, {"data": ujson.dumps(("initializing", {"run_id": run_id}))})
-    await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
-
-    # Pre-start abort check: Handle race condition where abort arrives before task starts
-    if await AbortService.check_abort_signal(thread_id, expected_user_id=user_id):
-        logger.info(
-            "task_pre_aborted",
-            extra={
-                "event": "task_pre_aborted",
-                "thread_id": thread_id,
-                "user_id": user_id,
-            },
-        )
-        # Write abort marker to stream for any listening clients
-        await redis_client.xadd(
-            stream_key,
-            {"data": ujson.dumps(("aborted", {"reason": "pre_aborted"}))},
-        )
-        await redis_client.xadd(stream_key, {"done": "true"})
-        await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
-        # Clear the abort signal
-        await AbortService.clear_abort_signal(thread_id)
-        await redis_client.aclose()
-        return {"status": "aborted", "stream_key": stream_key}
-
     config = None
     files_map = {}
     todos_list = []
     service_context = None
 
     try:
+        # Write initializing event immediately so clients waiting for the stream
+        # see activity before the heavy init work (model loading, DB connections, etc.)
+        await redis_client.xadd(stream_key, {"data": ujson.dumps(("initializing", {"run_id": run_id}))})
+        await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
+
+        # Pre-start abort check: Handle race condition where abort arrives before task starts
+        if await AbortService.check_abort_signal(thread_id, expected_user_id=user_id):
+            logger.info(
+                "task_pre_aborted",
+                extra={
+                    "event": "task_pre_aborted",
+                    "thread_id": thread_id,
+                    "user_id": user_id,
+                },
+            )
+            # Write abort marker to stream for any listening clients
+            await redis_client.xadd(
+                stream_key,
+                {"data": ujson.dumps(("aborted", {"reason": "pre_aborted"}))},
+            )
+            await redis_client.xadd(stream_key, {"done": "true"})
+            await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
+            # Clear the abort signal
+            await AbortService.clear_abort_signal(thread_id)
+            return {"status": "aborted", "stream_key": stream_key}
         # Reconstruct request from dict
         params = LLMRequest(**task_dict)
         params.metadata.user_id = user_id
@@ -157,7 +183,7 @@ async def run_agent_stream(
             from src.workers.state import get_worker_checkpointer, get_worker_store
 
             checkpointer = await get_worker_checkpointer()
-            store = await get_worker_store()
+            store = _RunScopedStore(await get_worker_store())
             service_context = ServiceContext(
                 user_id=user_id,
                 store=store,

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -105,6 +105,11 @@ async def run_agent_stream(
     stream_key = get_distributed_stream_key(thread_id, run_id)
     redis_client = redis.from_url(REDIS_URL)
 
+    # Write initializing event immediately so clients waiting for the stream
+    # see activity before the heavy init work (model loading, DB connections, etc.)
+    await redis_client.xadd(stream_key, {"data": ujson.dumps(("initializing", {"run_id": run_id}))})
+    await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
+
     # Pre-start abort check: Handle race condition where abort arrives before task starts
     if await AbortService.check_abort_signal(thread_id, expected_user_id=user_id):
         logger.info(
@@ -148,31 +153,30 @@ async def run_agent_stream(
 
         # Get checkpointer based on mode
         if CHECKPOINT_USE_RESILIENT:
-            # Use worker-level checkpointer (persistent per worker)
-            from src.workers.state import get_worker_checkpointer
+            # Use worker-level singletons (persistent per worker)
+            from src.workers.state import get_worker_checkpointer, get_worker_store
 
             checkpointer = await get_worker_checkpointer()
-            # Store still uses per-task context manager
-            async with get_store_db() as store:
-                service_context = ServiceContext(
-                    user_id=user_id,
-                    store=store,
-                    config=config,
-                    checkpointer=checkpointer,
-                )
-                return await _execute_agent_stream(
-                    params=params,
-                    config=config,
-                    files_map=files_map,
-                    todos_list=todos_list,
-                    service_context=service_context,
-                    checkpointer=checkpointer,
-                    user_id=user_id,
-                    thread_id=thread_id,
-                    run_id=run_id,
-                    stream_key=stream_key,
-                    redis_client=redis_client,
-                )
+            store = await get_worker_store()
+            service_context = ServiceContext(
+                user_id=user_id,
+                store=store,
+                config=config,
+                checkpointer=checkpointer,
+            )
+            return await _execute_agent_stream(
+                params=params,
+                config=config,
+                files_map=files_map,
+                todos_list=todos_list,
+                service_context=service_context,
+                checkpointer=checkpointer,
+                user_id=user_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                stream_key=stream_key,
+                redis_client=redis_client,
+            )
         else:
             # Legacy mode: per-task checkpointer
             async with (


### PR DESCRIPTION
## Summary

- **Redis resilience**: Subclass `RedisStreamBroker` as `ResilientRedisStreamBroker` with `ConnectionError` retry handling — prevents both workers from crashing simultaneously on Redis connection drops (closes #858)
- **Singleton store**: Add `AsyncPostgresStore` singleton to `WorkerState` managed via `AsyncExitStack`, eliminating orphaned asyncio tasks that accumulate over 19+ hours of uptime (closes #859)
- **SSE streaming fixes**: Add `X-Accel-Buffering: no` header to sync-mode SSE, write "initializing" event to Redis stream immediately on task start, and replace immediate `FileNotFoundError` with 30s wait-loop in `stream_from_redis()` (closes #861)

## Test plan

- [ ] `make test` passes (545 passed, 3 pre-existing failures)
- [ ] Simulate Redis restart (`docker restart orchestra-dev-redis-1`), verify workers reconnect
- [ ] Run worker for extended period, check for absence of "Task was destroyed" warnings
- [ ] Send chat message in production, verify SSE stream delivers response
- [ ] Test with `curl -N` behind nginx to verify `X-Accel-Buffering` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming compatibility with reverse proxies/load balancers by adjusting streaming response headers.
  * Added automatic recovery from temporary connection failures with transparent retries.
  * Operations now wait for unavailable resources (up to a short timeout) and emit periodic waiting events instead of failing immediately.

* **New Features**
  * Faster user feedback via early initialization status updates for long-running tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->