### PR TITLE
feat: add Joyride tour steps for ChatComposer sub-components

### DIFF
--- a/frontend/src/components/chat/ChatUtilityRow.tsx
+++ b/frontend/src/components/chat/ChatUtilityRow.tsx
@@ -99,6 +99,7 @@ export default function ChatUtilityRow() {
 					</Popover>
 				)}
 				<Button
+					data-tour="files-toggle-button"
 					variant="ghost"
 					size="sm"
 					className="h-8 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:text-foreground"

--- a/frontend/src/components/inputs/ChatInput.tsx
+++ b/frontend/src/components/inputs/ChatInput.tsx
@@ -184,6 +184,7 @@ export default function ChatInput({
 						<Popover open={modelOpen} onOpenChange={setModelOpen}>
 							<PopoverTrigger asChild>
 								<button
+									data-tour="model-selector"
 									title="Change default model"
 									className="cursor-pointer hover:opacity-80 transition-opacity"
 								>
@@ -219,12 +220,14 @@ export default function ChatInput({
 							</PopoverContent>
 						</Popover>
 					)}
-					<ChatSubmitButton
-						abortQuery={abortQuery}
-						handleSubmit={handleSubmit}
-						onRecordingChange={setIsRecording}
-						recorderControls={recorderControls}
-					/>
+					<div data-tour="chat-submit-button">
+						<ChatSubmitButton
+							abortQuery={abortQuery}
+							handleSubmit={handleSubmit}
+							onRecordingChange={setIsRecording}
+							recorderControls={recorderControls}
+						/>
+					</div>
 				</div>
 			</div>
 			<ImagePreviewModal

--- a/frontend/src/components/menus/AgentMenu.tsx
+++ b/frontend/src/components/menus/AgentMenu.tsx
@@ -257,6 +257,7 @@ function AgentMenu() {
 			<PopoverTrigger asChild>
 				{agent.id ? (
 					<span
+						data-tour="agent-selector-button"
 						role="combobox"
 						aria-expanded={open}
 						className="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground cursor-pointer hover:bg-accent transition-colors select-none"
@@ -281,6 +282,7 @@ function AgentMenu() {
 					</span>
 				) : (
 					<Button
+						data-tour="agent-selector-button"
 						role="combobox"
 						aria-expanded={open}
 						className="rounded-xl h-9 w-9 p-0 justify-center"

--- a/frontend/src/components/menus/BaseToolMenu.tsx
+++ b/frontend/src/components/menus/BaseToolMenu.tsx
@@ -139,6 +139,7 @@ export function BaseToolMenu() {
 			<DropdownMenu open={open}>
 				<DropdownMenuTrigger asChild>
 					<Button
+						data-tour="tools-menu-button"
 						onClick={() => setOpen(!open)}
 						size="icon"
 						variant="outline"

--- a/frontend/src/components/status/ThreadSandboxStatus.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.tsx
@@ -96,7 +96,10 @@ export default function ThreadSandboxStatus() {
 	};
 
 	return (
-		<div className="flex items-center justify-start">
+		<div
+			className="flex items-center justify-start"
+			data-tour="sandbox-selector"
+		>
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button

--- a/frontend/src/lib/config/onboardingSteps.ts
+++ b/frontend/src/lib/config/onboardingSteps.ts
@@ -34,6 +34,40 @@ export const onboardingSteps: Step[] = [
 		placement: "top",
 	},
 	{
+		target: '[data-tour="sandbox-selector"]',
+		content: "Choose where your code runs — local, cloud, or no sandbox.",
+		placement: "top",
+	},
+	{
+		target: '[data-tour="files-toggle-button"]',
+		content:
+			"Open the file editor to view and edit files alongside your conversation.",
+		placement: "top",
+	},
+	{
+		target: '[data-tour="tools-menu-button"]',
+		content:
+			"Attach images, toggle web search, and configure tools for your assistant.",
+		placement: "top",
+	},
+	{
+		target: '[data-tour="agent-selector-button"]',
+		content:
+			"Select a saved assistant to use its custom instructions and tool configuration.",
+		placement: "top",
+	},
+	{
+		target: '[data-tour="model-selector"]',
+		content: "Switch between AI models to balance speed, cost, and capability.",
+		placement: "top",
+	},
+	{
+		target: '[data-tour="chat-submit-button"]',
+		content:
+			"Send your message, or use the microphone for voice input when the field is empty.",
+		placement: "top",
+	},
+	{
 		target: '[data-tour="chat-nav-actions"]',
 		content:
 			"Save assistants, share threads, start new conversations, and toggle themes.",


### PR DESCRIPTION
## Summary
- Add 6 new onboarding tour steps (sandbox selector, files toggle, tools menu, agent selector, model picker, submit button) between the existing `chat-input` and `chat-nav-actions` steps
- Add `data-tour` attributes to targeted elements across 5 components
- Total tour steps: 9 → 15; conditional elements are skipped gracefully by Joyride

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (341 tests, 0 failures)
- [ ] Manual: replay tour on ThreadPage — all 15 steps appear in sequence
- [ ] Manual: replay tour on non-thread page — conditional steps skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identification markers to key UI controls (model selector, chat submit, agent selector, file toggle, tools menu, sandbox selector)
  * Configured new onboarding steps to guide users through core interface features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->