### PR TITLE
feat: add user timezone configuration in settings

### DIFF
--- a/backend/src/repos/user_settings_repo.py
+++ b/backend/src/repos/user_settings_repo.py
@@ -196,6 +196,7 @@ class UserSettingsRepo(BaseRepo):
         "files": "default_files",
         "deleted_files": "default_deleted_files",
         "onboarding_completed": "onboarding_completed",
+        "timezone": "default_timezone",
     }
 
     async def patch_defaults(self, data: dict) -> UserSettings:

--- a/backend/src/routes/v0/settings.py
+++ b/backend/src/routes/v0/settings.py
@@ -34,6 +34,7 @@ def _build_response(settings: UserSettings, statuses: list[ProviderKeyStatus]) -
             files=settings.default_files,
             deleted_files=settings.default_deleted_files,
             onboarding_completed=settings.onboarding_completed,
+            timezone=settings.default_timezone,
         ),
         provider_keys=statuses,
     )

--- a/backend/src/schemas/entities/settings.py
+++ b/backend/src/schemas/entities/settings.py
@@ -58,6 +58,7 @@ class UserSettings(BaseEntity):
     onboarding_completed: Optional[bool] = Field(
         default=None, description="Whether the user has completed the onboarding tour"
     )
+    default_timezone: Optional[str] = Field(default=None, description="User's preferred IANA timezone identifier")
 
 
 class DefaultsResponse(BaseModel):
@@ -73,6 +74,7 @@ class DefaultsResponse(BaseModel):
     files: Optional[dict[str, PersistedContextFile]] = None
     deleted_files: Optional[list[str]] = None
     onboarding_completed: Optional[bool] = None
+    timezone: Optional[str] = None
 
 
 class UserSettingsResponse(BaseModel):
@@ -103,6 +105,7 @@ class PatchDefaultsRequest(BaseModel):
     onboarding_completed: Optional[bool] = Field(
         default=None, description="Whether the user has completed the onboarding tour"
     )
+    timezone: Optional[str] = Field(default=None, description="IANA timezone identifier, or null to clear")
 
 
 class UpsertProviderKeyRequest(BaseModel):

