### PR TITLE
fix: re-add sandboxes submodule, standardize agent-browser viewport

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -75,6 +75,7 @@ Three types:
 
 ## Defaults
 
+- **Default viewport**: 1920x1080 — run `agent-browser set viewport 1920 1080` after opening any page (matches video-gif-generation recording ratio)
 - **Default test URL**: `http://localhost:5173`
 - **Default login credentials**: `admin@example.com` / `test1234`
 - **Default screenshot mode**: Light mode (run `agent-browser set media light` before capturing) — required when creating docs for `@wiki`
@@ -96,11 +97,13 @@ If the running server's working directory does NOT match the current worktree, s
 ## Agent Workflow
 
 1. **Check dev server** (see above) — start one if needed
-2. **Navigate + snapshot**: `agent-browser open <url> && agent-browser snapshot --json`
-3. **Parse refs** from JSON output to identify interactive elements
-4. **Act** using refs: `agent-browser click @e2`, `agent-browser fill @e3 "hello"`
-5. **Re-snapshot** after each action to observe new state
-6. **Screenshot** when visual verification is needed (light mode for wiki docs)
+2. **Navigate**: `agent-browser open <url>`
+3. **Set viewport**: `agent-browser set viewport 1920 1080` (always, before any interaction)
+4. **Snapshot**: `agent-browser snapshot --json` to get element refs
+5. **Parse refs** from JSON output to identify interactive elements
+6. **Act** using refs: `agent-browser click @e2`, `agent-browser fill @e3 "hello"`
+7. **Re-snapshot** after each action to observe new state
+8. **Screenshot** when visual verification is needed (light mode for wiki docs)
 
 ## JSON Output
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "wiki"]
 	path = wiki
 	url = git@github.com:ruska-ai/wiki.git
+[submodule "sandboxes"]
+	path = sandboxes
+	url = https://github.com/ruska-ai/sandboxes


### PR DESCRIPTION
## Summary
- Re-adds `sandboxes` git submodule (`https://github.com/ruska-ai/sandboxes`) for exec_server MCP sandbox development
- Updates agent-browser skill to default viewport to 1920x1080 (matching video-gif-generation ratio)
- Updates agent-browser workflow to include viewport setup step

## Test plan
- [x] `exec_server` container builds and starts via `COMPOSE_PROFILES=tools docker compose -f docker-compose.services.yml up exec_server --build -d`
- [x] Health check passes: `curl http://localhost:3005/health` returns `{"status":"ok"}`
- [x] MCP tool discovery works from Orchestra UI (exec_command renders)
- [x] MCP tool execution works end-to-end (validated via agent-browser headed mode)
- [ ] Verify `git submodule update --init sandboxes` works on fresh clone

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent workflow documentation with improved step organization for page navigation, default viewport configuration (1920x1080), and snapshot operations.

* **Chores**
  * Integrated sandboxes repository as a new git submodule dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->