--- a/frontend/src/components/settings/TimezoneSettings.tsx
+++ b/frontend/src/components/settings/TimezoneSettings.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { toast } from "sonner";
+import { getSettings, patchDefaults } from "@/lib/services/userSettingsService";
+
+const TIMEZONES = Intl.supportedValuesOf("timeZone");
+const BROWSER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export function TimezoneSettings() {
+	const [open, setOpen] = useState(false);
+	const [timezone, setTimezone] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		getSettings()
+			.then((res) => setTimezone(res.defaults.timezone))
+			.catch(() => {});
+	}, []);
+
+	const handleSelect = async (tz: string) => {
+		setOpen(false);
+		setLoading(true);
+		try {
+			const res = await patchDefaults({ timezone: tz });
+			setTimezone(res.defaults.timezone);
+			toast.success("Timezone updated");
+		} catch {
+			toast.error("Failed to update timezone");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleClear = async () => {
+		setLoading(true);
+		try {
+			const res = await patchDefaults({ timezone: null });
+			setTimezone(res.defaults.timezone);
+			toast.success("Timezone reset to auto-detect");
+		} catch {
+			toast.error("Failed to clear timezone");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Timezone</CardTitle>
+				<CardDescription>
+					Choose your preferred timezone for AI responses. When not set, your
+					browser timezone is used ({BROWSER_TIMEZONE}).
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="flex items-center gap-2">
+					<Popover open={open} onOpenChange={setOpen}>
+						<PopoverTrigger asChild>
+							<Button
+								variant="outline"
+								role="combobox"
+								aria-expanded={open}
+								disabled={loading}
+								className="w-full max-w-sm justify-between"
+							>
+								<span className="truncate">
+									{timezone || `Auto-detect (${BROWSER_TIMEZONE})`}
+								</span>
+								<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent className="w-[300px] p-0">
+							<Command>
+								<CommandInput placeholder="Search timezones..." />
+								<CommandList>
+									<CommandEmpty>No timezone found.</CommandEmpty>
+									<CommandGroup>
+										{TIMEZONES.map((tz) => (
+											<CommandItem key={tz} value={tz} onSelect={handleSelect}>
+												<Check
+													className={cn(
+														"mr-2 h-4 w-4",
+														timezone === tz ? "opacity-100" : "opacity-0",
+													)}
+												/>
+												{tz.replace(/_/g, " ")}
+											</CommandItem>
+										))}
+									</CommandGroup>
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					</Popover>
+					{timezone && (
+						<Button
+							variant="ghost"
+							size="icon"
+							disabled={loading}
+							onClick={handleClear}
+							title="Reset to auto-detect"
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -22,6 +22,7 @@ import {
 	upsertActiveStreamRecovery,
 } from "@/lib/utils/activeStreamRecovery";
 import { toast } from "sonner";
+import { getSettings } from "@/lib/services/userSettingsService";
 
 type StreamMode = "messages" | "values" | "updates" | "debug" | "tasks";
 
@@ -125,6 +126,14 @@ export default function useChat(): ChatContextType {
 		startTime: number;
 		rate: number | null;
 	} | null>(null);
+
+	const [savedTimezone, setSavedTimezone] = useState<string | null>(null);
+
+	useEffect(() => {
+		getSettings()
+			.then((res) => setSavedTimezone(res.defaults.timezone))
+			.catch(() => {});
+	}, []);
 
 	const [arcade, setArcade] = useState({
 		tools: [] as string[],
@@ -583,7 +592,8 @@ export default function useChat(): ChatContextType {
 			...metadata,
 			assistant_id: agent.id,
 			current_utc: new Date().toISOString(),
-			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+			timezone:
+				savedTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
 			language: Intl.DateTimeFormat().resolvedOptions().locale,
 		};
 	};

--- a/frontend/src/lib/services/userSettingsService.ts
+++ b/frontend/src/lib/services/userSettingsService.ts
@@ -24,6 +24,7 @@ export interface DefaultsResponse {
 	files: Record<string, PersistedContextFile> | null;
 	deleted_files: string[] | null;
 	onboarding_completed: boolean | null;
+	timezone: string | null;
 }
 
 export interface UserSettingsResponse {
@@ -48,6 +49,7 @@ export const patchDefaults = async (
 		files: Record<string, PersistedContextFile> | null;
 		deleted_files: string[] | null;
 		onboarding_completed: boolean | null;
+		timezone: string | null;
 	}>,
 ): Promise<UserSettingsResponse> => {
 	const response = await apiClient.patch("/settings/default", data);

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -2,6 +2,7 @@ import { ApiTokensSettings } from "@/components/settings/ApiTokensSettings";
 import { DefaultModelSettings } from "@/components/settings/DefaultModelSettings";
 import { SandboxSettings } from "@/components/settings/SandboxSettings";
 import { ModelVisibilitySettings } from "@/components/settings/ModelVisibilitySettings";
+import { TimezoneSettings } from "@/components/settings/TimezoneSettings";
 import { UserApiKeysSettings } from "@/components/settings/UserApiKeysSettings";
 import ChatLayout from "@/layouts/chat-layout-v2";
 import { ChatNav } from "@/components/nav/ChatNav";
@@ -25,6 +26,7 @@ export default function SettingsPage() {
 								</div>
 
 								<DefaultModelSettings />
+								<TimezoneSettings />
 								<SandboxSettings />
 								<UserApiKeysSettings />
 								<ApiTokensSettings />


### PR DESCRIPTION
## Summary
- Adds a persistent timezone setting so users can override the browser-detected timezone
- New `TimezoneSettings` component with searchable IANA timezone combobox on the settings page
- Chat metadata uses the saved timezone preference (falls back to browser auto-detect when unset)

## Changes
| File | Action |
|------|--------|
| `backend/src/schemas/entities/settings.py` | Add `default_timezone` field + API types |
| `backend/src/repos/user_settings_repo.py` | Add timezone to field map |
| `backend/src/routes/v0/settings.py` | Include timezone in response |
| `frontend/src/lib/services/userSettingsService.ts` | Add timezone to TS types |
| `frontend/src/components/settings/TimezoneSettings.tsx` | **New** timezone picker |
| `frontend/src/pages/settings/index.tsx` | Render TimezoneSettings |
| `frontend/src/hooks/useChat.ts` | Use saved timezone in chat metadata |

## Test plan
- [ ] Backend tests pass (`make test`) — 554 passed
- [ ] Frontend tests pass (`npm run test`) — 341 passed
- [ ] Set timezone via settings page, refresh, confirm it persists
- [ ] Clear timezone, confirm reverts to auto-detect
- [ ] Send a chat message, verify AI receives correct timezone in system prompt
- [ ] PATCH `/api/settings/default` with `{"timezone": "America/New_York"}` returns updated setting
- [ ] PATCH `/api/settings/default` with `{"timezone": null}` clears the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)