### PR TITLE
feat: MCP Sandbox backend, dispatch, frontend UX, and native tool overrides (#890)

### DIFF
--- a/.claude/plans/cryptic-enchanting-wave.md
+++ b/.claude/plans/cryptic-enchanting-wave.md
@@ -1,0 +1,1337 @@
+# Plan: Generate Specs for MCP Sandbox Backend (#890 + sandboxes#3)
+
+## Context
+
+Orchestra needs `McpSandboxBackend(BaseSandbox)` to connect DeepAgents to the `ruska-ai/sandboxes` exec_server via MCP JSON-RPC 2.0 over Streamable HTTP. This is a two-repo effort:
+
+- **orchestra#890**: New `McpSandboxBackend` class, wired into sandbox dispatch with Daytona -> MCP -> State fallback chain, frontend selector update
+- **sandboxes#3**: exec_server enhancements (structured `_meta` exit_code, `upload_file`/`download_file` tools, sandbox ID)
+
+The key constraint is **backward compatibility**: Phase 1 must work with the CURRENT exec_server (text-embedded exit_code, no file transfer tools). Later phases leverage structured responses.
+
+## Approach
+
+Generate **5 specs** in the `.claude/specs/feat-890-mcp-sandbox/` directory, organized in dependency order with clear parallelization opportunities.
+
+## BaseSandbox Full Tool Parity Requirement
+
+`McpSandboxBackend(BaseSandbox)` must support ALL DeepAgents sandbox tools. `BaseSandbox` (from `deepagents.backends.sandbox`) provides inherited implementations for most — they all delegate to `execute()` via shell commands. Only 4 methods are abstract and must be implemented:
+
+| Method | Abstract? | How it works |
+|--------|-----------|--------------|
+| `execute(command, *, timeout) -> ExecuteResponse` | **YES** | MCP JSON-RPC `tools/call` to `execute` |
+| `id -> str` | **YES** | Sandbox identifier property |
+| `upload_files(files) -> list[FileUploadResponse]` | **YES** | Base64 via `upload_file` tool or shell fallback |
+| `download_files(paths) -> list[FileDownloadResponse]` | **YES** | Base64 via `download_file` tool or shell fallback |
+| `read(file_path, offset, limit) -> str` | Inherited | Delegates to `execute()` via `_READ_COMMAND_TEMPLATE` (python3 heredoc) |
+| `write(file_path, content) -> WriteResult` | Inherited | Delegates to `execute()` via `_WRITE_COMMAND_TEMPLATE` (python3 heredoc) |
+| `edit(file_path, old, new, replace_all) -> EditResult` | Inherited | Delegates to `execute()` via `_EDIT_COMMAND_TEMPLATE` (python3 heredoc) |
+| `grep_raw(pattern, path, glob) -> list[GrepMatch]` | Inherited | Delegates to `execute()` via `grep -rHnF` command |
+| `ls_info(path) -> list[FileInfo]` | Inherited | Delegates to `execute()` via `os.scandir` python3 command |
+| `glob_info(pattern, path) -> list[FileInfo]` | Inherited | Delegates to `execute()` via `_GLOB_COMMAND_TEMPLATE` (python3 heredoc) |
+
+**Critical**: All inherited methods depend on `execute()` returning a proper `ExecuteResponse` with integer `exit_code`. The python3 heredoc commands use `sys.exit(N)` for error signaling — exit codes 1-4 have semantic meaning in `edit()`. The sandbox container MUST have `python3` available (the Dockerfile installs Node.js 22 on Debian bookworm which includes python3).
+
+**Return types**: `FileUploadResponse(path, error?)`, `FileDownloadResponse(path, content?, error?)`, `WriteResult(error?, path?, files_update?)`, `EditResult(error?, path?, files_update?, occurrences?)`, `ExecuteResponse(output, exit_code?, truncated?)`.
+
+## Architectural Decisions
+
+1. **Python3 required**: The sandbox container spec mandates `python3` availability. No shell fallbacks for inherited BaseSandbox tools — they work via `execute()` delegation to python3 heredoc commands.
+
+2. **Timeout pass-through**: `McpSandboxBackend.execute(command, timeout=N)` forwards the timeout parameter to the MCP JSON-RPC call. The exec_server already enforces a 120s max, so this respects existing limits while allowing shorter timeouts for specific operations.
+
+3. **Conformance test suite**: Spec 004 includes a portable conformance test script in `ruska-ai/sandboxes` that any sandbox implementation can run to self-certify it meets the BaseSandbox contract (execute, upload_file, download_file, _meta, sandbox_id, python3 availability).
+
+4. **Persistent session with reconnect**: `McpSandboxBackend` creates one MCP session on first `execute()` call and reuses it across all subsequent calls. If a call fails with a session error (e.g., exec_server restarted), it re-initializes the session and retries once before propagating the error.
+
+5. **Working directory convention (OpenClaw model)**: `/workspace` is the default working directory, structured after the [OpenClaw Agent Workspace](https://docs.openclaw.ai/concepts/agent-workspace) filesystem model. The sandbox initializes with the following layout:
+
+```
+/workspace/
+├── AGENTS.md          # Operating instructions for the agent (loaded each session)
+├── SOUL.md            # Agent persona, tone, behavioral boundaries (loaded each session)
+├── USER.md            # User identity and communication preferences (loaded each session)
+├── IDENTITY.md        # Agent name, identity metadata
+├── TOOLS.md           # Notes about available tools and conventions
+├── MEMORY.md          # Curated long-term memory (agent-writable)
+├── memory/            # Daily memory logs (YYYY-MM-DD.md)
+├── skills/            # Workspace-specific skills
+└── canvas/            # Optional UI/output files
+```
+
+Relative paths in all tools resolve relative to `/workspace`. Agents can still access `/tmp` and other system paths, but the OpenClaw-modeled workspace ensures consistent agent context across sandbox implementations. The Dockerfile/entrypoint creates this layout on container startup with empty template files.
+
+6. **Clean rename**: `exec_command` is renamed directly to `execute`. No backward compatibility alias — no other consumers exist yet. Orchestra Spec 001 targets the new name from the start.
+
+7. **JSON lines output format**: `grep`, `glob`, and `ls` MCP tools return newline-delimited JSON objects as text, matching the exact format that BaseSandbox's inherited python3 heredoc commands produce. This means McpSandboxBackend v2 uses identical parsing logic whether using native MCP tools or inherited shell fallbacks.
+
+8. **Full session lifecycle in conformance tests**: The conformance test suite validates init, session reuse across calls, concurrent requests, session cleanup (DELETE `/mcp`), and reconnect after server restart.
+
+9. **Agent tool sync for FileEditorPanel**: When the agent writes/edits/reads files on the sandbox, those files automatically appear in FileEditorPanel via the existing SSE stream (`files` in values event). No independent sandbox browsing — reviewer sees files the agent created/modified. This requires no new API endpoints; the existing streaming mechanism already syncs `agent.files` to the panel.
+
+10. **Live connection status**: MCP sandbox option shows a green/red dot indicating exec_server reachability. Health check runs on page load and when the sandbox selector dropdown is opened. No background polling.
+
+11. **User-approved fallback toast**: When MCP sandbox is unreachable and user sends a message, a toast appears: "MCP sandbox unreachable" with a "Use State for this message" action button. One click retries with State backend for that message only. MCP stays selected for future messages. This replaces the silent auto-fallback in `controllers/llm.py` and `utils/stream.py`.
+
+## Spec Breakdown
+
+### Spec 001: McpSandboxBackend Core Class (Foundation)
+**File**: `.claude/specs/feat-890-mcp-sandbox/001-mcp-sandbox-backend.md`
+
+Creates `backend/src/agents/mcp_sandbox.py` with:
+- `McpSandboxBackend(BaseSandbox)` implementing all 4 abstract methods: `execute()`, `id`, `upload_files()`, `download_files()`
+- All 6 inherited methods (`read`, `write`, `edit`, `grep_raw`, `ls_info`, `glob_info`) work automatically via `execute()` delegation
+- MCP JSON-RPC 2.0 client via `httpx` (already in deps) — POST to `/mcp` endpoint
+- `execute(command, *, timeout=None)` forwards timeout to MCP call; exec_server enforces 120s max
+- Text-embedded `exit_code: N` regex parser (works with current exec_server)
+- Shell-based file transfer: `upload_files()` uses base64 encode + `echo | base64 -d > path`, `download_files()` uses `base64 path` and decodes result — returns proper `FileUploadResponse`/`FileDownloadResponse` with per-file error handling
+- **Persistent session with reconnect**: lazy session init on first `execute()`, reused across calls. On session error, re-initializes and retries once before raising
+- Health check via GET `/health`
+- Unit tests in `backend/tests/unit/agents/test_mcp_sandbox.py`
+
+**Files**: `backend/src/agents/mcp_sandbox.py` (NEW), `backend/tests/unit/agents/test_mcp_sandbox.py` (NEW)
+
+---
+
+### Spec 002: Sandbox Dispatch Wiring (Depends on 001)
+**File**: `.claude/specs/feat-890-mcp-sandbox/002-sandbox-dispatch.md`
+
+Wires MCP into the existing sandbox system. **No hardcoded `MCP_SANDBOX_URL` env var** — the sandbox URL is user-configurable via the settings page and stored in `UserSettings`.
+
+- Add `MCP = "mcp"` to `SandboxType` enum (`backend/src/schemas/entities/settings.py`)
+- Add `default_mcp_sandbox_url: Optional[str]` field to `UserSettings` entity — user-configured sandbox endpoint
+- Add `mcp_sandbox_url` to `PatchDefaultsRequest` and `DefaultsResponse` schemas
+- Add `_create_mcp_backend_checked()` factory (`backend/src/agents/__init__.py`) — reads sandbox URL from user settings (not env var)
+- Register `"mcp"` in `_SANDBOX_FACTORIES`
+- Update `resolve_sandbox_backend()` to accept the user's sandbox URL and pass it to the factory
+- Update fallback chain: Daytona -> MCP (if URL configured) -> State
+- MCP sandbox option only available when `default_mcp_sandbox_url` is set in user settings
+- Add MCP error handling to `backend/src/controllers/llm.py` and `backend/src/utils/stream.py`
+
+**Files**: `settings.py`, `agents/__init__.py`, `controllers/llm.py`, `utils/stream.py`, `repos/user_settings_repo.py`
+
+---
+
+### Spec 003: Frontend MCP Sandbox Option + Health Indicator + Fallback UX (Independent — parallel with 001/002)
+**File**: `.claude/specs/feat-890-mcp-sandbox/003-frontend-mcp-option.md`
+
+Adds MCP to the frontend sandbox selector with live health indicator and user-approved fallback:
+
+**Type & config changes**:
+- Extend `SandboxType` union with `"mcp"` (`frontend/src/lib/services/userSettingsService.ts`)
+- Add MCP entry to `SANDBOX_OPTIONS` array (`frontend/src/lib/config/sandbox.ts`)
+- Update `normalizeSandboxValue()` to recognize `"mcp"`
+
+**MCP Sandbox visibility gating**:
+- MCP Sandbox option ONLY appears in the selector when the user has configured `mcp_sandbox_url` in their settings
+- Similar to how Daytona only shows when `DAYTONA_API_KEY` is set
+- New "MCP Sandbox URL" input field in settings page (below sandbox selector) — user enters their sandbox endpoint (e.g., `http://localhost:3005/mcp`)
+- URL is persisted via `patchDefaults({ mcp_sandbox_url: "..." })` to backend
+
+**Health indicator** (green/red dot):
+- New `useSandboxHealth()` hook that pings the user's configured sandbox URL `/health` endpoint
+- Runs on page load + when sandbox selector dropdown is opened
+- Shows green dot (reachable) or red dot (unreachable) next to "MCP Sandbox" in both `SandboxSettings.tsx` and `ThreadSandboxStatus.tsx`
+- Health endpoint URL derived from user's `mcp_sandbox_url` setting (strip `/mcp`, append `/health`)
+
+**User-approved fallback toast**:
+- When MCP sandbox is selected and agent execution fails due to unreachable exec_server:
+  - Backend returns a specific error type (e.g., `mcp_sandbox_unreachable`)
+  - Frontend shows toast: "MCP sandbox unreachable" with "Use State for this message" action button
+  - Clicking the button retries the same message with `sandbox_type=state` override
+  - MCP stays selected as the default for future messages
+- Requires: new error response type from backend, frontend toast handler in chat/stream flow
+
+**Files**: `userSettingsService.ts`, `sandbox.ts`, `SandboxSettings.tsx`, `ThreadSandboxStatus.tsx`, new `useSandboxHealth.ts` hook, chat stream error handler
+
+---
+
+### Spec 004: exec_server BaseSandbox-Conformant MCP Tools + Conformance Tests (Independent — parallel with 001/002/003)
+**File**: `.claude/specs/feat-890-mcp-sandbox/004-exec-server-structured.md`
+
+Enhances `sandboxes/ubuntu/index.js` to expose MCP tools that mirror the full `BaseSandbox` protocol 1:1. Any sandbox that conforms to this spec is a drop-in DeepAgents sandbox backend.
+
+**MCP Tools (maps to BaseSandbox protocol)**:
+
+| MCP Tool | BaseSandbox Method | Params | Returns |
+|----------|-------------------|--------|---------|
+| `execute` (renamed from exec_command) | `execute()` | `{cmd, timeout?}` | text output + `_meta.exit_code` (int) |
+| `read` (NEW) | `read()` | `{path, offset?, limit?}` | cat -n formatted content + `_meta.exit_code` |
+| `write` (NEW) | `write()` | `{path, content}` | success/error + `_meta.exit_code` |
+| `edit` (NEW) | `edit()` | `{path, old_string, new_string, replace_all?}` | occurrence count + `_meta.exit_code` (0=ok, 1=not found, 2=multiple, 3=file missing) |
+| `grep` (NEW) | `grep_raw()` | `{pattern, path?, glob?}` | JSON lines `{path, line, text}` + `_meta.exit_code` |
+| `glob` (NEW) | `glob_info()` | `{pattern, path?}` | JSON lines `{path, is_dir, size?, mtime?}` + `_meta.exit_code` |
+| `ls` (NEW) | `ls_info()` | `{path}` | JSON lines `{path, is_dir}` + `_meta.exit_code` |
+| `upload_file` (NEW) | `upload_files()` | `{path, content_base64}` | success/error + `_meta.exit_code` |
+| `download_file` (NEW) | `download_files()` | `{path}` | base64 content + `_meta.exit_code` |
+
+**Additional changes**:
+- **Rename** `exec_command` → `execute` (clean break, no alias)
+- Structured `_meta.exit_code` in ALL tool responses (integer, not text-embedded)
+- `_meta.sandbox_id` in ALL tool responses
+- Sandbox ID via `crypto.randomUUID()` in `/health` and `_meta`
+- `execute` keeps text-embedded `exit_code: N` for backward compat during Phase 1
+- **python3 required**: Dockerfile must ensure python3 is available
+- **Working directory (OpenClaw model)**: `/workspace` is the default cwd, initialized with the OpenClaw workspace layout (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md, MEMORY.md, memory/, skills/, canvas/). Dockerfile/entrypoint creates this structure on container startup.
+- **Exit code semantics**: `edit` uses codes 0-4 matching BaseSandbox's `_EDIT_COMMAND_TEMPLATE`; `write` returns exit_code=1 if file exists
+- **JSON lines format**: `grep`, `glob`, `ls` return newline-delimited JSON objects (matching BaseSandbox's python3 heredoc output format)
+
+**Conformance test suite** (`sandboxes/tests/conformance.sh`):
+- Validates ALL 9 MCP tools registered and functional
+- Tests exit_code semantics for each tool (success + error cases)
+- Tests `sandbox_id` in `/health` and `_meta`
+- Tests `python3` availability
+- Tests timeout behavior (120s max enforced)
+- Tests `/workspace` as default working directory with OpenClaw layout (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md, MEMORY.md, memory/, skills/, canvas/)
+- **Session lifecycle tests**: init, session reuse across multiple calls, concurrent requests (parallel curl), session cleanup (DELETE `/mcp`), reconnect after session expiry
+- Any new sandbox image runs this to self-certify BaseSandbox compatibility
+
+**Files**: `sandboxes/ubuntu/index.js`, `sandboxes/ubuntu/Dockerfile` (ensure python3), `sandboxes/tests/conformance.sh` (NEW)
+
+---
+
+### Spec 005: McpSandboxBackend v2 — Native MCP Tools for Full BaseSandbox (Depends on 002 + 004)
+**File**: `.claude/specs/feat-890-mcp-sandbox/005-mcp-sandbox-v2.md`
+
+Upgrades McpSandboxBackend to use native MCP tools for ALL BaseSandbox operations, overriding the inherited shell-delegation implementations when the exec_server supports them:
+
+**Native MCP tool overrides** (replaces inherited shell-based implementations):
+
+| BaseSandbox Method | Spec 001 (shell fallback) | Spec 005 (native MCP) |
+|---|---|---|
+| `execute()` | `execute` + text-parse exit_code | `execute` + `_meta.exit_code` |
+| `read()` | Inherited python3 heredoc via `execute()` | Native `read` MCP tool |
+| `write()` | Inherited python3 heredoc via `execute()` | Native `write` MCP tool |
+| `edit()` | Inherited python3 heredoc via `execute()` | Native `edit` MCP tool |
+| `grep_raw()` | Inherited `grep -rHnF` via `execute()` | Native `grep` MCP tool |
+| `glob_info()` | Inherited python3 heredoc via `execute()` | Native `glob` MCP tool |
+| `ls_info()` | Inherited python3 scandir via `execute()` | Native `ls` MCP tool |
+| `upload_files()` | Shell base64 via `execute()` | Native `upload_file` MCP tool |
+| `download_files()` | Shell base64 via `execute()` | Native `download_file` MCP tool |
+
+**Key behaviors**:
+- **Tool discovery on session init**: Calls `tools/list` and caches available tool names. Uses native MCP tools when available, falls back to inherited shell implementations when not.
+- **Dual-mode exit_code**: Prefers `_meta.exit_code` (structured int), falls back to text-parsing regex for older exec_servers.
+- **`_meta.sandbox_id`** for `id` property when available.
+- **Return type parity**: Native tools return the same `ExecuteResponse`, `WriteResult`, `EditResult`, `GrepMatch`, `FileInfo`, `FileUploadResponse`, `FileDownloadResponse` types — parsing MCP responses into the exact same structures.
+- **Graceful degradation**: If exec_server only has `execute` (no native tools), all inherited methods still work via `execute()` delegation.
+
+**Files**: `backend/src/agents/mcp_sandbox.py`, `backend/tests/unit/agents/test_mcp_sandbox.py`
+
+## Dependency Graph & Parallelization
+
+```
+Spec 001 ──> Spec 002 ──────────────> Spec 005
+                                        ^
+Spec 003 (independent, parallel)        |
+                                        |
+Spec 004 (independent, parallel) ───────┘
+```
+
+**Optimal execution**: Specs 001, 003, 004 can start simultaneously. Spec 002 waits for 001. Spec 005 waits for 002 + 004.
+
+## Critical Files to Modify
+
+| File | Spec | Action |
+|------|------|--------|
+| `backend/src/agents/mcp_sandbox.py` | 001, 005 | CREATE |
+| `backend/src/agents/__init__.py` | 002 | MODIFY (factory + dispatch) |
+| `backend/src/schemas/entities/settings.py` | 002 | MODIFY (SandboxType enum + `default_mcp_sandbox_url` field) |
+| `backend/src/controllers/llm.py` | 002 | MODIFY (error handling) |
+| `backend/src/utils/stream.py` | 002 | MODIFY (error handling) |
+| `frontend/src/lib/services/userSettingsService.ts` | 003 | MODIFY (SandboxType) |
+| `frontend/src/lib/config/sandbox.ts` | 003 | MODIFY (options + normalizer) |
+| `sandboxes/ubuntu/index.js` | 004 | MODIFY (structured responses) |
+| `sandboxes/ubuntu/Dockerfile` | 004 | MODIFY (ensure python3) |
+| `sandboxes/tests/conformance.sh` | 004 | CREATE (conformance test suite) |
+| `backend/tests/unit/agents/test_mcp_sandbox.py` | 001, 005 | CREATE |
+
+## Reusable Patterns
+
+- **Factory pattern**: Follow `_create_daytona_backend_checked()` in `backend/src/agents/__init__.py:277-301`
+- **Validation**: Follow `validate_daytona_execute_capability()` in `backend/src/agents/daytona.py:6-18`
+- **Error handling**: Follow Daytona fallback pattern in `backend/src/controllers/llm.py:162-196`
+- **HTTP client**: Use `httpx.AsyncClient()` pattern from `backend/src/common/client/client.py`
+- **Frontend config**: Follow existing `SANDBOX_OPTIONS` pattern in `frontend/src/lib/config/sandbox.ts`
+
+## QA Plan: Step-by-Step User Story Validation (Front-to-Back)
+
+Each spec includes a QA story that validates the full user workflow. Use the **agent-browser** skill (viewport 1920x1080) for all UI-facing validations (screenshots, clicks, form interactions). Backend validations use curl + test commands.
+
+**Default ports**: frontend=5173, backend=8000, sandbox=3005
+
+---
+
+### QA-001: McpSandboxBackend Core Class (after Spec 001)
+
+**Precondition**: exec_server running at `http://localhost:3005` via `COMPOSE_PROFILES=tools make dev.docker.up`
+
+**Backend unit tests**:
+```bash
+cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v
+```
+
+**Manual integration validation**:
+```bash
+# 1. Verify exec_server health
+curl http://localhost:3005/health
+# Expected: {"status":"ok","sessions":0}
+
+# 2. Test MCP JSON-RPC initialize (get session)
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' \
+  -D -
+# Expected: 200 OK with Mcp-Session-Id header in response
+
+# 3. Test execute via tools/call
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session_id_from_step_2>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"execute","arguments":{"cmd":"echo hello && echo exit_code: 0"}}}'
+# Expected: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"...exit_code: 0"}]}}
+
+# 4. Test exit_code parsing for failure case
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session_id_from_step_2>" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute","arguments":{"cmd":"ls /nonexistent"}}}'
+# Expected: text contains "exit_code: 2" (or non-zero)
+
+# 5. Test upload via shell fallback (base64 round-trip)
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session_id_from_step_2>" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"execute","arguments":{"cmd":"echo aGVsbG8gd29ybGQ= | base64 -d > /tmp/test.txt && cat /tmp/test.txt"}}}'
+# Expected: text contains "hello world"
+```
+
+**Pass criteria**: All unit tests green. Manual curl commands return expected responses.
+
+---
+
+### QA-002: Sandbox Dispatch Wiring (after Spec 002)
+
+**Precondition**: Backend running, user `admin@example.com` has configured `mcp_sandbox_url` in settings
+
+**Backend unit tests**:
+```bash
+cd backend && uv run pytest tests/unit/agents/ -v
+```
+
+**Dispatch logic validation**:
+```bash
+# 1. Verify SandboxType enum includes MCP
+cd backend && uv run python -c "from src.schemas.entities.settings import SandboxType; print(SandboxType.MCP)"
+# Expected: SandboxType.MCP
+
+# 2. Verify NO hardcoded MCP_SANDBOX_URL constant (user-configured only)
+cd backend && uv run python -c "from src.constants import __dict__ as c; print('MCP_SANDBOX_URL' not in c)"
+# Expected: True (no constant — URL comes from user settings)
+
+# 3. Verify factory registration
+cd backend && uv run python -c "from src.agents import _SANDBOX_FACTORIES; print(list(_SANDBOX_FACTORIES.keys()))"
+# Expected: ['daytona', 'state', 'mcp']
+
+# 4. Test resolve_sandbox_backend with sandbox_type="mcp" (exec_server running)
+cd backend && uv run python -c "
+from src.agents import resolve_sandbox_backend
+from deepagents.core.types import ToolRuntime
+runtime = ToolRuntime(tools=[], mcp={}, exec_server_url='')
+backend, sandbox, effective = resolve_sandbox_backend(runtime, sandbox_type='mcp')
+print(f'effective_type={effective}, backend={type(backend).__name__}')
+"
+# Expected: effective_type=mcp (if exec_server running) or effective_type=state (if not)
+
+# 5. Test auto fallback chain (exec_server stopped)
+# Stop exec_server, then:
+cd backend && uv run python -c "
+from src.agents import resolve_sandbox_backend
+from deepagents.core.types import ToolRuntime
+runtime = ToolRuntime(tools=[], mcp={}, exec_server_url='')
+backend, sandbox, effective = resolve_sandbox_backend(runtime, sandbox_type=None)
+print(f'effective_type={effective}')
+"
+# Expected: effective_type=state (graceful fallback)
+```
+
+**API endpoint validation**:
+```bash
+# 6. Login to get auth token
+TOKEN=$(curl -s -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@example.com","password":"test1234"}' | jq -r '.access_token')
+
+# 7. Set sandbox to MCP via settings API
+curl -s -X PATCH http://localhost:8000/api/settings/default \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"sandbox":"mcp"}'
+# Expected: {"defaults":{"sandbox":"mcp",...}}
+
+# 8. Invoke LLM with MCP sandbox active (exec_server running)
+curl -s -X POST http://localhost:8000/api/llm/invoke \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"input":{"input":"Run: echo hello from MCP sandbox"},"model":"gpt-4o-mini","instructions":"Execute the requested command"}'
+# Expected: Response includes output from exec_server execution
+
+# 9. Test fallback: stop exec_server, invoke again
+# Expected: Falls back to state backend, no crash
+```
+
+**Pass criteria**: All unit tests green. Factory registered. Dispatch resolves correctly for all sandbox_type values. API endpoints work with MCP sandbox.
+
+---
+
+### QA-003: Frontend MCP Sandbox Option (after Spec 003)
+
+**Precondition**: Frontend dev server running on :5173 (`cd frontend && npm run dev`), backend running on :8000
+
+**Frontend unit tests**:
+```bash
+cd frontend && npm run test
+```
+
+**agent-browser UI validation** (step-by-step user story):
+
+```
+Story: User selects MCP sandbox from the settings page
+
+1. NAVIGATE to http://localhost:5173/settings
+   - SCREENSHOT: Verify settings page loads
+
+2. SCROLL to "Default Sandbox" card
+   - SCREENSHOT: Verify SandboxSettings card is visible
+
+3. CLICK the sandbox selector dropdown
+   - SCREENSHOT: Verify dropdown shows options including "MCP Sandbox"
+   - VERIFY: "State (Default)" option is present
+   - VERIFY: "MCP Sandbox" option is present with description "Run agent code in an isolated MCP sandbox container."
+
+4. SELECT "MCP Sandbox" option
+   - SCREENSHOT: Verify selection persists (toast shows "Default sandbox updated")
+   - VERIFY: Dropdown now shows "MCP Sandbox" as selected
+
+5. REFRESH the page (navigate away and back to /settings)
+   - SCREENSHOT: Verify "MCP Sandbox" is still selected after page reload (persisted to backend)
+```
+
+```
+Story: User selects MCP sandbox from the chat thread status bar
+
+1. NAVIGATE to http://localhost:5173 (chat page)
+   - SCREENSHOT: Verify chat interface loads
+
+2. LOCATE the sandbox selector button in ChatUtilityRow (bottom of chat input area)
+   - SCREENSHOT: Verify button shows current sandbox (e.g., "Sandbox State")
+
+3. CLICK the sandbox status button to open popover
+   - SCREENSHOT: Verify popover opens with sandbox options
+   - VERIFY: "MCP Sandbox" option is listed
+   - VERIFY: Option has label "MCP Sandbox" and short label "MCP"
+
+4. CLICK "MCP Sandbox" option
+   - SCREENSHOT: Verify selection updates (toast shows "Sandbox updated")
+   - VERIFY: Button now shows "Sandbox MCP"
+
+5. CLICK the sandbox status button again to verify checkmark
+   - SCREENSHOT: Verify checkmark appears next to "MCP Sandbox"
+```
+
+```
+Story: Exercise ALL BaseSandbox tools on remote sandbox (:3005) — full parity test
+
+Precondition: MCP sandbox selected (from previous story), exec_server running at localhost:3005
+
+--- Tool 1: execute() — shell command execution ---
+1. TYPE: "Run this shell command on the sandbox: echo 'MCP execute test' && pwd && whoami"
+2. CLICK send
+   - SCREENSHOT: Verify agent response
+   - VERIFY: Output shows "MCP execute test", a working directory path, and a username from the remote sandbox (not local)
+   - VERIFY: exit_code is 0
+
+--- Tool 2: write() — create new file ---
+3. TYPE: "Create a new file /tmp/mcp-qa/parity-test.py on the sandbox with this content:\nimport json\nprint(json.dumps({'status': 'ok', 'source': 'mcp-sandbox'}))"
+4. CLICK send
+   - SCREENSHOT: Verify file created successfully on sandbox
+   - VERIFY: No "file already exists" error
+
+--- Tool 3: read() — read file with line numbers ---
+5. TYPE: "Read the file /tmp/mcp-qa/parity-test.py from the sandbox and show me the contents with line numbers"
+6. CLICK send
+   - SCREENSHOT: Verify file contents returned with line numbers (cat -n format)
+   - VERIFY: Shows line 1: import json, line 2: print(...)
+
+--- Tool 4: edit() — string replacement ---
+7. TYPE: "Edit /tmp/mcp-qa/parity-test.py on the sandbox: replace 'ok' with 'modified', then read it back to confirm"
+8. CLICK send
+   - SCREENSHOT: Verify edit succeeded and re-read shows 'modified' instead of 'ok'
+   - VERIFY: EditResult shows 1 occurrence replaced
+
+--- Tool 5: execute() — run the edited script ---
+9. TYPE: "Execute 'python3 /tmp/mcp-qa/parity-test.py' on the sandbox"
+10. CLICK send
+    - SCREENSHOT: Verify output is JSON with {"status": "modified", "source": "mcp-sandbox"}
+    - VERIFY: exit_code is 0
+
+--- Tool 6: ls_info() — directory listing ---
+11. TYPE: "List all files in /tmp/mcp-qa/ on the sandbox with file metadata"
+12. CLICK send
+    - SCREENSHOT: Verify structured listing showing parity-test.py
+    - VERIFY: Shows file paths and is_dir flags
+
+--- Tool 7: glob_info() — pattern matching ---
+13. TYPE: "Find all .py files under /tmp/mcp-qa/ on the sandbox using glob pattern **/*.py"
+14. CLICK send
+    - SCREENSHOT: Verify glob returns parity-test.py
+    - VERIFY: Structured FileInfo results
+
+--- Tool 8: grep_raw() — content search ---
+15. TYPE: "Search for the string 'mcp-sandbox' in all files under /tmp/mcp-qa/ on the sandbox"
+16. CLICK send
+    - SCREENSHOT: Verify grep returns match in parity-test.py with line number
+    - VERIFY: GrepMatch with path, line number, and matched text
+
+--- Tool 9: execute() with non-zero exit code ---
+17. TYPE: "Run 'ls /nonexistent-path-12345' on the sandbox — I expect this to fail"
+18. CLICK send
+    - SCREENSHOT: Verify agent reports non-zero exit code
+    - VERIFY: exit_code is non-zero (2), error output present
+
+--- Tool 10: Cleanup ---
+19. TYPE: "Remove /tmp/mcp-qa and everything in it on the sandbox, then verify it's gone"
+20. CLICK send
+    - SCREENSHOT: Verify cleanup succeeded
+    - VERIFY: rm -rf executed, ls confirms directory no longer exists
+```
+
+**Pass criteria**: All frontend tests green. All agent-browser stories pass with screenshots. MCP option visible, selectable, persistable in both settings page and thread status bar. E2E chat with MCP sandbox produces exec_server output.
+
+---
+
+### QA-004: exec_server BaseSandbox-Conformant MCP Tools (after Spec 004)
+
+**Precondition**: Updated exec_server running at `http://localhost:3005`
+
+**Manual validation** (all 9 tools):
+```bash
+# 1. Health check with sandbox_id
+curl -s http://localhost:3005/health | jq .
+# Expected: {"status":"ok","sessions":0,"sandbox_id":"<uuid>"}
+
+# 2. Initialize session
+SESSION=$(curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' \
+  -D /dev/stderr 2>&1 | grep -i mcp-session-id | awk '{print $2}' | tr -d '\r')
+
+# 3. List tools — verify all 9 BaseSandbox-conformant tools registered
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | jq '.result.tools[].name'
+# Expected: "execute", "read", "write", "edit", "grep", "glob", "ls", "upload_file", "download_file"
+
+# --- Tool: execute (execute) ---
+# 4. execute success with structured _meta
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute","arguments":{"cmd":"echo hello"}}}' | jq '.result._meta'
+# Expected: {"exit_code":0,"sandbox_id":"<uuid>"}
+
+# 5. execute failure
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"execute","arguments":{"cmd":"ls /nonexistent"}}}' | jq '.result._meta.exit_code'
+# Expected: 2 (non-zero)
+
+# --- Tool: write (write) ---
+# 6. write — create new file
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"write","arguments":{"path":"/tmp/qa-test.txt","content":"Hello from QA test!"}}}' | jq '.result._meta'
+# Expected: {"exit_code":0,...}
+
+# 7. write — error if file exists
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"write","arguments":{"path":"/tmp/qa-test.txt","content":"duplicate"}}}' | jq '.result._meta.exit_code'
+# Expected: 1 (file exists error)
+
+# --- Tool: read (read) ---
+# 8. read with line numbers
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"read","arguments":{"path":"/tmp/qa-test.txt","offset":0,"limit":10}}}' | jq '.result.content[0].text'
+# Expected: "     1\tHello from QA test!" (cat -n format)
+
+# --- Tool: edit (edit) ---
+# 9. edit — replace string
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"edit","arguments":{"path":"/tmp/qa-test.txt","old_string":"QA test","new_string":"QA PASSED"}}}' | jq '.result'
+# Expected: content text = "1" (1 occurrence), _meta.exit_code = 0
+
+# 10. edit — string not found
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"edit","arguments":{"path":"/tmp/qa-test.txt","old_string":"nonexistent","new_string":"x"}}}' | jq '.result._meta.exit_code'
+# Expected: 1 (string not found)
+
+# --- Tool: ls (ls_info) ---
+# 11. ls directory
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"ls","arguments":{"path":"/tmp"}}}' | jq '.result.content[0].text' | head -5
+# Expected: JSON lines with {path, is_dir} including qa-test.txt
+
+# --- Tool: grep ---
+# 12. grep for pattern
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"grep","arguments":{"pattern":"PASSED","path":"/tmp"}}}' | jq '.result.content[0].text'
+# Expected: JSON lines with {path: "/tmp/qa-test.txt", line: 1, text: "Hello from QA PASSED!"}
+
+# --- Tool: glob ---
+# 13. glob for *.txt
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"glob","arguments":{"pattern":"*.txt","path":"/tmp"}}}' | jq '.result.content[0].text'
+# Expected: JSON lines with {path, is_dir, size, mtime} including qa-test.txt
+
+# --- Tool: upload_file ---
+# 14. Upload binary file
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"upload_file","arguments":{"path":"/tmp/qa-binary.bin","content_base64":"AQIDBA=="}}}' | jq '.result._meta'
+# Expected: {"exit_code":0,...}, "Written 4 bytes to /tmp/qa-binary.bin"
+
+# --- Tool: download_file ---
+# 15. Download and verify round-trip
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"download_file","arguments":{"path":"/tmp/qa-binary.bin"}}}' | jq -r '.result.content[0].text' | base64 -d | xxd
+# Expected: 01 02 03 04 (binary round-trip preserved)
+
+# 16. Download nonexistent file
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"download_file","arguments":{"path":"/tmp/nonexistent.txt"}}}' | jq '.result._meta.exit_code'
+# Expected: non-zero (file_not_found error)
+```
+
+**Conformance test suite**:
+```bash
+# 17. Run conformance tests against the updated exec_server
+cd sandboxes && bash tests/conformance.sh http://localhost:3005
+# Expected: All 9 tools PASS — execute, read, write, edit, grep, glob, ls, upload_file, download_file
+# Expected: _meta.exit_code semantics correct for all tools
+# Expected: sandbox_id present, python3 available
+```
+
+**Pass criteria**: Health returns sandbox_id. tools/list returns all 9 tools. _meta.exit_code is integer in all tool responses with correct semantics (edit codes 0-4, write code 1 for exists). File round-trips (text + binary) succeed. Error cases handled gracefully. Conformance test suite passes.
+
+---
+
+### QA-005: McpSandboxBackend v2 — Native Features (after Spec 005)
+
+**Precondition**: Updated exec_server (Spec 004) + McpSandboxBackend v2 (Spec 005) both deployed
+
+**Backend unit tests**:
+```bash
+cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v
+```
+
+**Integration validation**:
+```bash
+# 1. Verify structured _meta parsing takes precedence
+# (Run with updated exec_server — _meta.exit_code should be used)
+cd backend && uv run python -c "
+import asyncio
+from src.agents.mcp_sandbox import McpSandboxBackend
+async def test():
+    sb = McpSandboxBackend(url='http://localhost:3005/mcp')
+    result = await sb.execute('echo structured test')
+    print(f'exit_code={result.exit_code}, output={result.output[:50]}')
+    print(f'sandbox_id={sb.id}')
+asyncio.run(test())
+"
+# Expected: exit_code=0, sandbox_id=<uuid from _meta>
+
+# 2. Verify native upload_file tool
+cd backend && uv run python -c "
+import asyncio
+from src.agents.mcp_sandbox import McpSandboxBackend
+async def test():
+    sb = McpSandboxBackend(url='http://localhost:3005/mcp')
+    await sb.upload_files([('/tmp/v2-test.txt', b'native upload works')])
+    result = await sb.execute('cat /tmp/v2-test.txt')
+    print(f'content={result.output}')
+asyncio.run(test())
+"
+# Expected: content includes "native upload works"
+
+# 3. Verify native download_file tool
+cd backend && uv run python -c "
+import asyncio
+from src.agents.mcp_sandbox import McpSandboxBackend
+async def test():
+    sb = McpSandboxBackend(url='http://localhost:3005/mcp')
+    files = await sb.download_files(['/tmp/v2-test.txt'])
+    print(f'downloaded={files[0][1].decode()}')
+asyncio.run(test())
+"
+# Expected: downloaded=native upload works
+
+# 4. Verify fallback to shell-based transfer (old exec_server without upload_file tool)
+# Stop updated exec_server, start OLD exec_server (pre-Spec 004)
+# Re-run steps 2-3 — should still work via base64 shell fallback
+```
+
+**agent-browser E2E validation** (exercises native upload_file/download_file + all inherited tools on sandbox :3005):
+
+```
+Story: MCP v2 full tool parity E2E — native file transfer + all BaseSandbox tools
+
+1. NAVIGATE to http://localhost:5173 (chat page)
+   - ENSURE MCP sandbox is selected in thread status bar
+
+--- Native upload_files() via upload_file MCP tool ---
+2. TYPE: "Upload a binary-safe file to /tmp/v2-qa/config.json on the sandbox with content: {\"version\": 2, \"native\": true, \"emoji\": \"🚀\"}"
+3. CLICK send
+   - SCREENSHOT: Verify agent used sandbox upload (FileUploadResponse with no error)
+   - VERIFY: Response confirms file written to remote sandbox at :3005
+
+--- Native download_files() via download_file MCP tool ---
+4. TYPE: "Download /tmp/v2-qa/config.json from the sandbox and show me the raw contents"
+5. CLICK send
+   - SCREENSHOT: Verify agent used sandbox download (FileDownloadResponse)
+   - VERIFY: Contents match including emoji character (binary-safe round-trip)
+
+--- Inherited read() with offset/limit ---
+6. TYPE: "Read /tmp/v2-qa/config.json from the sandbox starting at line 1, limit 10 lines, with line numbers"
+7. CLICK send
+   - VERIFY: Output shows cat -n formatted content from remote sandbox
+
+--- Inherited write() + edit() ---
+8. TYPE: "Create /tmp/v2-qa/editable.txt on the sandbox with 'Hello World from MCP v2', then edit it replacing 'World' with 'Sandbox'"
+9. CLICK send
+   - VERIFY: WriteResult path set, then EditResult shows 1 occurrence replaced
+   - VERIFY: Re-read shows "Hello Sandbox from MCP v2"
+
+--- Inherited grep_raw() ---
+10. TYPE: "Search for 'native' in all files under /tmp/v2-qa/ on the sandbox"
+11. CLICK send
+    - VERIFY: GrepMatch returns config.json with line number and matched text
+
+--- Inherited glob_info() ---
+12. TYPE: "Find all .json files under /tmp/v2-qa/ on the sandbox"
+13. CLICK send
+    - VERIFY: FileInfo list includes config.json
+
+--- Inherited ls_info() ---
+14. TYPE: "List /tmp/v2-qa/ on the sandbox with file info"
+15. CLICK send
+    - VERIFY: Shows config.json and editable.txt with is_dir=false
+
+--- Batch upload_files() (multiple files) ---
+16. TYPE: "Upload these 3 files to the sandbox: /tmp/v2-qa/batch/a.txt with 'file A', /tmp/v2-qa/batch/b.txt with 'file B', /tmp/v2-qa/batch/c.txt with 'file C'"
+17. CLICK send
+    - VERIFY: 3 FileUploadResponse entries, all with no error
+
+--- Batch download_files() (multiple files) ---
+18. TYPE: "Download all 3 files from /tmp/v2-qa/batch/ and show their contents"
+19. CLICK send
+    - VERIFY: 3 FileDownloadResponse entries with correct contents
+
+--- Error handling: download nonexistent file ---
+20. TYPE: "Try to download /tmp/v2-qa/nonexistent.txt from the sandbox"
+21. CLICK send
+    - VERIFY: FileDownloadResponse with error="file_not_found"
+
+--- Cleanup ---
+22. TYPE: "Remove /tmp/v2-qa and everything in it on the sandbox"
+23. CLICK send
+    - VERIFY: Cleanup succeeded, directory gone
+```
+
+**Pass criteria**: All unit tests green. Structured _meta exit_code used when available. Native file transfer tools used when available. Shell fallback works when tools unavailable. E2E chat flow succeeds with file operations.
+
+---
+
+### QA-FINAL: Full Regression & Fallback Chain
+
+**Purpose**: Verify nothing is broken and fallback chain works correctly across all combinations.
+
+| Scenario | exec_server | Daytona | Expected effective_type | Test |
+|----------|-------------|---------|------------------------|------|
+| Auto, nothing available | OFF | OFF | `state` | Send chat message, verify state backend response |
+| Auto, MCP available | ON | OFF | `mcp` | Send chat message, verify exec_server logs show activity |
+| Auto, both available | ON | ON | `daytona` | Daytona takes priority |
+| Explicit MCP, available | ON | - | `mcp` | Send chat message with MCP selected |
+| Explicit MCP, unavailable | OFF | - | `state` | Falls back gracefully, no crash |
+| Explicit State | - | - | `state` | Always state, never tries MCP/Daytona |
+
+**agent-browser regression** (verify existing sandbox + MCP filesystem isolation):
+```
+Story: Verify existing sandbox options still work after MCP addition
+
+1. NAVIGATE to http://localhost:5173/settings
+2. CLICK sandbox selector
+   - SCREENSHOT: Verify all options visible
+   - VERIFY: "State (Default)" still present and selectable
+   - VERIFY: "Daytona" visible only when DAYTONA_API_KEY is set (same as before)
+   - VERIFY: "MCP Sandbox" always visible
+
+3. SELECT "State (Default)"
+   - VERIFY: Selection persists, toast shows success
+
+4. NAVIGATE to chat page
+5. SEND: "List the files in /tmp on your filesystem"
+   - VERIFY: Agent responds using state backend (local filesystem, not remote sandbox)
+   - VERIFY: No connection to exec_server :3005
+
+6. Switch sandbox to MCP (via thread status bar)
+7. SEND: "List the files in /tmp on the sandbox filesystem"
+   - VERIFY: Agent responds using remote sandbox :3005 (different filesystem)
+   - SCREENSHOT: Compare — MCP response should show sandbox /tmp (different from step 5)
+
+8. Switch sandbox back to State
+9. SEND: "Create /tmp/regression-test.txt with content 'state backend' and read it back"
+   - VERIFY: Agent operates on local filesystem, not remote sandbox
+   - VERIFY: No errors, state backend fully functional
+```
+
+**Full test suite**:
+```bash
+# Backend
+cd backend && make test
+
+# Frontend
+cd frontend && npm run test
+```
+
+**Pass criteria**: All 6 fallback scenarios work as expected. Existing sandbox options unaffected. Full test suites green on both backend and frontend.
+
+## PR Submission & Human Review Process
+
+### Final PR (All Specs Combined)
+
+Per the feature request template at `.github/ISSUE_TEMPLATE/feature_request.md`, the final PR consolidates all specs into one submission.
+
+**Metadata**:
+```yml
+pull_request_title: "FROM feat/890-mcp-sandbox TO development"
+branch: "feat/890-mcp-sandbox"
+worktree_path: "$WORKSPACE/.worktrees/feat-890"
+```
+
+**PR Body** (follows feature_request.md template):
+
+```markdown
+## Summary
+
+MCP Sandbox Backend for DeepAgents — connects Orchestra to `ruska-ai/sandboxes` exec_server
+via MCP JSON-RPC 2.0 over Streamable HTTP as a first-class BaseSandbox implementation.
+
+Closes #890. Depends on ruska-ai/sandboxes#3.
+
+## User Stories
+
+- As a **developer**, I want to select "MCP Sandbox" in the sandbox selector so that my agent
+  code executes in an isolated container at :3005 instead of locally.
+- As a **developer**, I want to see a green/red dot on the MCP option so that I know whether
+  the sandbox is reachable before sending messages.
+- As a **developer**, I want files created by the agent on the sandbox to appear in the
+  FileEditorPanel so that I can review and edit them.
+- As a **developer**, I want a toast with "Use State for this message" when the MCP sandbox is
+  unreachable so that I can choose to fall back without losing my message.
+
+## Key Integration Points
+
+| File | Function(s) | Role |
+|------|-------------|------|
+| `backend/src/agents/mcp_sandbox.py` | `McpSandboxBackend(BaseSandbox)` | Core MCP sandbox implementation — execute, upload, download |
+| `backend/src/agents/__init__.py` | `_create_mcp_backend_checked()`, `resolve_sandbox_backend()` | Factory registration + Daytona → MCP → State fallback chain |
+| `backend/src/schemas/entities/settings.py` | `SandboxType` | Add MCP enum value |
+| `backend/src/schemas/entities/settings.py` | `default_mcp_sandbox_url` | User-configured sandbox URL (no env var) |
+| `backend/src/controllers/llm.py` | `llm_invoke()` | MCP error handling + user-approved fallback response |
+| `backend/src/utils/stream.py` | `stream_generator()` | MCP error handling + fallback response |
+
+## UI Integration Points
+
+| Component / Route | Change Type | Description |
+|-------------------|-------------|-------------|
+| `SandboxSettings.tsx` | Modify | Add MCP option with health indicator dot |
+| `ThreadSandboxStatus.tsx` | Modify | Add MCP option with health indicator dot |
+| `frontend/src/lib/config/sandbox.ts` | Modify | Add MCP to SANDBOX_OPTIONS, update normalizer |
+| `frontend/src/lib/services/userSettingsService.ts` | Modify | Extend SandboxType union |
+| `frontend/src/hooks/useSandboxHealth.ts` | New hook | Health check for exec_server on page load + dropdown open |
+| Chat stream error handler | Modify | Toast with "Use State for this message" button |
+
+## Storage
+
+- **Persistence layer**: LangGraph Store (existing UserSettings entity)
+- **Namespace**: `(user_id, "settings")` — existing `default_sandbox` field
+- **Model pattern**: `SandboxType` enum, `PatchDefaultsRequest` — existing patterns
+
+## Architectural Decisions
+
+- **Source of truth**: Backend `UserSettings.default_sandbox` — NOT localStorage
+- **State management**: Existing `patchDefaults()` → `getSettings()` cycle
+- **Auth / scoping**: User-scoped via session user_id
+- **Sandbox protocol**: MCP JSON-RPC 2.0 over Streamable HTTP, BaseSandbox-conformant
+- **Fallback chain**: Daytona → MCP → State (user-approved for MCP failures)
+- **Session lifecycle**: Persistent with reconnect on failure
+- **Working directory**: `/workspace` default in sandbox container
+
+## Validation Tools
+
+- [x] Load `agent-browser` skill with screenshots to validate E2E
+- [x] Conformance test suite in sandboxes repo validates BaseSandbox contract
+- [x] Unit tests for McpSandboxBackend (mocked + integration)
+- [x] Frontend tests for MCP option rendering and selection
+
+## Acceptance Criteria
+
+- [ ] `McpSandboxBackend(BaseSandbox)` implements all 4 abstract methods (execute, id, upload_files, download_files)
+- [ ] All 6 inherited tools (read, write, edit, grep_raw, glob_info, ls_info) work via execute() delegation
+- [ ] Registered in `_SANDBOX_FACTORIES` as `"mcp"`
+- [ ] Fallback chain: Daytona → MCP → State
+- [ ] Frontend sandbox selector shows MCP option with green/red health indicator
+- [ ] FileEditorPanel displays files created by agent on sandbox
+- [ ] Toast with "Use State for this message" button when MCP unreachable
+- [ ] exec_server exposes all 9 BaseSandbox-conformant MCP tools (execute, read, write, edit, grep, glob, ls, upload_file, download_file)
+- [ ] Conformance test suite passes against exec_server
+- [ ] All previous & new tests pass, validated using `agent-browser` CLI
+- [ ] New code follows existing repo/service/route patterns
+- [ ] No new dependencies added beyond what's already in the project
+```
+
+### Sandboxes Repo PR (Spec 004 — separate repo)
+
+```yml
+pull_request_title: "FROM feat/3-basesandbox-conformant TO main"
+branch: "feat/3-basesandbox-conformant"
+repo: "ruska-ai/sandboxes"
+```
+
+Must be merged + RC-tagged before the Orchestra PR can be fully validated.
+
+### Sub-Branch Strategy (development within worktree)
+
+Within the `feat/890-mcp-sandbox` worktree, specs are implemented sequentially:
+
+| Spec | Commit(s) | Description |
+|------|-----------|-------------|
+| 001 | `feat(sandbox): add McpSandboxBackend core class` | mcp_sandbox.py + tests |
+| 002 | `feat(sandbox): wire MCP into dispatch + fallback chain` | factory, enum, error handling |
+| 003 | `feat(frontend): add MCP sandbox option + health + fallback UX` | types, config, components, hook |
+| 005 | `feat(sandbox): McpSandboxBackend v2 with native MCP tools` | override all methods + tests |
+
+### Human Reviewer UI Walkthrough
+
+The human reviewer validates correctness by walking through the UI user story. All automated tests (unit, integration, conformance) are run by CI/agents before the PR reaches the reviewer. The reviewer's job is to prove the implementation is correct from the user's perspective.
+
+**Setup** (one-time before review):
+```bash
+# 1. Seed test user
+cd backend && make seeds.user
+
+# 2. Start exec_server (sandbox at :3005)
+COMPOSE_PROFILES=tools make dev.docker.up
+
+# 3. Start backend (:8000)
+cd backend && make dev
+
+# 4. Start frontend (:5173)
+cd frontend && npm run dev
+```
+
+**Login**: Navigate to `http://localhost:5173`, log in as `admin@example.com` / `test1234`
+
+---
+
+#### Review 1: Configure MCP Sandbox URL + MCP Option Appears with Health Indicator (PR-002, 003)
+
+**What to look for**: User configures sandbox URL in settings, then MCP option appears with live connection status dot.
+
+1. Navigate to **Settings** page (`/settings`)
+2. Scroll to "Default Sandbox" card
+3. Click the sandbox dropdown
+   - **EXPECT**: Only "State (Default)" and optionally "Daytona" visible — NO "MCP Sandbox" yet (URL not configured)
+4. Find the "MCP Sandbox URL" input field (below the sandbox selector)
+   - **EXPECT**: Empty input with placeholder like "http://localhost:3005/mcp"
+5. Enter `http://localhost:3005/mcp` and save
+   - **EXPECT**: Toast "MCP Sandbox URL saved" (or similar)
+6. Click the sandbox dropdown again
+   - **EXPECT**: "MCP Sandbox" option NOW appears (because URL is configured)
+   - **EXPECT**: Green dot next to "MCP Sandbox" (exec_server is running at :3005)
+   - **EXPECT**: Description reads "Run agent code in an isolated MCP sandbox container."
+7. Select "MCP Sandbox"
+   - **EXPECT**: Toast "Default sandbox updated"
+   - **EXPECT**: Dropdown shows "MCP Sandbox" as selected
+8. Refresh the page (F5)
+   - **EXPECT**: "MCP Sandbox" still selected after reload (URL + sandbox choice persisted)
+6. Navigate to the chat page (`/`)
+7. Find the sandbox selector button in the bottom utility row
+   - **EXPECT**: Button shows "Sandbox MCP" with green dot
+8. Click the sandbox button to open popover
+   - **EXPECT**: Popover shows all options, checkmark next to "MCP Sandbox"
+   - **EXPECT**: Green dot visible next to MCP option
+
+**Health indicator negative test**:
+9. Stop the exec_server (`docker stop <exec_server_container>`)
+10. Refresh the page or re-open the sandbox selector
+    - **EXPECT**: Red dot next to "MCP Sandbox" (exec_server unreachable)
+11. Restart exec_server before continuing
+
+---
+
+#### Review 2: Agent Executes on Remote Sandbox + Files Sync to FileEditorPanel (PR-001, 002, 003)
+
+**What to look for**: Agent commands run on the remote sandbox (not local), and files created by the agent appear in the FileEditorPanel.
+
+1. Ensure MCP sandbox is selected (from Review 1)
+2. Open the FileEditorPanel (click the file icon or sidebar toggle)
+   - **EXPECT**: Panel opens, may show existing files or be empty
+3. Type in chat: **"Run `whoami && hostname && pwd` on the sandbox"**
+4. Send message
+   - **EXPECT**: Agent response shows tool execution
+   - **EXPECT**: `whoami` output is `executor` (the sandbox unprivileged user, NOT your local username)
+   - **EXPECT**: `pwd` output is `/workspace` (the sandbox working directory)
+   - **EXPECT**: `hostname` is the container hostname (NOT your local hostname)
+   - This proves the command ran on the remote sandbox at :3005
+5. Type: **"Create a file /workspace/hello.py with content: print('Hello from MCP sandbox')"**
+6. Send message
+   - **EXPECT**: Agent uses the write tool to create the file on the sandbox
+   - **EXPECT**: `/workspace/hello.py` appears in the FileEditorPanel file tree
+   - **EXPECT**: Clicking on it shows the content: `print('Hello from MCP sandbox')`
+7. Type: **"Edit /workspace/hello.py replacing 'Hello' with 'Greetings'"**
+8. Send message
+   - **EXPECT**: Agent uses the edit tool
+   - **EXPECT**: FileEditorPanel updates to show `print('Greetings from MCP sandbox')`
+9. Type: **"Run `python3 /workspace/hello.py` on the sandbox"**
+10. Send message
+    - **EXPECT**: Output is "Greetings from MCP sandbox"
+    - **EXPECT**: exit_code is 0
+11. Type: **"List all files in /workspace on the sandbox"**
+12. Send message
+    - **EXPECT**: Response shows `hello.py` in the listing
+    - **EXPECT**: ls_info returns structured file metadata
+
+---
+
+#### Review 3: All BaseSandbox Tools Work on Remote Sandbox (PR-005)
+
+**What to look for**: Every BaseSandbox tool (execute, read, write, edit, grep, glob, ls, upload, download) works correctly on the remote sandbox.
+
+1. Type: **"Search for the word 'Greetings' in all files under /workspace on the sandbox"**
+   - **EXPECT**: grep returns a match in `/workspace/hello.py` with line number
+2. Type: **"Find all .py files under /workspace on the sandbox"**
+   - **EXPECT**: glob returns `/workspace/hello.py` with file metadata
+3. Type: **"Read /workspace/hello.py from the sandbox with line numbers"**
+   - **EXPECT**: Output shows `     1	print('Greetings from MCP sandbox')` (cat -n format)
+4. Type: **"Upload a file to /workspace/data.json on the sandbox with content: {\"test\": true}"**
+   - **EXPECT**: File uploaded successfully, appears in FileEditorPanel
+5. Type: **"Download /workspace/data.json from the sandbox"**
+   - **EXPECT**: Content matches `{"test": true}`
+6. Type: **"Try to download /workspace/nonexistent.txt from the sandbox"**
+   - **EXPECT**: Error response indicating file not found
+7. Type: **"Run `ls /nonexistent-dir` on the sandbox"**
+   - **EXPECT**: Non-zero exit code reported in response
+8. Type: **"Clean up: remove all files in /workspace on the sandbox"**
+   - **EXPECT**: Cleanup succeeds
+
+---
+
+#### Review 4: Fallback UX When Sandbox Unreachable (PR-002, 003)
+
+**What to look for**: User-approved fallback with toast and action button.
+
+1. Ensure MCP sandbox is still selected
+2. Stop the exec_server: `docker stop <exec_server_container>`
+3. Type: **"What is 2+2?"**
+4. Send message
+   - **EXPECT**: Toast appears: "MCP sandbox unreachable"
+   - **EXPECT**: Toast has an action button: "Use State for this message"
+   - **EXPECT**: Message is NOT processed yet (waiting for user decision)
+5. Click "Use State for this message" button
+   - **EXPECT**: Message processes using State backend
+   - **EXPECT**: Agent responds with "4" (or equivalent)
+   - **EXPECT**: MCP sandbox is STILL selected as default (check thread status bar)
+6. Restart exec_server: `docker start <exec_server_container>`
+7. Type: **"Run `whoami` on the sandbox"**
+8. Send message
+   - **EXPECT**: Resumes using MCP sandbox (shows `executor`, not local user)
+   - **EXPECT**: No fallback toast (exec_server is back)
+
+---
+
+#### Review 5: Sandbox Isolation — State vs MCP (Final Regression)
+
+**What to look for**: State and MCP sandboxes are truly isolated environments.
+
+1. Switch to State sandbox (via thread status bar)
+2. Type: **"Run `whoami && pwd`"**
+   - **EXPECT**: Shows your LOCAL username and LOCAL working directory
+   - **EXPECT**: This is different from the sandbox `executor` / `/workspace`
+3. Switch to MCP sandbox
+4. Type: **"Run `whoami && pwd`"**
+   - **EXPECT**: Shows `executor` and `/workspace`
+5. Switch to State sandbox
+6. Type: **"List files in /workspace"**
+   - **EXPECT**: Either error (no /workspace locally) or different contents than sandbox
+7. Switch to MCP sandbox
+8. Type: **"List files in /workspace"**
+   - **EXPECT**: Shows files from the sandbox container (may include files from Review 2-3)
+
+**Reviewer sign-off**: If all 5 reviews pass, the implementation correctly provides a full BaseSandbox-conformant MCP sandbox backend with proper UI integration, health monitoring, and user-approved fallback.
+
+### Merge Order
+
+```
+1. Sandboxes PR (ruska-ai/sandboxes#3 — independent, merge + RC tag first)
+2. Orchestra PR (feat/890-mcp-sandbox → development — single PR with all specs)
+3. Run Human Reviewer UI Walkthrough after both PRs merged
+```
+
+### RC Tag Workflow
+
+Per project convention (feedback_rc_tag_workflow): NEVER merge Docker/infra changes before validating with an RC tag in production. After Sandboxes PR is approved:
+1. Tag a release candidate: `git tag v1.x.x-rc.1` in sandboxes repo
+2. Deploy RC to staging/test environment
+3. Run conformance test suite against RC deployment: `bash tests/conformance.sh`
+4. Only merge to main after RC validation passes
+5. Then proceed with Orchestra PR review
+
+## Documentation Update Spec (Part of Implementation)
+
+Documentation gaps that must be addressed as part of the PR. Each spec includes its doc updates.
+
+### Docs to UPDATE (existing files):
+
+| File | Gap | Update Required |
+|------|-----|-----------------|
+| `wiki/docs/tools/sandbox.md` | Documents only `exec_command` tool | Update to list all 9 BaseSandbox-conformant MCP tools (execute, read, write, edit, grep, glob, ls, upload_file, download_file). Update endpoint from `/exec` to `/mcp`. Document `/workspace` working directory convention. |
+| `wiki/docs/tools/sandbox-tutorial.md` | Shows only MCP tool config, not sandbox backend selection | Add section: "Selecting MCP Sandbox as Execution Backend" — settings page + thread status bar walkthrough with screenshots. Document health indicator (green/red dot). |
+| `wiki/docs/tools/mcp.md` | No mention of sandbox backends | Add subsection: "MCP Servers as Sandbox Backends" explaining that conformant MCP servers can serve as DeepAgents execution backends. |
+| `wiki/docs/getting-started.md` | Sandbox selection mentioned briefly ("Auto tries Daytona, falls back to local") | Expand to document all 3 options: State (Default), Daytona, MCP Sandbox. Explain fallback chain. Document the "MCP sandbox unreachable" toast + user-approved fallback UX. |
+| `backend/.example.env` | `SHELL_EXEC_SERVER_URL` points to `/exec` (old endpoint) | Add deprecation note for `SHELL_EXEC_SERVER_URL`. Document that MCP sandbox URL is now user-configured via Settings page, not an env var. |
+| `backend/CLAUDE.md` | Only mentions `COMPOSE_PROFILES=tools` briefly | Add "MCP Sandbox" section documenting: how to start exec_server, how users configure sandbox URL in Settings, how to run conformance tests. |
+| `sandboxes/README.md` | No protocol specification | Add "BaseSandbox Protocol Conformance" section: required MCP tools, exit code semantics, `/workspace` convention, session lifecycle, python3 requirement. |
+| `sandboxes/ubuntu/README.md` | Documents only `exec_command` | Update to list all 9 tools. Add conformance test instructions: `bash tests/conformance.sh http://localhost:3005`. |
+| `website/public/llm.txt` | Likely missing MCP Sandbox capabilities | Add MCP Sandbox as an execution backend option. Document how external LLMs can use it. |
+
+### Docs to CREATE (new files):
+
+| File | Purpose |
+|------|---------|
+| `wiki/docs/tools/sandbox-protocol.md` | **BaseSandbox Protocol Specification**: All 9 MCP tools with params, return formats, exit code semantics. Session lifecycle. Working directory convention. Conformance requirements. This is the canonical spec for anyone building a new sandbox. |
+| `sandboxes/tests/README.md` | **Conformance Test Suite Documentation**: How to run tests, what they validate, how to interpret results, how to add new tests. |
+
+### Doc Update Rules
+
+- Documentation updates are committed in the **same PR** as the code they document
+- Wiki changes go to `wiki/` submodule (committed inside wiki directory)
+- `llm.txt` updates require running `npm run prebuild` in `website/` after changes
+- All doc updates must be reviewable in the PR diff
+- Screenshots for UI docs are captured via agent-browser during QA
+
+## Development Environment Optimizations
+
+The MCP Sandbox feature introduces a new service dependency (exec_server at :3005) that exposes gaps in the current dev tooling. These optimizations reduce friction for developers working with sandboxes.
+
+### 1. New Makefile Targets (root `Makefile`)
+
+Currently developers must remember `COMPOSE_PROFILES=tools make dev.docker.up` to include exec_server. Add dedicated targets:
+
+```makefile
+# Sandbox-specific targets
+dev.sandbox.up:        # docker compose -f docker-compose.services.yml --profile tools up -d exec_server
+dev.sandbox.down:      # docker compose -f docker-compose.services.yml --profile tools stop exec_server
+dev.sandbox.health:    # curl -sf http://localhost:3005/health | jq . || echo "Sandbox unreachable"
+dev.sandbox.logs:      # docker compose -f docker-compose.services.yml logs -f exec_server
+dev.sandbox.test:      # cd sandboxes && bash tests/conformance.sh http://localhost:3005
+
+# Full stack with sandbox
+dev.full.up:           # make dev.storage.up && make dev.sandbox.up && make dev.docker.up
+dev.full.down:         # make dev.docker.down && make dev.sandbox.down && make dev.storage.down
+```
+
+**Files**: `Makefile`
+
+### 2. CI Pipeline: Sandbox Image Build + Integration Test
+
+Currently CI (`test.yml`) skips sandbox entirely. `build.yml` never builds the sandbox image.
+
+**Add to `.github/workflows/test.yml`**:
+```yaml
+test-sandbox:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with: { submodules: true }
+    - name: Build exec_server
+      run: docker build -t exec-server-test sandboxes/ubuntu/
+    - name: Start exec_server
+      run: docker run -d -p 3005:3005 --name exec-server exec-server-test
+    - name: Run conformance tests
+      run: cd sandboxes && bash tests/conformance.sh http://localhost:3005
+    - name: Cleanup
+      run: docker stop exec-server
+```
+
+**Add to `.github/workflows/build.yml`**:
+```yaml
+- name: Build sandbox image
+  run: docker build -t ghcr.io/${{ github.repository_owner }}/orchestra-sandbox:${{ env.TAG }} sandboxes/ubuntu/
+- name: Push sandbox image
+  run: docker push ghcr.io/${{ github.repository_owner }}/orchestra-sandbox:${{ env.TAG }}
+```
+
+**Files**: `.github/workflows/test.yml`, `.github/workflows/build.yml`
+
+### 3. Backend Test Fixture for Sandbox
+
+Currently `backend/tests/conftest.py` has no sandbox fixture. Tests skip sandbox entirely.
+
+**Add sandbox fixture**:
+```python
+@pytest.fixture
+def mock_mcp_sandbox(respx_mock):
+    """Mock MCP sandbox for unit tests — no exec_server needed."""
+    respx_mock.get("http://localhost:3005/health").respond(json={"status": "ok", "sandbox_id": "test-sandbox-123"})
+    respx_mock.post("http://localhost:3005/mcp").respond(json={
+        "jsonrpc": "2.0", "id": 1,
+        "result": {"content": [{"type": "text", "text": "mocked output\nexit_code: 0"}]}
+    })
+    return respx_mock
+```
+
+**Add integration test marker**:
+```python
+# backend/tests/integration/test_mcp_sandbox_integration.py
+@pytest.mark.skipif(not is_sandbox_available(), reason="exec_server not running at :3005")
+class TestMcpSandboxIntegration:
+    ...
+```
+
+**Files**: `backend/tests/conftest.py`, `backend/tests/integration/test_mcp_sandbox_integration.py` (NEW)
+
+### 4. Environment Variable Fixes
+
+**Current problem**: `.example.env` has `SHELL_EXEC_SERVER_URL="http://localhost:3005/exec"` — the `/exec` endpoint doesn't exist on the MCP server (it's `/mcp`).
+
+**Fix in `.example.env`**:
+```bash
+## MCP Sandbox Backend
+# MCP Sandbox URL is user-configured via Settings page (not an env var)
+# Users enter their sandbox URL in Settings > Default Sandbox > MCP Sandbox URL
+# Example: http://localhost:3005/mcp
+# SHELL_EXEC_SERVER_URL is deprecated
+```
+
+**Files**: `backend/.example.env`
+
+### 5. Hot-Reload for Sandbox Development
+
+Currently the exec_server container doesn't support hot-reload — changes to `sandboxes/ubuntu/index.js` require rebuilding the image.
+
+**Add volume mount in `docker-compose.services.yml`**:
+```yaml
+exec_server:
+  volumes:
+    - ./sandboxes/ubuntu/index.js:/app/index.js:ro   # Hot-reload on save
+    - ./sandboxes/ubuntu/package.json:/app/package.json:ro
+```
+
+Combined with `node --watch` in the entrypoint (Node 22 supports `--watch` natively), this enables live-reload during sandbox development.
+
+**Files**: `docker-compose.services.yml`, `sandboxes/ubuntu/entrypoint.sh`
+
+### 6. Pre-commit Hook: Sandbox Conformance (Optional)
+
+Too heavy for every commit, but add as an optional hook that runs when sandbox files change:
+
+```yaml
+- id: sandbox-conformance
+  name: Sandbox Conformance Test
+  entry: bash -c 'cd sandboxes && bash tests/conformance.sh http://localhost:3005 2>/dev/null || echo "SKIP: exec_server not running"'
+  language: system
+  files: ^sandboxes/
+  stages: [manual]  # Only runs with: pre-commit run sandbox-conformance
+```
+
+**Files**: `.pre-commit-config.yaml`
+
+### Summary of Dev Environment Changes
+
+| Change | Impact | Files |
+|--------|--------|-------|
+| Makefile sandbox targets | Reduces 1-line commands to memorable `make` targets | `Makefile` |
+| CI sandbox build + test | Catches sandbox regressions in PR checks | `.github/workflows/test.yml`, `build.yml` |
+| Backend test fixture | Enables unit testing without running exec_server | `backend/tests/conftest.py` |
+| Env var fix | Corrects stale `/exec` endpoint to `/mcp` | `backend/.example.env` |
+| Hot-reload volumes | Live sandbox development without image rebuilds | `docker-compose.services.yml` |
+| Pre-commit hook (optional) | Conformance validation on sandbox file changes | `.pre-commit-config.yaml` |
+
+## Post-Implementation Insights & Follow-Up Improvements
+
+After each spec is implemented, the implementing agent should capture insights that improve future sessions. These go into `.claude/projects/` memory files:
+
+### Insights to Capture During Implementation
+
+| Spec | Insight Category | What to Record |
+|------|-----------------|----------------|
+| 001 | **MCP protocol** | Exact JSON-RPC 2.0 message format that worked, any protocol quirks discovered (e.g., session header casing, content-type requirements, error response format) |
+| 001 | **httpx patterns** | Which httpx client configuration worked best (timeouts, connection pooling, headers). Record as reusable pattern for future MCP integrations |
+| 002 | **Fallback chain** | Any race conditions or edge cases in the dispatch logic. Record error types that need special handling |
+| 003 | **Health check** | Latency of health check on page load — does it cause visible delay? Record if debouncing/caching was needed |
+| 003 | **Toast UX** | How the retry-with-state flow interacts with SSE streaming. Record if the stream needs special reconnection logic |
+| 004 | **exec_server tools** | Zod schema patterns that map cleanly to BaseSandbox params. Record as template for adding future tools |
+| 004 | **Conformance tests** | Which tests caught real bugs vs. which were just validation. Prune or highlight accordingly |
+| 005 | **Tool discovery** | Performance impact of `tools/list` call on session init. Record if caching strategy needed adjustment |
+| 005 | **Native vs shell** | Measurable latency difference between native MCP tools and shell-delegation fallback. Record metrics |
+
+### Memory Files to Create/Update
+
+After implementation, create or update these memory files:
+
+1. **`memory/feedback_mcp_sandbox_patterns.md`** — Validated MCP JSON-RPC patterns (message format, session lifecycle, error handling) that worked. Future MCP integrations should reference this.
+
+2. **`memory/project_sandbox_architecture.md`** — How the sandbox system works post-MCP: factory pattern, fallback chain, BaseSandbox protocol conformance. Prevents re-exploration in future sandbox work.
+
+3. **`memory/feedback_conformance_testing.md`** — What the conformance test suite caught, what it missed. Guide for improving the suite.
+
+4. **`memory/feedback_file_editor_sync.md`** — How agent tool outputs sync to FileEditorPanel via SSE streaming. Any gotchas with file source tagging, dirty state, or persistence timing.
+
+### Process Improvements for Future Specs
+
+After the full feature ships, reflect on:
+
+1. **Spec granularity**: Were 5 specs the right number? Would fewer (bundled) or more (finer-grained) have been better for Ralph execution?
+2. **QA story effectiveness**: Which agent-browser QA steps caught real issues vs. were redundant? Trim the template.
+3. **Human review efficiency**: Did the reviewer find the 5-section walkthrough practical? Were any sections skippable or missing?
+4. **Conformance test ROI**: Did the conformance test suite catch bugs that unit tests missed? Worth the investment for future features?
+5. **Parallel spec execution**: Did specs 001, 003, 004 actually parallelize well, or did implicit dependencies cause rework?
+
+Record these reflections in **`memory/project_mcp_sandbox_retro.md`** to improve the next feature's spec generation process.
+
+## Deliverables
+
+Create 5 spec files at `.claude/specs/feat-890-mcp-sandbox/` following the feature spec template format with frontmatter, requirements, success criteria checkboxes, example output, and Ralph instructions. Each spec includes its corresponding QA story from above as a "QA Validation" section.

--- a/.claude/plans/greedy-tumbling-boole-agent-a03dc3ae9503ebd65.md
+++ b/.claude/plans/greedy-tumbling-boole-agent-a03dc3ae9503ebd65.md
@@ -1,0 +1,395 @@
+# Acceptance Criteria Alignment Audit — MCP Sandbox Feature #890
+
+## Artifact Legend
+
+| Abbreviation | File |
+|---|---|
+| **PRD** | `.ralph/prd.json` (59 user stories, the master source) |
+| **Spec-001** | `.claude/specs/.../001-mcp-sandbox-backend.md` |
+| **Spec-002** | `.claude/specs/.../002-sandbox-dispatch.md` |
+| **Spec-003** | `.claude/specs/.../003-frontend-mcp-option.md` |
+| **Spec-004** | `.claude/specs/.../004-exec-server-structured.md` |
+| **Spec-005** | `.claude/specs/.../005-mcp-sandbox-v2.md` |
+| **Task-Backend** | `tasks/prd-mcp-sandbox-backend.md` |
+| **Task-Dispatch** | `tasks/prd-mcp-sandbox-dispatch.md` |
+| **Task-Frontend** | `tasks/prd-mcp-sandbox-frontend.md` |
+| **Task-ExecServer** | `tasks/prd-mcp-sandbox-exec-server.md` |
+| **Task-V2** | `tasks/prd-mcp-sandbox-v2-native.md` |
+
+---
+
+## CRITICAL Contradictions (Would Cause Implementation Bugs)
+
+### C-1: Constructor Signature — `base_url` vs `url` vs keyword-only
+
+| Artifact | Constructor Signature |
+|---|---|
+| PRD US-001 | `__init__(self, *, base_url: str, api_key: str \| None = None)` |
+| Spec-001 (skeleton) | `__init__(self, url: str, api_key: str \| None = None)` |
+| Spec-001 (usage) | `McpSandboxBackend(url="http://localhost:3005/mcp")` |
+| Task-Backend US-001 | `__init__(self, *, base_url: str, api_key: str \| None = None)` |
+| Spec-002 (factory) | `McpSandboxBackend(url=mcp_sandbox_url)` |
+| Spec-005 (usage) | `McpSandboxBackend(url="http://localhost:3005/mcp")` |
+
+**Contradiction:** PRD and Task-Backend use `base_url` as keyword-only (`*`). Spec-001, Spec-002, and Spec-005 use `url` as a positional parameter. An implementer following the spec would use `url`, while someone following the PRD/task would use `base_url`. The factory in Spec-002 calls `McpSandboxBackend(url=mcp_sandbox_url)` which would fail if the constructor expects `base_url`.
+
+**Impact:** Factory instantiation in `_create_mcp_backend_checked()` will crash with `TypeError` if the parameter name is wrong.
+
+### C-2: URL Semantics — Base URL vs Full MCP Endpoint URL
+
+| Artifact | What the URL Represents |
+|---|---|
+| PRD US-001 | `base_url` = server root (e.g., `http://localhost:3005`), `/mcp` appended internally |
+| PRD US-004 | Posts to `{base_url}/mcp` |
+| PRD US-005 | `id` returns `f"mcp-sandbox:{self._base_url}"` -> `"mcp-sandbox:http://localhost:3005"` |
+| Spec-001 (skeleton) | `url` = "Full MCP endpoint URL (e.g., `http://localhost:3005/mcp`)" |
+| Spec-001 (usage) | `McpSandboxBackend(url="http://localhost:3005/mcp")` |
+| Spec-001 (class) | Has `_base_url()` helper: "Derive base URL from MCP URL (strip /mcp path)" |
+| Task-Backend US-001 | `base_url` stored with trailing slash stripped; no mention of `/mcp` being part of it |
+| Task-Backend US-002 | Posts to `{base_url}/mcp` |
+| Task-Backend open Q5 | "Should the backend accept `base_url` only, or a full URL with `/mcp` path?" |
+
+**Contradiction:** The PRD stores a `base_url` like `http://localhost:3005` and appends `/mcp` internally. The Spec stores a `url` like `http://localhost:3005/mcp` (full endpoint) and strips `/mcp` to derive the base URL. These are inverse approaches. The `id` property in the PRD returns `mcp-sandbox:http://localhost:3005`, but if the Spec approach is followed, the stored URL includes `/mcp` so the id would be `mcp-sandbox:http://localhost:3005/mcp`.
+
+**Impact:** The health check, session termination (DELETE), and `id` property will all generate wrong URLs if the URL convention is mismatched.
+
+### C-3: `httpx.AsyncClient` vs `httpx.Client` (Sync vs Async)
+
+| Artifact | HTTP Client |
+|---|---|
+| PRD US-001 | "An `httpx.AsyncClient` is created" |
+| PRD US-004 (execute) | Async (implies async client) |
+| Task-Backend (considerations) | "Should we use `httpx.Client` (sync) to match `DaytonaSandbox` pattern, or `httpx.AsyncClient`?" and "The sync approach is simpler and matches existing patterns." |
+| Spec-001 (class skeleton) | `httpx.AsyncClient(timeout=httpx.Timeout(130.0))` |
+| Spec-001 (skeleton) | All methods are `async def` |
+
+**Contradiction:** The Task-Backend's Technical Considerations section strongly recommends `httpx.Client` (sync) for consistency with `DaytonaSandbox`, noting that `BaseSandbox.execute()` is synchronous. However, the PRD, the spec, and the class skeleton all use `httpx.AsyncClient` with `async def` methods. The Task even asks this as an open question while the PRD has already decided on async.
+
+**Impact:** If sync is used, all the `await` calls in the spec code snippets would fail. If async is used, there may be compatibility issues with `BaseSandbox`'s sync `execute()` contract.
+
+### C-4: Default Client Timeout — 120s vs 130s
+
+| Artifact | Timeout |
+|---|---|
+| PRD US-001 | "default timeout of 120 seconds" |
+| Spec-001 (skeleton) | `httpx.Timeout(130.0)` |
+| Task-Backend | Open question: "Should the default timeout (120s) match the exec_server's timeout (120s)?" |
+
+**Contradiction:** The PRD says 120 seconds. The spec skeleton code says 130 seconds. The task identifies this as an open question. 130s would give 10s headroom above the exec_server's 120s internal limit, but the PRD explicitly says 120s.
+
+**Impact:** With a 120s client timeout and a 120s server timeout, race conditions could cause premature client-side timeouts when the server is at its limit.
+
+### C-5: MCP Protocol Version — "2024-11-05" vs "2025-03-26"
+
+| Artifact | Protocol Version |
+|---|---|
+| PRD US-003 | Not specified directly |
+| Spec-001 (protocol details) | `"protocolVersion": "2024-11-05"` |
+| Task-Backend US-002 | `"protocolVersion": "2025-03-26"` |
+
+**Contradiction:** The spec uses `"2024-11-05"` in the JSON-RPC initialize example. The task uses `"2025-03-26"`. These are different MCP protocol versions with potentially different capabilities.
+
+**Impact:** Using the wrong protocol version could cause the exec_server to reject the handshake or behave differently.
+
+### C-6: Tool Name Contradiction — `exec_command` vs `execute` in Phase 1
+
+| Artifact | Phase 1 Tool Name |
+|---|---|
+| PRD US-004 | `exec_command` |
+| PRD US-024 | Rename `exec_command` to `execute` in Phase 4 |
+| PRD US-049 | Phase 5 supports both `execute` (new) and `exec_command` (old) |
+| Spec-001 | `exec_command` (consistent) |
+| Spec-004 | Renames to `execute`, removes `exec_command` |
+| Task-Backend | `exec_command` (consistent) |
+
+**Consistent within phases** but the rename creates a **breaking change** in Spec-004 ("No backward compatibility alias") while PRD US-049/Spec-005 expects to support both. If Spec-004 is deployed without Spec-005, the existing Phase 1 backend will break because `exec_command` no longer exists.
+
+**Impact:** Deployment ordering matters. If exec_server is updated (Phase 4) before the backend is updated (Phase 5), the Phase 1 backend calling `exec_command` will fail with tool-not-found errors.
+
+### C-7: `_ensure_initialized()` vs `_ensure_session()` Method Name
+
+| Artifact | Method Name |
+|---|---|
+| PRD US-003, US-004, US-011 | `_ensure_initialized()` |
+| Spec-001 (skeleton) | `_ensure_session()` |
+| Spec-005 | `_ensure_session()` |
+| Task-Backend US-002, US-003 | `_ensure_initialized()` |
+| Task-V2 US-001 | `_ensure_session()` |
+
+**Contradiction:** PRD and Task-Backend use `_ensure_initialized()`. Specs use `_ensure_session()`. These are the same method with different names.
+
+**Impact:** Tests and cross-references in PRD user stories referencing `_ensure_initialized()` would fail if the spec's `_ensure_session()` name is implemented.
+
+### C-8: `clientInfo.name` — "orchestra" vs "orchestra-backend"
+
+| Artifact | clientInfo.name |
+|---|---|
+| Spec-001 (protocol details) | `"name": "orchestra"` |
+| Task-Backend US-002 | `"name": "orchestra-backend"` |
+
+**Contradiction:** Different client identity strings in the MCP handshake.
+
+**Impact:** Minor functionally (servers typically log this), but indicates spec drift.
+
+---
+
+## MAJOR Inconsistencies (Significant Discrepancy)
+
+### M-1: Health Check Timeout — 5s vs 3s
+
+| Artifact | Health Timeout |
+|---|---|
+| PRD US-008 | 5 seconds |
+| PRD US-014 (test) | "Test: health() uses a 5-second timeout" |
+| Task-Backend US-007 | 5 seconds |
+| Task-Frontend US-006 | 3 seconds ("Fetch uses a short timeout (3 seconds)") |
+| Spec-003 | Not specified for backend; frontend hook: no timeout mentioned in AC |
+
+**Discrepancy:** The backend health check uses 5 seconds. The frontend health hook uses 3 seconds. These serve different purposes (backend: server-to-server, frontend: browser-to-server), but the inconsistency should be documented.
+
+### M-2: upload_files() Error Values — "permission_denied" Only vs "permission_denied" + "invalid_path"
+
+| Artifact | Error Values |
+|---|---|
+| PRD US-006 | `error="permission_denied"` on non-zero exit |
+| Task-Backend US-005 | `error="permission_denied"` on non-zero exit PLUS `error="invalid_path"` for paths not starting with `/` |
+
+**Discrepancy:** The Task-Backend adds an `invalid_path` error case for paths not starting with `/`. The PRD does not mention path validation at all. This is an additional AC in the task not present in the PRD.
+
+### M-3: download_files() Error Values — "file_not_found" Only vs "file_not_found" + "invalid_path"
+
+| Artifact | Error Values |
+|---|---|
+| PRD US-007 | `error="file_not_found"` on non-zero exit |
+| Task-Backend US-006 | `error="file_not_found"` PLUS `error="invalid_path"` for paths not starting with `/` |
+
+**Discrepancy:** Same pattern as M-2. The task adds path validation not present in the PRD.
+
+### M-4: `_resolve_user_settings()` Return — 4-tuple Naming
+
+| Artifact | 4th Element Name |
+|---|---|
+| PRD US-020 | "4-tuple (model, api_key, default_sandbox, mcp_sandbox_url)" |
+| Spec-002 (code) | `default_mcp_sandbox_url` (from settings attribute) |
+| Task-Dispatch US-006 | "4-tuple (model, api_key, default_sandbox, mcp_sandbox_url)" |
+
+**Consistent** on the return value but the internal variable name (`default_mcp_sandbox_url` on the settings object vs `mcp_sandbox_url` as the return tuple element) could cause confusion.
+
+### M-5: `_ensure_initialized()` `_request_id` Post-Init Value
+
+| Artifact | `_request_id` After Init |
+|---|---|
+| PRD US-003 | "Sets `self._request_id = 1` (since ID 1 was used for init)" |
+| Task-Backend US-002 | "Sets `self._initialized = True` and `self._request_id = 1` (since ID 1 was used for init)" |
+| Spec-001 | Not explicitly specified for `_request_id` post-init value |
+
+**Discrepancy:** PRD and Task agree that `_request_id` is set to 1 after init (meaning the next execute call will use id=2). The spec does not specify this, relying on the implementer to increment before use.
+
+### M-6: Session Error Detection — HTTP 400 Only vs Broader Check
+
+| Artifact | Session Error Trigger |
+|---|---|
+| PRD US-004 | "On session-related error (HTTP 400)" |
+| Task-Backend US-003 | "HTTP 400 with 'Invalid or missing session ID', or connection error" |
+| Spec-001 | "On session error (e.g., 400 'Invalid or missing session ID')" |
+
+**Discrepancy:** Task-Backend expands session errors to include connection errors. PRD and Spec limit to HTTP 400. Connection errors during a tool call could be transient network issues, not session issues.
+
+### M-7: SSE Error Event Format — Tuple vs Object
+
+| Artifact | SSE Event Format |
+|---|---|
+| Spec-002 (code snippet) | `ujson.dumps(("mcp_sandbox_unreachable", str(e)))` (tuple) |
+| Task-Dispatch US-007 | `("error", {"type": "mcp_sandbox_unreachable", "message": "<detail>"})` (object nested in error tuple) |
+| Task-Frontend US-009 | `["mcp_sandbox_unreachable", {"message": "Connection refused"}]` (array with object) |
+| Spec-003 | `("mcp_sandbox_unreachable", "<error message>")` via SSE stream |
+
+**Contradiction:** Four different SSE event formats across three artifacts:
+1. Spec-002: `["mcp_sandbox_unreachable", "error string"]`
+2. Task-Dispatch: `["error", {"type": "mcp_sandbox_unreachable", "message": "..."}]`
+3. Task-Frontend: `["mcp_sandbox_unreachable", {"message": "..."}]`
+4. Spec-003: `("mcp_sandbox_unreachable", "error message")`
+
+**Impact:** The frontend SSE parser and backend SSE emitter MUST agree on format. This mismatch would cause the frontend to fail silently or mis-parse the error event.
+
+### M-8: ThreadSandboxStatus File Path
+
+| Artifact | File Path |
+|---|---|
+| Spec-003 | `frontend/src/components/tools/ThreadSandboxStatus.tsx` |
+| Task-Frontend (Files Changed) | `frontend/src/components/status/ThreadSandboxStatus.tsx` |
+
+**Contradiction:** The file is referenced under two different directories (`tools/` vs `status/`). Only one can be correct.
+
+### M-9: _SANDBOX_FACTORIES Registration Pattern
+
+| Artifact | Registration Approach |
+|---|---|
+| PRD US-017 | "`'mcp'` key added to `_SANDBOX_FACTORIES` dict" |
+| Spec-002 (code) | Shows `_SANDBOX_FACTORIES` registration but notes "MCP needs special handling since it requires the URL" |
+| Task-Dispatch US-003 | "`'mcp'` key added to `_SANDBOX_FACTORIES` dict, pointing to the factory callable" |
+| Spec-002 (resolve code) | Actually bypasses `_SANDBOX_FACTORIES` and calls factory directly in the dispatch logic |
+
+**Discrepancy:** The PRD and Task say to register in the dict, but the Spec-002 code snippet shows the dispatch function calling the MCP factory directly (not through the dict lookup) because the MCP factory needs the URL parameter. This creates ambiguity about whether the factory is actually in the dict or handled as a special case.
+
+### M-10: `execute()` `timeout` Parameter Type — `int | None` vs `float | None`
+
+| Artifact | Timeout Type |
+|---|---|
+| PRD US-004 | `timeout: int \| None = None` |
+| Spec-001 (skeleton) | `timeout: float \| None = None` |
+| Task-Backend US-003 | `timeout: int \| None = None` |
+
+**Contradiction:** PRD and Task use `int`, Spec uses `float`. httpx accepts both, but the type annotation matters for type checking.
+
+---
+
+## MINOR Inconsistencies (Cosmetic / Documentation Drift)
+
+### m-1: PRD US Numbering vs Spec/Task US Numbering
+
+The PRD has 59 user stories (US-001 through US-059) spanning all 5 phases. The specs and tasks have their own independent US numbering per phase. For example:
+- PRD US-015 = Task-Dispatch US-001 (Add MCP to SandboxType)
+- PRD US-024 = Task-ExecServer US-001 (Rename exec_command)
+
+This is not a bug but makes cross-referencing difficult.
+
+### m-2: Missing "Typecheck passes" AC in Some Task Stories
+
+| Task-Backend | Missing From |
+|---|---|
+| US-001 through US-009 | All have `make format` but not all have explicit "Typecheck passes" (some only have format+lint) |
+
+The PRD consistently includes "Typecheck passes" in every story. Some task stories omit it.
+
+### m-3: Health Check Endpoint Derivation
+
+| Artifact | How Health URL is Derived |
+|---|---|
+| Spec-001 | "GETs `/health` endpoint (derived from MCP URL by stripping `/mcp` path)" |
+| PRD US-008 | "Sends GET to `{base_url}/health`" |
+| Task-Backend US-007 | "Sends GET to `{base_url}/health`" |
+| Task-Frontend US-006 | "strip trailing `/mcp` suffix from URL, append `/health`" |
+
+These are consistent given the URL convention difference (C-2), but the derivation approach differs: PRD/Task assume `base_url` already excludes `/mcp`, while Spec/Frontend task strip `/mcp` from the full URL.
+
+### m-4: Spec-001 Says "No exit_code Line Means 0" But Also "Regex: Last Match Wins"
+
+Spec-001 has two slightly different descriptions:
+- "Success: text ends with nothing (no exit_code line means 0)"
+- "Regex: `r'exit_code:\s*(\d+)'` -- search the full text, last match wins"
+
+The "last match wins" implies scanning for multiple matches, while the PRD's regex `r'exit_code:\s*(\d+)'` just uses `re.search()` which finds the first match. The Task-V2 says "last match" explicitly. The PRD and Spec-001 do not specify first vs last match.
+
+### m-5: Missing Test AC in PRD for `is_mcp_sandbox_error()` and `McpSandboxError`
+
+PRD US-002 (McpSandboxError) and US-019 (is_mcp_sandbox_error) do not have corresponding test user stories. The PRD's test stories (US-010 through US-014) cover the main class but not the error helpers from Phase 2.
+
+### m-6: `_parse_meta` Return Type
+
+| Artifact | Return Type |
+|---|---|
+| PRD US-047 | `tuple[int \| None, str \| None]` |
+| Spec-005 | `_parse_meta(result: dict) -> tuple[int, str]` (no Optional) |
+| Task-V2 US-002 | `tuple[int \| None, str \| None]` |
+
+**Discrepancy:** Spec-005 omits `None` types in the return, while PRD and Task correctly indicate the values can be None.
+
+### m-7: `is_mcp_sandbox_error` Checks `McpSandboxError` Type
+
+| Artifact | Checks McpSandboxError? |
+|---|---|
+| PRD US-019 | "Checks for ConnectionError, TimeoutError, OSError, and McpSandboxError" |
+| Task-Dispatch US-005 | "Checks for connection errors (e.g., ConnectionError, TimeoutError, OSError)" — does NOT mention McpSandboxError |
+| Task-Dispatch Open Q | "If Phase 1 introduces McpSandboxError... should is_mcp_sandbox_error() check for that type?" |
+
+The PRD explicitly includes `McpSandboxError` in the check list. The Task leaves it as an open question.
+
+---
+
+## Missing ACs (Present in One Artifact, Absent in Corresponding Artifact)
+
+### Missing-1: PRD US-005 (`id` property) has `f"mcp-sandbox:{self._base_url}"` format
+- **Present in:** PRD, Task-Backend
+- **Absent from:** Spec-001 (says "Return sandbox URL or generated UUID" but does not specify the format string)
+
+### Missing-2: Path validation for upload/download (`invalid_path` error)
+- **Present in:** Task-Backend US-005, US-006
+- **Absent from:** PRD US-006, US-007; Spec-001
+
+### Missing-3: Conformance test count
+- **Present in:** Spec-004 ("24/24 tests passed" in example)
+- **Absent from:** Task-ExecServer (says "N/M tests passed" generically)
+
+### Missing-4: Frontend `ThreadSandboxStatus` reading `mcp_sandbox_url` from `getSettings()`
+- **Present in:** PRD US-043, Task-Frontend US-008
+- **Absent from:** Spec-003 (mentions it briefly but does not detail the data flow)
+
+### Missing-5: `notifications/initialized` Notification
+- **Present in:** PRD US-003, Task-Backend US-002
+- **Absent from:** Spec-001 (protocol section shows `initialize` but does not mention the `notifications/initialized` follow-up)
+
+Actually, Spec-001 does mention session lifecycle steps but does not include `notifications/initialized` in the protocol details section or the class skeleton. The PRD and Task-Backend both require it.
+
+### Missing-6: `_request_id` Increment Mechanics
+- **Present in:** PRD US-004 ("Increments self._request_id and uses it as the JSON-RPC id")
+- **Present in:** Task-Backend US-003 (same)
+- **Absent from:** Spec-001 class skeleton (shows `self._request_id = 0` in init but does not detail increment logic)
+
+---
+
+## Specificity Gaps
+
+### SG-1: Health Check Response Validation
+- **PRD US-008:** "Returns True if response is HTTP 200 and JSON body contains 'status': 'ok'" (specific)
+- **Spec-001:** "Check exec_server health via GET /health" (vague — no validation criteria)
+
+### SG-2: Session Reconnection Retry Count
+- **PRD US-004:** "retries once" (specific)
+- **Spec-001:** "retry once before raising" (consistent)
+- **Task-Backend US-003:** "retries once" (consistent)
+
+### SG-3: Frontend Health Check `isHealthy` Criteria
+- **PRD US-041:** "true on 2xx, false on any error" (specific)
+- **Task-Frontend US-006:** "true when GET returns 2xx, false on any error or non-2xx" (specific, consistent)
+- **Spec-003:** "isHealthy: boolean | null" in hook signature but checking criteria not detailed in AC
+
+### SG-4: Exit Code Regex — First vs Last Match
+- **PRD/Task-Backend:** Do not specify first vs last
+- **Spec-001:** "last match wins"
+- **Task-V2:** "last match is used"
+
+---
+
+## Overall Alignment Score: 5 / 10
+
+### Justification
+
+**What works well:**
+- The overall feature architecture is consistent across all layers: 5-phase approach, BaseSandbox extension, MCP JSON-RPC protocol, fallback chains
+- The PRD is comprehensive with 59 user stories and detailed ACs
+- The specs provide good implementation guidance with code snippets
+- Phase dependencies are correctly identified across all artifacts
+
+**What needs resolution before implementation:**
+- **3 showstopper contradictions (C-1, C-2, C-3):** The constructor parameter name/semantics, URL convention, and sync-vs-async decisions are fundamental to the class design. An implementer cannot proceed without resolving these first.
+- **2 protocol contradictions (C-5, C-8):** Different MCP protocol versions and client names would cause handshake issues
+- **1 deployment hazard (C-6):** The exec_server rename to `execute` (no alias) creates a breaking change window
+- **1 critical format mismatch (M-7):** The SSE error event format for `mcp_sandbox_unreachable` differs across 4 artifacts. Backend and frontend MUST agree.
+- **1 file path conflict (M-8):** ThreadSandboxStatus is referenced under two different directories
+- Multiple method name inconsistencies (C-7) that would cause test failures
+
+The PRD is the most complete and internally consistent artifact. The specs introduce implementation details that sometimes contradict the PRD. The tasks generally track the PRD well but add extra requirements (path validation) and leave open questions that the PRD has already resolved. The cross-boundary concerns (SSE format, URL convention) are the most dangerous because they span multiple implementers working on different phases.
+
+### Recommended Resolution Priority
+
+1. **Decide constructor signature**: `url` vs `base_url`, positional vs keyword-only, full MCP URL vs base URL
+2. **Decide sync vs async**: `httpx.Client` vs `httpx.AsyncClient`
+3. **Standardize SSE error event format** for `mcp_sandbox_unreachable`
+4. **Pick MCP protocol version**: `2024-11-05` vs `2025-03-26`
+5. **Standardize method name**: `_ensure_initialized()` vs `_ensure_session()`
+6. **Standardize timeout**: 120s vs 130s for default client timeout
+7. **Resolve ThreadSandboxStatus file path**: `tools/` vs `status/`
+8. **Address deployment ordering** for exec_command -> execute rename
+9. **Decide on exit code regex**: first match vs last match
+10. **Decide on path validation**: include `invalid_path` or not

--- a/.claude/plans/greedy-tumbling-boole-agent-a1f62fc892d2b5f0e.md
+++ b/.claude/plans/greedy-tumbling-boole-agent-a1f62fc892d2b5f0e.md
@@ -1,0 +1,199 @@
+# Story Coverage Audit: MCP Sandbox Feature (#890)
+
+## Methodology
+
+Mapped all 59 Ralph PRD user stories (US-001 through US-059) against:
+- 5 spec files in `.claude/specs/feat-890-mcp-sandbox/`
+- 5 PRD task files in `tasks/prd-mcp-sandbox-*.md`
+
+**Key structural observation**: Both spec files and PRD task files use **internal numbering** (US-001, US-002, etc. within each file). These do NOT correspond to Ralph's global numbering (US-001 through US-059). The mapping must be done by **content matching**, not by ID matching.
+
+---
+
+## 1. Coverage Matrix
+
+### Phase 1: McpSandboxBackend Core Class
+**Spec**: `001-mcp-sandbox-backend.md` | **PRD Task**: `tasks/prd-mcp-sandbox-backend.md`
+
+| Ralph ID | Ralph Title | Spec File | Spec Internal ID | PRD Task | PRD Internal ID | ID Mismatch? |
+|----------|------------|-----------|-----------------|----------|----------------|--------------|
+| US-001 | McpSandboxBackend class skeleton and constructor | 001 | Requirement 1-2 (class skeleton) | backend | US-001 | Yes - Ralph US-001 = PRD-backend US-001, but spec uses numbered requirements not US IDs |
+| US-002 | Custom McpSandboxError exception class | 001 | Requirement 6 (mentions custom exception) | backend | US-008 | Yes - Ralph US-002 maps to PRD-backend US-008 |
+| US-003 | MCP session initialization | 001 | Requirement 6 (session lifecycle) | backend | US-002 | Yes - Ralph US-003 maps to PRD-backend US-002 |
+| US-004 | execute() method | 001 | Requirement 2 | backend | US-003 | Yes - Ralph US-004 maps to PRD-backend US-003 |
+| US-005 | Sandbox id property | 001 | Requirement 3 | backend | US-004 | Yes - Ralph US-005 maps to PRD-backend US-004 |
+| US-006 | upload_files() | 001 | Requirement 4 | backend | US-005 | Yes - Ralph US-006 maps to PRD-backend US-005 |
+| US-007 | download_files() | 001 | Requirement 5 | backend | US-006 | Yes - Ralph US-007 maps to PRD-backend US-006 |
+| US-008 | health() async method | 001 | Requirement 7 | backend | US-007 | Yes - Ralph US-008 maps to PRD-backend US-007 |
+| US-009 | Client cleanup (close + context manager) | 001 | (mentioned in class skeleton as close()) | backend | US-009 | Match |
+| US-010 | Unit tests -- constructor and id | 001 | Requirement 9 (create unit tests) | backend | US-010 | Match |
+| US-011 | Unit tests -- MCP initialize handshake | 001 | Requirement 9 | backend | US-011 | Match |
+| US-012 | Unit tests -- execute method | 001 | Requirement 9 | backend | US-012 | Match |
+| US-013 | Unit tests -- upload and download files | 001 | Requirement 9 | backend | US-013 | Match |
+| US-014 | Unit tests -- health check and cleanup | 001 | Requirement 9 | backend | US-014 | Match |
+
+### Phase 2: Sandbox Dispatch Wiring
+**Spec**: `002-sandbox-dispatch.md` | **PRD Task**: `tasks/prd-mcp-sandbox-dispatch.md`
+
+| Ralph ID | Ralph Title | Spec File | Spec Internal ID | PRD Task | PRD Internal ID | ID Mismatch? |
+|----------|------------|-----------|-----------------|----------|----------------|--------------|
+| US-015 | Add MCP to SandboxType enum and UserSettings | 002 | Requirements 1-2 | dispatch | US-001 | Yes - Ralph US-015 = PRD-dispatch US-001 |
+| US-016 | Add mcp_sandbox_url to API schemas and routes | 002 | Requirements 3-4 | dispatch | US-002 | Yes - Ralph US-016 = PRD-dispatch US-002 |
+| US-017 | Add MCP sandbox factory and register | 002 | Requirements 5-6 | dispatch | US-003 | Yes - Ralph US-017 = PRD-dispatch US-003 |
+| US-018 | Update resolve_sandbox_backend() | 002 | Requirement 7 | dispatch | US-004 | Yes - Ralph US-018 = PRD-dispatch US-004 |
+| US-019 | Add is_mcp_sandbox_error() helper | 002 | Requirement 10 | dispatch | US-005 | Yes - Ralph US-019 = PRD-dispatch US-005 |
+| US-020 | Wire mcp_sandbox_url through LLMController | 002 | Requirement 8 (controllers) | dispatch | US-006 | Yes - Ralph US-020 = PRD-dispatch US-006 |
+| US-021 | Wire mcp_sandbox_url through stream_generator | 002 | Requirement 8 (stream) + 9 | dispatch | US-007 | Yes - Ralph US-021 = PRD-dispatch US-007 |
+| US-022 | Wire mcp_sandbox_url through worker tasks | 002 | Requirement 8 (worker) | dispatch | US-008 | Yes - Ralph US-022 = PRD-dispatch US-008 |
+| US-023 | Integration validation -- dispatch pipeline | 002 | (covered by success criteria 15-16) | dispatch | US-009 | Yes - Ralph US-023 = PRD-dispatch US-009 |
+
+### Phase 4: exec_server Structured Tools (sandboxes submodule)
+**Spec**: `004-exec-server-structured.md` | **PRD Task**: `tasks/prd-mcp-sandbox-exec-server.md`
+
+| Ralph ID | Ralph Title | Spec File | Spec Internal ID | PRD Task | PRD Internal ID | ID Mismatch? |
+|----------|------------|-----------|-----------------|----------|----------------|--------------|
+| US-024 | Rename exec_command to execute | 004 | Requirement 1, 3 | exec-server | US-001 | Yes - Ralph US-024 = PRD-exec US-001 |
+| US-025 | Add _meta structure to all tool responses | 004 | Requirement 2 | exec-server | US-002 | Yes - Ralph US-025 = PRD-exec US-002 |
+| US-026 | Implement read MCP tool | 004 | Requirement 4 | exec-server | US-003 | Yes - Ralph US-026 = PRD-exec US-003 |
+| US-027 | Implement write MCP tool | 004 | Requirement 5 | exec-server | US-004 | Yes - Ralph US-027 = PRD-exec US-004 |
+| US-028 | Implement edit MCP tool | 004 | Requirement 6 | exec-server | US-005 | Yes - Ralph US-028 = PRD-exec US-005 |
+| US-029 | Implement grep MCP tool | 004 | Requirement 7 | exec-server | US-006 | Yes - Ralph US-029 = PRD-exec US-006 |
+| US-030 | Implement glob MCP tool | 004 | Requirement 8 | exec-server | US-007 | Yes - Ralph US-030 = PRD-exec US-007 |
+| US-031 | Implement ls MCP tool | 004 | Requirement 9 | exec-server | US-008 | Yes - Ralph US-031 = PRD-exec US-008 |
+| US-032 | Implement upload_file MCP tool | 004 | Requirement 10 | exec-server | US-009 | Yes - Ralph US-032 = PRD-exec US-009 |
+| US-033 | Implement download_file MCP tool | 004 | Requirement 11 | exec-server | US-010 | Yes - Ralph US-033 = PRD-exec US-010 |
+| US-034 | Infrastructure -- sandbox_id, python3, /workspace | 004 | Requirements 12-14 | exec-server | US-011 | Yes - Ralph US-034 = PRD-exec US-011 |
+| US-035 | Conformance test suite for all 9 MCP tools | 004 | Requirement 16 | exec-server | US-012 | Yes - Ralph US-035 = PRD-exec US-012 |
+
+### Phase 3: Frontend MCP Option + Health + Fallback UX
+**Spec**: `003-frontend-mcp-option.md` | **PRD Task**: `tasks/prd-mcp-sandbox-frontend.md`
+
+| Ralph ID | Ralph Title | Spec File | Spec Internal ID | PRD Task | PRD Internal ID | ID Mismatch? |
+|----------|------------|-----------|-----------------|----------|----------------|--------------|
+| US-036 | Extend SandboxType union and normalizeSandboxValue | 003 | Requirements 1, 5 | frontend | US-001 | Yes - Ralph US-036 = PRD-frontend US-001 |
+| US-037 | Add mcp_sandbox_url to API type interfaces | 003 | Requirements 2-3 | frontend | US-002 | Yes - Ralph US-037 = PRD-frontend US-002 |
+| US-038 | Add MCP entry to SANDBOX_OPTIONS | 003 | Requirement 4 | frontend | US-003 | Yes - Ralph US-038 = PRD-frontend US-003 |
+| US-039 | Add MCP Sandbox URL input field | 003 | Requirement 6 | frontend | US-004 | Yes - Ralph US-039 = PRD-frontend US-004 |
+| US-040 | MCP option visibility gating | 003 | Requirement 7 | frontend | US-005 | Yes - Ralph US-040 = PRD-frontend US-005 |
+| US-041 | Create useSandboxHealth hook | 003 | Requirement 8 | frontend | US-006 | Yes - Ralph US-041 = PRD-frontend US-006 |
+| US-042 | Health dot in SandboxSettings dropdown | 003 | Requirement 9 | frontend | US-007 | Yes - Ralph US-042 = PRD-frontend US-007 |
+| US-043 | Health dot in ThreadSandboxStatus popover | 003 | Requirement 10 | frontend | US-008 | Yes - Ralph US-043 = PRD-frontend US-008 |
+| US-044 | Handle mcp_sandbox_unreachable SSE event | 003 | Requirements 11-12 | frontend | US-009 | Yes - Ralph US-044 = PRD-frontend US-009 |
+| US-045 | Frontend integration validation | 003 | (covered by success criteria 16) | frontend | US-010 | Yes - Ralph US-045 = PRD-frontend US-010 |
+
+### Phase 5: McpSandboxBackend v2 Native MCP Tools
+**Spec**: `005-mcp-sandbox-v2.md` | **PRD Task**: `tasks/prd-mcp-sandbox-v2-native.md`
+
+| Ralph ID | Ralph Title | Spec File | Spec Internal ID | PRD Task | PRD Internal ID | ID Mismatch? |
+|----------|------------|-----------|-----------------|----------|----------------|--------------|
+| US-046 | Tool discovery on session init | 005 | Requirement 1-2 | v2-native | US-001 | Yes - Ralph US-046 = PRD-v2 US-001 |
+| US-047 | Dual-mode exit code extraction | 005 | Requirement 3 | v2-native | US-002 | Yes - Ralph US-047 = PRD-v2 US-002 |
+| US-048 | Sandbox ID from _meta.sandbox_id | 005 | Requirement 4 | v2-native | US-003 | Yes - Ralph US-048 = PRD-v2 US-003 |
+| US-049 | Override execute() -- dual tool name | 005 | Requirement 5 | v2-native | US-004 | Yes - Ralph US-049 = PRD-v2 US-004 |
+| US-050 | Override read() | 005 | Requirement 6 | v2-native | US-005 | Yes - Ralph US-050 = PRD-v2 US-005 |
+| US-051 | Override write() | 005 | Requirement 7 | v2-native | US-006 | Yes - Ralph US-051 = PRD-v2 US-006 |
+| US-052 | Override edit() | 005 | Requirement 8 | v2-native | US-007 | Yes - Ralph US-052 = PRD-v2 US-007 |
+| US-053 | Override grep_raw() | 005 | Requirement 9 | v2-native | US-008 | Yes - Ralph US-053 = PRD-v2 US-008 |
+| US-054 | Override glob_info() | 005 | Requirement 10 | v2-native | US-009 | Yes - Ralph US-054 = PRD-v2 US-009 |
+| US-055 | Override ls_info() | 005 | Requirement 11 | v2-native | US-010 | Yes - Ralph US-055 = PRD-v2 US-010 |
+| US-056 | Override upload_files() | 005 | Requirement 12 | v2-native | US-011 | Yes - Ralph US-056 = PRD-v2 US-011 |
+| US-057 | Override download_files() | 005 | Requirement 13 | v2-native | US-012 | Yes - Ralph US-057 = PRD-v2 US-012 |
+| US-058 | Graceful degradation -- old exec_server | 005 | Requirement 15 | v2-native | US-013 | Yes - Ralph US-058 = PRD-v2 US-013 |
+| US-059 | Integration validation -- all tests pass | 005 | Requirement 16-17 | v2-native | US-014 | Yes - Ralph US-059 = PRD-v2 US-014 |
+
+---
+
+## 2. Orphan Detection
+
+### Stories in Ralph PRD NOT covered by any spec: **NONE**
+All 59 Ralph stories (US-001 through US-059) are covered by at least one spec file.
+
+### Stories in Ralph PRD NOT covered by any PRD task: **NONE**
+All 59 Ralph stories (US-001 through US-059) are covered by at least one PRD task file.
+
+### Requirements in specs NOT reflected in Ralph PRD
+
+**Spec 001 (001-mcp-sandbox-backend.md):**
+- The spec mentions a `_call_tool()` private helper method and `_base_url()` helper in its class skeleton (line 131-138). These are implementation details, not separate stories in Ralph. **Not a gap** -- they are internal to the class implementation stories.
+- The spec has a detailed "Technical Considerations" section about sync vs async `execute()` and `BaseSandbox` contract (lines 282-288). Ralph does not have a dedicated story for this design decision. **Not a gap** -- this is design guidance, not a deliverable.
+
+**Spec 002 (002-sandbox-dispatch.md):**
+- No orphan requirements found. All numbered requirements map to Ralph stories.
+
+**Spec 003 (003-frontend-mcp-option.md):**
+- The spec mentions `SSEEvent` type updates, `fetchStreamReader.ts` changes, and `useChat.ts` changes in its "Files Changed" table (lines 346-353). These are implementation detail files for US-044 (mcp_sandbox_unreachable handling). **Not a gap** -- covered by Ralph US-044.
+
+**Spec 004 (004-exec-server-structured.md):**
+- Requirement 15: "Update `tools/list` response: All 9 tools should be listed" -- This is covered implicitly in Ralph US-035 (conformance test validates tools/list). **Not a separate gap**.
+- Success criterion 20: "All tool handlers run commands as `executor` user (unprivileged)" -- This is mentioned in individual Ralph stories' acceptance criteria. **Not a separate gap**.
+
+**Spec 005 (005-mcp-sandbox-v2.md):**
+- Requirement 14: "All native tool overrides must return the exact same types" (return type parity). This is covered implicitly across all override stories in Ralph (US-049 through US-057). Ralph US-059 integration validation also covers this. **Not a separate gap**.
+- The spec's `_parse_json_lines()` helper is mentioned in requirement 9 (grep) and the implementation approach section. Ralph US-053 includes it in acceptance criteria. **Not a gap**.
+
+### Requirements in PRD tasks NOT reflected in Ralph PRD
+
+**PRD-backend:**
+- FR-12: "All logging MUST use `src.utils.logger.logger`" -- This is an acceptance criterion in Ralph US-001 ("from src.utils.logger import logger is used for all logging"). **Not a gap**.
+- FR-13: "A custom `McpSandboxError(Exception)` MUST be defined" -- This is Ralph US-002. **Not a gap**.
+- The PRD-backend has a detailed "Open Questions" section (lines 305-309) covering sync/async, close() lifecycle, timeout matching, base64 for large files, and URL format. None of these resulted in separate Ralph stories. **Minor gap** -- these design decisions should be documented as notes on the relevant stories, but they are not missing deliverables.
+
+**PRD-dispatch:**
+- All requirements map cleanly to Ralph stories.
+
+**PRD-frontend:**
+- The PRD-frontend has detailed "Technical Considerations" sections about health endpoint derivation algorithm, SSE event handling pattern, toast retry mechanism, and visibility gating approach (lines 257-340). These are implementation guidance for existing Ralph stories. **Not gaps**.
+- Open question about CORS proxying through backend API (line 373). Not reflected as a separate story. **Minor gap** -- but this is an open question, not a committed deliverable.
+
+**PRD-exec-server:**
+- FR-14: "Tool Registration" and FR-15: "Unprivileged Execution" are covered in individual tool stories' acceptance criteria. **Not gaps**.
+
+**PRD-v2-native:**
+- FR-10: "JSON lines parsing must handle empty text, single-line, and multi-line responses gracefully, skipping malformed lines" -- Covered in Ralph US-053 (grep_raw) acceptance criteria which mentions `_parse_json_lines`. **Not a separate gap**, though it's a cross-cutting concern used by US-053, US-054, and US-055.
+
+---
+
+## 3. ID Mismatch Summary
+
+**Every PRD task file and spec file uses internal numbering that resets to US-001 within each file.** This is a systematic pattern, not an error:
+
+| Layer | ID Range | Ralph Global Range |
+|-------|----------|-------------------|
+| PRD-backend | US-001 to US-014 | Ralph US-001 to US-014 |
+| PRD-dispatch | US-001 to US-009 | Ralph US-015 to US-023 |
+| PRD-exec-server | US-001 to US-012 | Ralph US-024 to US-035 |
+| PRD-frontend | US-001 to US-010 | Ralph US-036 to US-045 |
+| PRD-v2-native | US-001 to US-014 | Ralph US-046 to US-059 |
+
+The spec files use numbered requirements (1, 2, 3...) rather than US-XXX IDs, making them even less directly comparable. However, the content aligns 1:1.
+
+**Notable ID ordering differences between Ralph and PRD-backend:**
+- Ralph US-002 (McpSandboxError) = PRD-backend US-008 (moved to later position)
+- Ralph US-003 (session init) = PRD-backend US-002 (moved earlier)
+- Ralph US-004 (execute) = PRD-backend US-003
+- Ralph US-005 (id property) = PRD-backend US-004
+- Ralph US-006 (upload_files) = PRD-backend US-005
+- Ralph US-007 (download_files) = PRD-backend US-006
+- Ralph US-008 (health) = PRD-backend US-007
+
+The PRD-backend reordered the McpSandboxError story from position 2 (Ralph) to position 8 (PRD-backend), placing it after all the method implementations. All other phase PRD tasks maintain the same relative ordering as Ralph.
+
+---
+
+## 4. Overall Coverage Score: **9/10**
+
+### Justification
+
+**Strengths (pushing toward 10):**
+- Perfect 59/59 story coverage: every Ralph story maps to both a spec file and a PRD task file
+- Zero orphan stories in any direction (no Ralph stories missing from specs/PRDs, no spec/PRD requirements missing from Ralph)
+- Consistent phase grouping: stories are logically grouped into 5 phases across all three layers
+- Acceptance criteria alignment: Ralph's acceptance criteria are faithfully reflected in both specs and PRDs, often with additional implementation detail in the PRDs
+- Dependency chains are explicit and consistent across all three layers
+
+**Weaknesses (preventing 10):**
+- **ID numbering mismatch (-0.5)**: PRD tasks use file-local US-001 numbering that collides with Ralph's global numbering. This creates potential confusion when referencing stories across documents. A developer looking at "US-003" needs to know which document to interpret it in context. The PRD-backend additionally reorders the McpSandboxError story relative to Ralph.
+- **Spec files use requirement numbers, not US-IDs (-0.25)**: The specs use numbered requirements (1-16) rather than US-XXX identifiers, making cross-referencing between Ralph and specs require content matching rather than ID lookup.
+- **Open questions untracked (-0.25)**: Several PRD files contain open design questions (sync/async execute, CORS proxying, file size limits, etc.) that are not tracked as notes on corresponding Ralph stories. These could block implementation if not resolved pre-development.
+
+**Overall**: The three artifact layers are in excellent alignment. Content coverage is 100% with no gaps. The only friction is in the ID numbering scheme, which is a traceability inconvenience rather than a coverage gap.

--- a/.claude/plans/greedy-tumbling-boole-agent-a6e07ed02be61f7cd.md
+++ b/.claude/plans/greedy-tumbling-boole-agent-a6e07ed02be61f7cd.md
@@ -1,0 +1,356 @@
+# Technical Consistency Audit: MCP Sandbox Feature (#890)
+
+## Summary
+
+Overall **Score: 6.5/10** -- The specifications, PRDs, and Ralph stories are largely consistent with each other in terms of design intent, but contain **15 concrete discrepancies** with the existing codebase that must be resolved before implementation. The most critical issues are constructor signature inconsistencies, a breaking change to `_resolve_user_settings`, and a missing field mapping in the settings repo.
+
+---
+
+## Dimension 1: API Contract Consistency
+
+### DISCREPANCY 1 -- `_resolve_user_settings` 3-tuple to 4-tuple is a breaking change
+
+**Severity: HIGH**
+
+The existing `_resolve_user_settings()` at `/home/ryaneggz/ruska-ai/orchestra/backend/src/controllers/llm.py:70` returns a 3-tuple:
+
+```python
+async def _resolve_user_settings(self, model: str) -> tuple[str, str | None, str | None]:
+    # Returns (model, api_key, default_sandbox)
+```
+
+All three callers unpack it as a 3-tuple:
+- `llm_invoke` line 121: `params.model, api_key, default_sandbox = await self._resolve_user_settings(params.model)`
+- `llm_stream` line 211: `assistant.model, api_key, default_sandbox = await self._resolve_user_settings(assistant.model)`
+
+The specs (002-sandbox-dispatch.md, prd-mcp-sandbox-dispatch.md) and Ralph US-020 propose changing this to a 4-tuple `(model, api_key, default_sandbox, mcp_sandbox_url)`. **Every existing call site must be updated simultaneously or they will crash with a ValueError from tuple unpacking.** The artifacts correctly identify both callsites, but do not mention that the worker task (`_execute_agent_stream` in `tasks.py`) independently duplicates this logic (lines 421-431) rather than calling `_resolve_user_settings()`. The worker reads `default_sandbox` directly from `settings` -- the same pattern must be replicated for `mcp_sandbox_url`.
+
+**Status: Acknowledged in artifacts** -- US-022 and prd-mcp-sandbox-dispatch US-008 both address the worker, but the worker does NOT call `_resolve_user_settings()` -- it has its own inline settings resolution. The spec says "mirrors LLMController._resolve_user_settings" which is accurate.
+
+### DISCREPANCY 2 -- `DefaultsResponse` missing `mcp_sandbox_url` field in `_build_response()`
+
+**Severity: HIGH**
+
+The specs and PRDs propose adding `mcp_sandbox_url` to `DefaultsResponse`. The existing `_build_response()` in `/home/ryaneggz/ruska-ai/orchestra/backend/src/routes/v0/settings.py:24-40` explicitly maps each field:
+
+```python
+defaults=DefaultsResponse(
+    model=settings.default_model,
+    sandbox=settings.default_sandbox,
+    # ... 9 explicit fields ...
+    timezone=settings.default_timezone,
+)
+```
+
+The specs (002-sandbox-dispatch.md criteria #3, prd-mcp-sandbox-dispatch US-002) correctly identify that `_build_response()` must be updated. However, they also reference `_DEFAULTS_FIELD_MAP` in `UserSettingsRepo` -- and this mapping at `/home/ryaneggz/ruska-ai/orchestra/backend/src/repos/user_settings_repo.py:188-200` does NOT currently have `mcp_sandbox_url`. Both the `_build_response()` mapping AND `_DEFAULTS_FIELD_MAP` must be updated. The PRD correctly identifies both.
+
+**Status: Consistently identified across artifacts.**
+
+### DISCREPANCY 3 -- `PatchDefaultsRequest` has no `mcp_sandbox_url` field yet
+
+**Severity: MEDIUM**
+
+The existing `PatchDefaultsRequest` in `settings.py:87-108` does not include `mcp_sandbox_url`. The `patch_defaults()` method in the repo uses `_DEFAULTS_FIELD_MAP` to translate short keys to entity field names. Both the field on `PatchDefaultsRequest` and the repo map entry are needed. Additionally, the `patch_defaults()` method validates `sandbox` against `SandboxType` enum values (line 204-207) -- once `MCP = "mcp"` is added to the enum, `sandbox: "mcp"` will be accepted automatically.
+
+**Status: Consistently identified.**
+
+### DISCREPANCY 4 -- SSE error event format inconsistency between spec and PRD
+
+**Severity: MEDIUM**
+
+The spec 002 (`002-sandbox-dispatch.md`) shows the SSE error as:
+```python
+error_msg = ujson.dumps(("mcp_sandbox_unreachable", str(e)))
+```
+
+But the frontend PRD (`prd-mcp-sandbox-frontend.md`) describes the SSE event as:
+```
+data: ["mcp_sandbox_unreachable", {"message": "Connection refused"}]
+```
+
+And the dispatch PRD (`prd-mcp-sandbox-dispatch.md` US-007) says:
+```python
+("error", {"type": "mcp_sandbox_unreachable", "message": "<detail>"})
+```
+
+These are **three different wire formats**. The existing Daytona pattern in `stream.py:417` uses:
+```python
+error_msg = ujson.dumps(("error", f"Daytona sandbox error: {e}"))
+```
+
+The artifacts must agree on ONE format. The existing pattern is `("error", <string>)`. To add a typed error, a structured format like `("error", {"type": "mcp_sandbox_unreachable", "message": str(e)})` would be the least disruptive, but the frontend must be updated to parse both string and dict payloads for the `"error"` event.
+
+---
+
+## Dimension 2: Existing Pattern Conformance
+
+### DISCREPANCY 5 -- MCP factory signature differs from Daytona factory
+
+**Severity: MEDIUM**
+
+The existing `_create_daytona_backend_checked(runtime)` takes only `runtime` as a parameter and returns `tuple[CompositeBackend, Any] | None`. The proposed `_create_mcp_backend_checked(runtime, mcp_sandbox_url)` takes an extra parameter. This means it CANNOT be registered in `_SANDBOX_FACTORIES` the same way as Daytona, because the factory dispatch in `resolve_sandbox_backend()` (line 334) currently calls factories with just `runtime`:
+
+```python
+effective = sandbox_type if sandbox_type in _SANDBOX_FACTORIES else None
+```
+
+The specs acknowledge this -- they propose special-casing MCP in `resolve_sandbox_backend()` rather than using the factory dict generically. However, the Ralph story US-017 says `'mcp' key added to _SANDBOX_FACTORIES dict` while simultaneously noting the factory needs a URL parameter. This creates an inconsistency: registering in the dict is cosmetic since MCP can't be dispatched through the generic path.
+
+**Recommendation:** Either update the factory protocol to accept `**kwargs`, or don't register MCP in `_SANDBOX_FACTORIES` and handle it explicitly in `resolve_sandbox_backend()`.
+
+### DISCREPANCY 6 -- `is_mcp_sandbox_error()` does not check for `McpSandboxError`
+
+**Severity: LOW**
+
+The spec 002 and Ralph US-019 define `is_mcp_sandbox_error()` as checking for `ConnectionError, TimeoutError, OSError, and McpSandboxError`. The existing `is_daytona_error()` at `agents/__init__.py:49-53` uses `isinstance(exc, DaytonaError)` -- a single type check. The MCP version proposes checking multiple exception types, which is a different pattern. Additionally, `McpSandboxError` is defined in `mcp_sandbox.py` (spec 001), but `is_mcp_sandbox_error()` is in `agents/__init__.py` (spec 002). This means `agents/__init__.py` will need to import from `mcp_sandbox.py`, creating a cross-module dependency. The Daytona pattern avoids this because `DaytonaError` comes from an external package.
+
+**Recommendation:** Use a conditional import (try/except) for `McpSandboxError`, mirroring the Daytona conditional import pattern at `agents/__init__.py:23-31`.
+
+### DISCREPANCY 7 -- Frontend visibility gating pattern differs from Daytona
+
+**Severity: LOW**
+
+The existing Daytona gating in `SandboxSettings.tsx:35-43` uses `providerKeys` to filter:
+```typescript
+if (opt.value !== "daytona") return true;
+return providerKeys.some(k => k.provider === "DAYTONA_API_KEY" && k.is_set);
+```
+
+The proposed MCP gating uses `mcp_sandbox_url` (a string from settings, not from `providerKeys`). This means:
+1. `SandboxSettings.tsx` needs new state for `mcpSandboxUrl` (currently does not exist)
+2. The `visibleOptions` memo must depend on both `providerKeys` AND `mcpSandboxUrl`
+3. The `getSettings()` response must be parsed for `mcp_sandbox_url`
+
+The specs correctly identify this, and the pattern is sound. The state management is different from Daytona (provider key vs. URL string) but the filtering logic is analogous. The frontend PRD and spec 003 handle this consistently.
+
+---
+
+## Dimension 3: Import Path Validity
+
+### DISCREPANCY 8 -- Spec 001 references `BaseSandbox` from `deepagents.backends.sandbox`
+
+**Severity: HIGH (needs verification)**
+
+Spec 001 and the PRD reference:
+```python
+from deepagents.backends.sandbox import BaseSandbox, ExecuteResponse, FileUploadResponse, FileDownloadResponse
+```
+
+The codebase imports from `deepagents.backends`:
+```python
+from deepagents.backends import CompositeBackend, StateBackend
+```
+(at `agents/__init__.py:18`)
+
+The exact module path `deepagents.backends.sandbox` for `BaseSandbox` is stated in the spec but **cannot be verified** without inspecting the installed `deepagents` package. The spec's PRD notes it's at `deepagents.backends.sandbox` and references `langchain_daytona/sandbox.py` as using the same base class.
+
+**Recommendation:** Verify with `python -c "from deepagents.backends.sandbox import BaseSandbox"` before implementing.
+
+### DISCREPANCY 9 -- Spec 001 constructor signature `base_url` vs `url`
+
+**Severity: HIGH**
+
+The spec 001 markdown shows **two different constructor signatures**:
+
+1. In the PRD (`prd-mcp-sandbox-backend.md` US-001): `__init__(self, *, base_url: str, api_key: str | None = None)` -- keyword-only, parameter named `base_url`
+2. In the spec class skeleton (`001-mcp-sandbox-backend.md`): `__init__(self, url: str, api_key: str | None = None)` -- positional, parameter named `url`
+3. In the Ralph prd.json US-001: `__init__(self, *, base_url: str, api_key: str | None = None)` -- keyword-only, named `base_url`
+
+The spec 002 factory code references:
+```python
+McpSandboxBackend(url=mcp_sandbox_url)
+```
+
+This inconsistency between `base_url` and `url` will cause an import-time or call-time error depending on which spec is followed.
+
+The `id` property uses `self._base_url` in the PRD but the spec skeleton stores it as `self._url`. The Ralph stories reference both.
+
+**Recommendation:** Standardize on one name. Given the `_base_url` property in the spec skeleton, `url` as constructor param with `self._url` as attribute (and `_base_url()` as a derived method) seems cleanest. But all specs must agree.
+
+### DISCREPANCY 10 -- `execute()` timeout parameter type mismatch
+
+**Severity: MEDIUM**
+
+- Spec 001 class skeleton: `timeout: float | None = None`
+- Ralph US-004: `timeout: int | None = None`
+- PRD US-003: `timeout: int | None = None`
+
+The exec_server (spec 004) expects `timeout?: number` in Zod (which maps to both int and float in JSON). Using `int` is more restrictive but the underlying httpx accepts both. This should be `int | None` for consistency with the PRD.
+
+---
+
+## Dimension 4: Method Signature Accuracy
+
+### DISCREPANCY 11 -- `resolve_sandbox_backend()` current signature vs proposed
+
+**Severity: HIGH**
+
+Current signature at `agents/__init__.py:319-322`:
+```python
+def resolve_sandbox_backend(
+    runtime: ToolRuntime,
+    sandbox_type: str | None = None,
+) -> tuple[CompositeBackend, Any, str]:
+```
+
+Proposed (spec 002, Ralph US-018):
+```python
+def resolve_sandbox_backend(
+    runtime: ToolRuntime,
+    sandbox_type: str | None = None,
+    mcp_sandbox_url: str | None = None,
+) -> tuple[CompositeBackend, Any, str]:
+```
+
+Adding a new keyword-only parameter with a default is backward-compatible. All existing callers pass `sandbox_type` as a keyword argument:
+- `llm.py:142`: `resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)`
+- `stream.py:376`: `resolve_sandbox_backend(runtime, sandbox_type=sandbox_type)`
+- `tasks.py:455`: `resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)`
+
+**Status: This is safe.** The new `mcp_sandbox_url` parameter with default `None` will not break any existing callers.
+
+### DISCREPANCY 12 -- `stream_generator()` signature change
+
+**Severity: MEDIUM**
+
+Current signature at `stream.py:321-333`:
+```python
+async def stream_generator(
+    input: LLMInput,
+    model: BaseChatModel,
+    system_prompt: str,
+    tools: list[BaseTool],
+    subagents: list[SubAgent],
+    config: RunnableConfig,
+    service_context: ServiceContext,
+    instructions: str = None,
+    api_key: str | None = None,
+    sandbox_type: str | None = None,
+    stream_mode: list[str] | None = None,
+):
+```
+
+The spec proposes adding `mcp_sandbox_url: str | None = None`. The caller in `llm.py:213-225` passes keyword arguments:
+
+```python
+return stream_generator(
+    input=assistant.input,
+    ...
+    sandbox_type=default_sandbox,
+    stream_mode=assistant.resolved_stream_mode,
+)
+```
+
+Adding `mcp_sandbox_url` as a new keyword-only parameter with default is safe, but the caller must also pass it. The spec and PRD correctly identify this.
+
+---
+
+## Dimension 5: Type System Consistency
+
+### DISCREPANCY 13 -- `UserSettings.default_mcp_sandbox_url` vs `default_mcp` field name collision risk
+
+**Severity: LOW**
+
+The existing `UserSettings` has `default_mcp: Optional[dict]` (line 46 of settings.py) which is for MCP server configuration. The proposed new field is `default_mcp_sandbox_url: Optional[str]`. These are clearly different -- `default_mcp` is the MCP tool server config, `default_mcp_sandbox_url` is the sandbox server URL. However, the naming proximity could cause confusion. The spec/PRD are consistent with each other on the naming.
+
+### DISCREPANCY 14 -- Frontend `SandboxType` is a string union, not an enum
+
+**Severity: LOW**
+
+Backend uses `SandboxType(str, Enum)` but frontend uses `type SandboxType = "daytona" | "state"`. The specs correctly propose adding `| "mcp"` to the frontend union and `MCP = "mcp"` to the backend enum. These are consistent.
+
+### DISCREPANCY 15 -- `ThreadSandboxStatus.tsx` file path discrepancy in specs
+
+**Severity: LOW**
+
+Spec 003 references the file at:
+```
+frontend/src/components/tools/ThreadSandboxStatus.tsx
+```
+
+But the actual file is at:
+```
+frontend/src/components/status/ThreadSandboxStatus.tsx
+```
+
+The correct path is `/home/ryaneggz/ruska-ai/orchestra/frontend/src/components/status/ThreadSandboxStatus.tsx`. The spec's "Files" table at the bottom of 003 says `frontend/src/components/tools/ThreadSandboxStatus.tsx` -- **this is wrong**.
+
+---
+
+## Dimension 6: Cross-Artifact Consistency
+
+### Phase dependency chain verification
+
+The Ralph prd.json organizes 59 user stories across 5 phases (P1-P5) with priorities 1-59. The dependency chain is:
+
+- **P1 (US-001 to US-014):** McpSandboxBackend class -- **no dependencies, self-contained**
+- **P2 (US-015 to US-023):** Dispatch wiring -- **depends on P1** (needs `McpSandboxBackend`)
+- **P3 (US-036 to US-045):** Frontend -- **independent** of P1/P4, depends on P2 API contract only
+- **P4 (US-024 to US-035):** exec_server tools -- **independent** (separate submodule)
+- **P5 (US-046 to US-059):** Native MCP tools -- **depends on P2 + P4**
+
+The dependency chain is correctly specified. P3 frontend can be built against the API contract from P2 without needing the actual backend implementation.
+
+### Spec-to-Ralph story mapping
+
+All 5 specs map cleanly to Ralph user stories:
+- Spec 001 -> Ralph US-001 to US-014 (P1)
+- Spec 002 -> Ralph US-015 to US-023 (P2)
+- Spec 003 -> Ralph US-036 to US-045 (P3)
+- Spec 004 -> Ralph US-024 to US-035 (P4)
+- Spec 005 -> Ralph US-046 to US-059 (P5)
+
+The PRD files (`tasks/prd-*.md`) align with their corresponding specs. No orphaned stories.
+
+### Tool name: `exec_command` vs `execute` transition
+
+Spec 004 renames `exec_command` to `execute` (clean break, no alias). Spec 005 (v2) adds dual-name support (`execute` preferred, `exec_command` fallback). Spec 001 (Phase 1) uses `exec_command` exclusively. This is intentionally sequential:
+1. P1 ships with `exec_command` (current exec_server)
+2. P4 renames to `execute` (new exec_server)
+3. P5 adds client-side support for both names
+
+This is consistent and well-designed.
+
+---
+
+## Summary of All Discrepancies
+
+| # | Severity | Description | Files Affected |
+|---|----------|-------------|----------------|
+| 1 | HIGH | `_resolve_user_settings` 3-to-4-tuple breaking change requires all callers updated simultaneously | `controllers/llm.py`, `workers/tasks.py` |
+| 2 | HIGH | `_build_response()` must add `mcp_sandbox_url` mapping | `routes/v0/settings.py` |
+| 3 | MEDIUM | `PatchDefaultsRequest` and `_DEFAULTS_FIELD_MAP` both need updates | `schemas/entities/settings.py`, `repos/user_settings_repo.py` |
+| 4 | MEDIUM | SSE error event wire format inconsistent across 3 artifacts | `utils/stream.py`, frontend event handlers |
+| 5 | MEDIUM | MCP factory can't fit generic `_SANDBOX_FACTORIES` dispatch protocol | `agents/__init__.py` |
+| 6 | LOW | `is_mcp_sandbox_error()` needs conditional import pattern | `agents/__init__.py` |
+| 7 | LOW | MCP visibility gating uses URL (not provider key) -- new state needed | `SandboxSettings.tsx`, `ThreadSandboxStatus.tsx` |
+| 8 | HIGH | `deepagents.backends.sandbox.BaseSandbox` import path unverified | `agents/mcp_sandbox.py` (new) |
+| 9 | HIGH | Constructor param named `base_url` in PRD vs `url` in spec skeleton | `agents/mcp_sandbox.py` (new), `agents/__init__.py` |
+| 10 | MEDIUM | `execute()` timeout type: `float` in spec skeleton vs `int` in PRD/Ralph | `agents/mcp_sandbox.py` (new) |
+| 11 | HIGH | `resolve_sandbox_backend()` signature change is safe (backward-compatible) | `agents/__init__.py` |
+| 12 | MEDIUM | `stream_generator()` must pass new `mcp_sandbox_url` param | `utils/stream.py`, `controllers/llm.py` |
+| 13 | LOW | `default_mcp` vs `default_mcp_sandbox_url` naming proximity | `schemas/entities/settings.py` |
+| 14 | LOW | Frontend/backend type systems aligned (union vs enum) | N/A |
+| 15 | LOW | `ThreadSandboxStatus.tsx` file path wrong in spec 003 | Spec 003 only |
+
+---
+
+## Score Justification: 6.5/10
+
+**Positives (pushing score up):**
+- The overall architecture is sound and well-decomposed across 5 phases
+- Dependency ordering is correct -- phases can be parallelized as documented
+- The fallback chain design (Daytona -> MCP -> State) follows the existing pattern cleanly
+- Frontend patterns (visibility gating, health hook, toast) are well-aligned with existing code
+- Return type parity requirements in Phase 5 are thorough and correct
+- The worker task (`tasks.py`) is correctly identified as a third caller site
+
+**Negatives (pushing score down):**
+- **Constructor name disagreement** (`base_url` vs `url`) across 3 artifacts is a guaranteed implementation bug
+- **SSE wire format** has 3 different proposals across the artifacts
+- **The `_SANDBOX_FACTORIES` registration** is specified but impractical given the different factory signature
+- **Import path for `BaseSandbox`** is assumed correct but unverified against the installed package
+- **File path for ThreadSandboxStatus** is wrong in spec 003 (`tools/` vs `status/`)
+- The `timeout` type inconsistency (`float` vs `int`) is minor but will cause a type-check failure if not resolved
+
+The specs are internally well-structured and thorough. The main gaps are cross-artifact coordination issues (naming, wire formats) and a few assumptions about the codebase that don't match reality. Fixing the 5 HIGH-severity items before implementation would raise this to an 8/10.

--- a/.claude/plans/greedy-tumbling-boole-agent-aec0915e73f3d3de4.md
+++ b/.claude/plans/greedy-tumbling-boole-agent-aec0915e73f3d3de4.md
@@ -1,0 +1,256 @@
+# Cross-Phase Dependency & Sequencing Audit: MCP Sandbox (#890)
+
+## Executive Summary
+
+The MCP Sandbox feature is decomposed into 5 phases with 59 user stories in Ralph's `prd.json`. The analysis reveals **3 critical sequencing risks**, **4 moderate dependency gaps**, and **2 minor ordering preferences**. The overall dependency alignment score is **5/10** -- functional but with real gaps that will cause execution failures if unaddressed.
+
+---
+
+## 1. Priority vs Dependency Conflict Analysis
+
+### Ralph Priority Mapping
+
+Ralph processes stories by ascending `priority` number. The actual execution order encoded in `prd.json` is:
+
+| Phase | Description | Ralph Priority Range | Story IDs |
+|-------|------------|---------------------|-----------|
+| P1 | McpSandboxBackend Core | 1--14 | US-001 to US-014 |
+| P2 | Sandbox Dispatch Wiring | 15--23 | US-015 to US-023 |
+| P4 | exec_server Structured Tools | 24--35 | US-024 to US-035 |
+| P3 | Frontend MCP Option | 36--45 | US-036 to US-045 |
+| P5 | Native MCP Tool Overrides | 46--59 | US-046 to US-059 |
+
+**Observation**: The numbering scheme (P1, P2, P4, P3, P5) is intentional -- P4 (exec_server) has lower priority numbers than P3 (frontend), meaning Ralph will execute P4 before P3. This contradicts the specs which say **P3 and P4 are independent and can run in parallel**.
+
+### FINDING 1 (MODERATE): P3/P4 Sequencing is Suboptimal, Not Broken
+
+- **Spec 003** (Frontend) header says: *"Independent: Can be implemented in parallel with Specs 001 and 004."*
+- **Spec 004** (exec_server) header says: *"Independent: Can be implemented in parallel with Specs 001, 002, and 003."*
+- **Ralph reality**: P4 (priorities 24--35) executes entirely before P3 (priorities 36--45).
+
+**Impact**: This is not a blocker because P3 and P4 have no mutual dependency. However, it means Ralph serializes two parallelizable workstreams, adding unnecessary calendar time. The frontend can be developed with only the Phase 2 API contract (schema types), not the exec_server itself. Executing P4 before P3 is safe but wasteful.
+
+**Risk Level**: LOW -- no execution failure, just suboptimal throughput.
+
+### FINDING 2 (CRITICAL): P4 is in a Different Repository -- Ralph Cannot Execute It
+
+- **prd.json US-024 through US-035** all have notes like: *"This is in the sandboxes/ submodule (separate ruska-ai/sandboxes repo). Commit inside sandboxes/ directory."*
+- Ralph's sequential execution model operates within the orchestra repo. It runs `make format`, `make lint`, `make test` as acceptance criteria -- but these commands target the **orchestra backend**, not the sandboxes submodule.
+- The acceptance criteria for P4 stories reference `Typecheck passes` but the sandboxes repo is JavaScript (Node.js), not Python. The `make test` criterion is meaningless in the sandboxes context.
+- The conformance test (US-035) requires `bash tests/conformance.sh http://localhost:3005`, which requires a **running Docker container** of the exec_server.
+
+**Impact**:
+1. Ralph will attempt to execute P4 stories (priorities 24--35) in sequence after P2 completes, but `make format` / `make test` will pass vacuously (no sandboxes changes are visible to the orchestra backend test suite).
+2. The conformance test requires Docker build + container startup, which Ralph's standard flow does not orchestrate.
+3. Git operations must happen inside `sandboxes/` (a submodule), and then the submodule pointer in orchestra must be updated.
+
+**Risk Level**: CRITICAL -- Ralph's execution model cannot correctly validate or commit P4 work without manual intervention or a custom workflow adapter.
+
+### FINDING 3 (CRITICAL): P5 Depends on Both P2 AND P4, but P4 Validation is Unreliable
+
+- **Spec 005** header: *"Depends on: Spec 002 (dispatch wiring) + Spec 004 (exec_server structured tools)"*
+- **prd.json US-046** (P5 first story) has priority 46, after P4 (priority 35) and P3 (priority 45).
+- P5 unit tests mock the exec_server, so they can run without a live P4 server. However:
+  - US-049 `execute()` override depends on the `execute` tool name (renamed from `exec_command` in P4). If P4's rename hasn't been verified, the name assumption is untested.
+  - US-058 (graceful degradation) explicitly tests compatibility with old exec_servers that only have `exec_command`. This story is valid regardless of P4 status.
+  - US-059 (integration validation) includes *"Invoke integration-qa agent to validate cross-boundary alignment"* -- this requires the P4 exec_server to be running.
+
+**Impact**: P5 unit tests will pass (mocked), but the integration gate (US-059) cannot be satisfied without a running P4 exec_server. Ralph will either skip this criterion or fail on it.
+
+**Risk Level**: CRITICAL -- the integration gate at the end of the feature depends on a cross-repo deliverable that Ralph cannot orchestrate.
+
+---
+
+## 2. Implicit Dependencies Not Declared
+
+### Phase 2 Dependencies on Phase 1
+
+| P2 Story | Depends On (P1) | Declared? | Notes |
+|----------|-----------------|-----------|-------|
+| US-015 (SandboxType enum) | None | N/A | Pure schema change, no P1 dependency |
+| US-016 (API schemas) | None | N/A | Pure schema change |
+| US-017 (MCP factory) | US-001 (class skeleton) | **YES** (spec header) | Factory imports `McpSandboxBackend` |
+| US-018 (resolve dispatch) | US-017 (factory) | **IMPLICIT** | Uses factory registered in US-017 |
+| US-019 (error helper) | US-002 (McpSandboxError) | **NOT DECLARED** | `is_mcp_sandbox_error()` checks for `McpSandboxError` type |
+| US-020 (LLMController wiring) | US-018 (dispatch rules) | **IMPLICIT** | Calls updated `resolve_sandbox_backend()` |
+| US-021 (stream_generator) | US-018, US-019 | **IMPLICIT** | Uses dispatch + error helper |
+| US-022 (worker tasks) | US-018, US-019 | **IMPLICIT** | Same pattern |
+| US-023 (integration validation) | US-015 through US-022 | **IMPLICIT** | Gate story -- needs all prior P2 stories |
+
+**FINDING 4 (MODERATE)**: US-019 (`is_mcp_sandbox_error`) depends on `McpSandboxError` being importable from `mcp_sandbox.py` (created in P1 US-002). This dependency is not declared in the PRD or prd.json. If Ralph somehow executed P2's US-019 before P1's US-002 completed, the import would fail. However, since Ralph's priority ordering guarantees P1 (1--14) runs before P2 (15--23), this is safe **in practice** despite the missing declaration.
+
+### Phase 3 Dependencies on Phase 2
+
+| P3 Story | Depends On (P2) | Declared? |
+|----------|-----------------|-----------|
+| US-036 (SandboxType union) | US-015 (backend SandboxType) | **NOT DECLARED** (but spec says "Independent") |
+| US-037 (API type interfaces) | US-016 (backend API schemas) | **NOT DECLARED** |
+| US-039 (URL input field) | US-016 (PATCH endpoint for mcp_sandbox_url) | **NOT DECLARED** |
+| US-044 (SSE event handler) | US-021 (stream_generator emitting mcp_sandbox_unreachable) | **NOT DECLARED** |
+
+**FINDING 5 (MODERATE)**: Spec 003 header says *"Independent: Can be implemented in parallel with Specs 001 and 004"* -- but it does NOT claim independence from Spec 002. The PRD says *"depends only on the API schema contract defined in Phase 2"*. This is honest, but the prd.json doesn't encode this dependency. In Ralph's execution order (P3 after P4 after P2), this happens to be satisfied, but it is a documentation gap.
+
+**Specific risk**: US-044 (handle `mcp_sandbox_unreachable` SSE event) cannot be browser-tested until the backend (P2 US-021) emits that event. The frontend code can be written and unit-tested with mocks, but the integration story US-045 requires both backend and frontend to be deployed.
+
+### Phase 5 Dependencies on Phase 4
+
+| P5 Story | Depends On (P4) | Declared? |
+|----------|-----------------|-----------|
+| US-046 (tool discovery) | US-024+ (tools/list returns 9 tools) | **IMPLICIT** |
+| US-047 (_parse_meta) | US-025 (_meta structure in responses) | **IMPLICIT** |
+| US-048 (sandbox_id from _meta) | US-025, US-034 (sandbox_id in _meta and /health) | **IMPLICIT** |
+| US-049 (execute dual name) | US-024 (rename exec_command -> execute) | **IMPLICIT** |
+| US-050--057 (native overrides) | US-026--033 (corresponding exec_server tools) | **IMPLICIT** |
+| US-058 (graceful degradation) | None (tests fallback when tools absent) | N/A |
+
+**FINDING 6 (LOW)**: Every P5 native override story (US-050 through US-057) implicitly depends on the corresponding P4 tool existing. However, since P5 unit tests mock the exec_server responses, these dependencies don't block unit test execution. They only matter for integration testing.
+
+---
+
+## 3. Cross-Repository Sequencing
+
+### The Sandboxes Submodule Problem
+
+Phase 4 operates in `sandboxes/` which is a git submodule pointing to `ruska-ai/sandboxes`. This creates several issues:
+
+**FINDING 7 (CRITICAL)**: **Ralph's sequential execution model breaks across repo boundaries**.
+
+1. **Git operations**: Ralph commits changes to the orchestra repo. P4 changes must be committed to the sandboxes repo. Ralph would need to:
+   - `cd sandboxes/` and commit there
+   - Then `cd ..` and update the submodule pointer in orchestra
+   - This is a two-step process not described in Ralph's workflow
+
+2. **Testing**: P4 acceptance criteria include "Typecheck passes" -- but the sandboxes repo uses JavaScript, not Python. The orchestra `make test` command does not test sandboxes code. The actual test is `bash tests/conformance.sh http://localhost:3005` which requires:
+   - Building the Docker image: `cd sandboxes/ubuntu && docker build -t exec-server-test .`
+   - Running a container: `docker run -d -p 3005:3005 exec-server-test`
+   - Running the test: `bash tests/conformance.sh http://localhost:3005`
+   - Cleaning up: `docker stop exec-server-test`
+
+3. **`make format` / `make lint`**: These orchestra-scoped commands are meaningless for JavaScript changes in the sandboxes submodule. The P4 stories list these as acceptance criteria but they'll pass vacuously since no Python files changed.
+
+4. **Conformance tests (US-035)**: Requires a running Docker container. Ralph's standard test harness does not start Docker services. The `docker-compose.dev.yml` includes an optional `exec_server` profile (`COMPOSE_PROFILES=tools`), but Ralph doesn't know to use it.
+
+### Implications for Integration Gates
+
+- **US-023 (P2 integration)**: Does not require exec_server -- tests dispatch logic only. Safe.
+- **US-045 (P3 integration)**: Requires backend APIs from P2. Uses agent-browser for UI testing. Does NOT require exec_server (health check can show red dot). **Partially safe** -- the health dot test needs a running exec_server to show green.
+- **US-059 (P5 integration)**: Explicitly requires cross-boundary validation with the exec_server. **Not safe without manual intervention**.
+
+---
+
+## 4. Integration Gate Analysis
+
+### US-023: P2 Integration Validation (Priority 23)
+
+**Prerequisites needed**:
+- All P1 stories (US-001 to US-014) complete -- McpSandboxBackend class exists
+- All P2 stories (US-015 to US-022) complete -- dispatch wiring, API schemas, error handling
+
+**Prerequisites declared**: None explicitly, but position at end of P2 implies all prior P2 stories.
+
+**Assessment**: **CORRECT**. Ralph's priority ordering ensures all P1 and P2 stories complete before US-023. The acceptance criteria (API calls via curl) test the dispatch pipeline without needing a live exec_server. When `sandbox='mcp'` but no exec_server is running, the system should fall back to State -- which is exactly what US-023 tests.
+
+**Risk**: LOW. One gap: US-023 doesn't test that the MCP backend actually connects to an exec_server. It only tests the fallback path. There is no P2 integration test that validates the happy path (MCP actually working).
+
+### US-045: P3 Frontend Integration (Priority 45)
+
+**Prerequisites needed**:
+- P2 complete (backend APIs for settings/defaults)
+- P3 stories US-036 to US-044 complete (frontend types, components, hooks)
+
+**Prerequisites declared**: None explicitly.
+
+**Assessment**: **MOSTLY CORRECT** but with a gap.
+
+- The browser-based test (agent-browser) requires the backend running with P2 changes deployed -- not just frontend.
+- Step 7: "Verify health dot color (green if exec_server running)" -- requires P4 to be deployed for green. If P4 is already complete (priorities 24--35 before P3's 36--45), this should work. **BUT** -- this assumes the Docker exec_server is running, which Ralph doesn't manage.
+- Step 14: "Clear the MCP URL in Settings -- verify MCP option disappears and sandbox reverts to State" -- requires P2 backend for the PATCH call.
+
+**Risk**: MODERATE. The agent-browser test is comprehensive but assumes both backend (P2) and exec_server (P4) are running. Ralph completing P4 stories doesn't mean the exec_server is deployed.
+
+### US-059: P5 Integration Validation (Priority 59)
+
+**Prerequisites needed**:
+- All P1 stories (base class)
+- All P2 stories (dispatch wiring)
+- All P4 stories (exec_server with 9 native tools + _meta)
+- All P5 stories US-046 to US-058
+
+**Prerequisites declared**: "Invoke integration-qa agent to validate cross-boundary alignment"
+
+**Assessment**: **INCOMPLETE PREREQUISITES**.
+
+- Acceptance criteria say *"Minimum 25 new test cases"* -- these are unit tests with mocks, achievable.
+- The criterion *"Invoke integration-qa agent"* implies an external validation step that is not a standard Ralph operation.
+- There is no acceptance criterion that explicitly requires the exec_server conformance suite (US-035) to pass. The integration validation should reference US-035 as a prerequisite.
+
+**Risk**: HIGH. This gate story is the final validation for the entire feature, but it doesn't explicitly require a live exec_server passing conformance tests. The 25 unit tests will pass with mocks, but the actual integration (Python backend talking to Node.js exec_server via MCP) is not validated.
+
+---
+
+## 5. Additional Sequencing Risks
+
+### FINDING 8 (MODERATE): Tool Name Mismatch Window
+
+P1 (US-004, priority 4) hardcodes `exec_command` as the tool name for `execute()`. P4 (US-024, priority 24) renames `exec_command` to `execute`. P5 (US-049, priority 49) adds dual-name support.
+
+Between P1 completion and P5 completion, there is a **compatibility window** where:
+- If someone deploys the P4 exec_server (with `execute` tool name) while the backend is still on P1 code (expecting `exec_command`), **all MCP sandbox calls will fail** because the tool name doesn't match.
+- This window spans priorities 14--49 (roughly 35 stories).
+
+**Mitigation**: P4 spec says "clean break, no backward compatibility alias." This means deploying P4's exec_server before P5 is merged will break P1's backend. The specs acknowledge this but don't enforce a deployment ordering.
+
+### FINDING 9 (LOW): Phase 2 Return Tuple Change
+
+P2 US-020 changes `_resolve_user_settings()` from a 3-tuple to a 4-tuple. All callers of this function must be updated atomically. If Ralph processes US-020 (LLMController) but hasn't yet processed US-021 (stream_generator) or US-022 (worker tasks), the intermediate state could have callers expecting different tuple lengths.
+
+**Mitigation**: Ralph processes stories sequentially by priority, so US-020 (priority 20) completes before US-021 (priority 21) and US-022 (priority 22). Within a single story, the developer should update the function and all its callers. However, if US-020 only updates `_resolve_user_settings()` and its direct caller in `llm_invoke()`/`llm_stream()`, while US-021/US-022 update the other callers, there's a brief window where `make test` might fail.
+
+**Actual risk**: LOW -- Ralph runs `make test` as an acceptance criterion for US-020, so if the intermediate state breaks tests, the story won't pass.
+
+---
+
+## 6. Dependency Alignment Score
+
+### Score: 5/10
+
+**Justification**:
+
+**Positives (+)**:
+- P1 -> P2 ordering is correct and enforced by priority numbers
+- P2 -> P3/P5 ordering is correct
+- Integration gates exist at the end of each major phase
+- The specs clearly identify which phases are parallelizable vs sequential
+- Graceful degradation (P5 US-058) explicitly handles the old-server case
+
+**Negatives (-)**:
+- **-2**: P4 cross-repository execution is fundamentally broken for Ralph's sequential model. No mechanism exists for Ralph to commit to the sandboxes submodule, build Docker images, or start containers.
+- **-1**: P5 integration gate (US-059) doesn't explicitly require a running exec_server or reference the conformance suite (US-035).
+- **-1**: Tool name mismatch window (P1 uses `exec_command`, P4 renames to `execute`, P5 adds dual support) creates a dangerous deployment ordering dependency that is documented in specs but not enforced in prd.json.
+- **-1**: P3/P4 parallelism is possible but not exploited -- Ralph serializes them unnecessarily.
+
+---
+
+## 7. Recommendations
+
+### Must Fix (Before Ralph Starts)
+
+1. **Separate P4 from Ralph's sequential pipeline**. Create a dedicated task or branch for the sandboxes submodule work. Mark P4 stories in prd.json with a flag indicating they cannot be auto-executed by Ralph. Run the conformance suite manually or via CI.
+
+2. **Add exec_server startup to US-059's acceptance criteria**. Add: "conformance.sh passes against a running exec_server built from Phase 4 code."
+
+3. **Document the deployment ordering constraint**. Between P4 exec_server deployment and P5 backend deployment, there is a breaking change window (exec_command -> execute rename). Add a note to prd.json or a coordination document.
+
+### Should Fix
+
+4. **Interleave P3 and P4** if Ralph supports parallel execution (or split into two Ralph instances). P3 (frontend) and P4 (sandboxes) have zero mutual dependencies.
+
+5. **Add explicit `dependsOn` fields to prd.json stories**. Currently dependencies are implicit (ordering by priority). Making them explicit enables future tooling to validate the dependency graph.
+
+6. **Add a P2 happy-path integration test**. US-023 only tests the fallback path. Add a test that verifies MCP sandbox actually connects to a running exec_server when available.
+
+### Nice to Have
+
+7. **Move P4 acceptance criteria from `make format`/`make test` to sandboxes-appropriate commands** (e.g., `npm run lint` for the Node.js code, `bash tests/conformance.sh` for integration).
+
+8. **Add a "deployment gate" story between P4 and P5** that verifies the exec_server Docker image is built and the conformance suite passes before P5 begins.

--- a/.claude/plans/greedy-tumbling-boole.md
+++ b/.claude/plans/greedy-tumbling-boole.md
@@ -1,0 +1,193 @@
+# MCP Sandbox Artifact Alignment Audit
+
+## Context
+
+Three artifact layers describe Feature #890 (MCP Sandbox):
+- **Specs** (5 files): `.claude/specs/feat-890-mcp-sandbox/001-005`
+- **PRD Tasks** (5 files): `tasks/prd-mcp-sandbox-{backend,dispatch,exec-server,frontend,v2-native}.md`
+- **Ralph PRD**: `.ralph/prd.json` (59 user stories, US-001 through US-059)
+
+This audit identifies alignment gaps that must be resolved **before Ralph execution begins**.
+
+---
+
+## Council Scores
+
+| Auditor | Score | Summary |
+|---------|-------|---------|
+| Story Coverage | **9/10** | All 59 stories covered across all layers. Minor ID numbering drift. |
+| Acceptance Criteria | **5/10** | 8 critical contradictions, 10 major inconsistencies found. |
+| Dependency & Sequencing | **5/10** | 3 critical sequencing issues, 4 moderate gaps. |
+| Technical Consistency | **6.5/10** | 5 high-severity codebase mismatches, 5 medium. |
+
+**Composite Score: 6.4/10** — Story coverage is excellent but implementation-level specs have dangerous contradictions.
+
+---
+
+## CRITICAL Issues (Must Fix Before Implementation)
+
+### C-1: Constructor parameter name — `base_url` vs `url`
+- **Ralph/PRD**: `__init__(self, *, base_url: str, api_key: str | None = None)`
+- **Specs 001/002/005**: Use `url` as the parameter name; factory calls `McpSandboxBackend(url=mcp_sandbox_url)`
+- **Impact**: Factory call crashes with `TypeError` at runtime
+- **Resolution**: Standardize on `base_url` (matches PRD and Ralph). Update specs 001, 002, 005.
+
+### C-2: URL semantics — base URL vs full MCP endpoint
+- **PRD**: Stores `http://localhost:3005`, appends `/mcp` internally
+- **Spec 001**: Stores `http://localhost:3005/mcp`, strips `/mcp` to derive base
+- **Impact**: Health check, DELETE, and id property generate wrong URLs
+- **Resolution**: Standardize on base URL convention (PRD approach). Update spec 001.
+
+### C-3: Sync vs Async HTTP client
+- **PRD/Specs**: `httpx.AsyncClient` with `async def` methods
+- **Task-Backend**: Recommends `httpx.Client` (sync) for DaytonaSandbox consistency
+- **Impact**: Architecture-level decision affecting every method signature
+- **Resolution**: Verify whether `BaseSandbox.execute()` is sync or async in `deepagents`. If sync, use `httpx.Client`. If async, keep `AsyncClient`. Update the losing artifact.
+
+### C-4: MCP protocol version
+- **Spec 001**: `"2024-11-05"`
+- **Task-Backend**: `"2025-03-26"`
+- **Impact**: Wrong version may cause handshake rejection
+- **Resolution**: Check actual exec_server's expected version. Standardize across all artifacts.
+
+### C-5: SSE error event format — 4 different formats
+- **Spec 002**: `("mcp_sandbox_unreachable", "error string")`
+- **Task-Dispatch**: `("error", {"type": "mcp_sandbox_unreachable", "message": "..."})`
+- **Task-Frontend**: `("mcp_sandbox_unreachable", {"message": "..."})`
+- **Spec 003**: `("mcp_sandbox_unreachable", "error message")`
+- **Impact**: Frontend toast handler will never fire if format mismatches
+- **Resolution**: Check existing `daytona_unreachable` event format for precedent. Standardize all 4.
+
+### C-6: Tool name rename without backward compat creates breakage window
+- **Phase 1** (P1): Backend hardcodes `exec_command`
+- **Phase 4** (P4): Exec server renames to `execute` with NO alias
+- **Phase 5** (P5): Backend adds dual-name support
+- **Impact**: Between P4 deploy and P5 deploy, sandbox is completely broken
+- **Resolution**: Either (a) Phase 4 keeps `exec_command` as alias until Phase 5 ships, or (b) Phase 1 uses dual-name from the start.
+
+### C-7: Private method name — `_ensure_initialized()` vs `_ensure_session()`
+- **PRD/Task-Backend**: `_ensure_initialized()`
+- **Specs**: `_ensure_session()`
+- **Impact**: Tests reference wrong method name
+- **Resolution**: Standardize on `_ensure_initialized()` (matches PRD). Update specs.
+
+### C-8: Default client timeout — 120s vs 130s
+- **PRD**: 120 seconds
+- **Spec 001**: 130 seconds (`httpx.Timeout(130.0)`)
+- **Resolution**: Pick one (120s aligns with exec_server's max timeout). Update spec 001.
+
+---
+
+## MAJOR Issues (Should Fix)
+
+### M-1: Health check timeout disagreement
+- Backend: 5s (PRD/Task-Backend) vs Frontend: 3s (Task-Frontend)
+- **Resolution**: Backend health() uses 5s. Frontend useSandboxHealth uses its own timeout (3s is fine for UX). Document both.
+
+### M-2: `_resolve_user_settings` breaking change (3-tuple to 4-tuple)
+- File: `backend/src/controllers/llm.py:70`
+- Must update BOTH `llm_invoke` (line ~121) and `llm_stream` (line ~211)
+- Worker at `backend/src/workers/tasks.py:421-431` duplicates this logic inline and also needs updating
+- **Resolution**: Update all 3 callsites in the same commit (US-020/US-021/US-022).
+
+### M-3: MCP factory signature mismatch with `_SANDBOX_FACTORIES` pattern
+- Existing factories: `factory(runtime)` — single param
+- MCP factory: `_create_mcp_backend_checked(runtime, mcp_sandbox_url)` — two params
+- Can't register in generic `_SANDBOX_FACTORIES` dict and call through same dispatch
+- **Resolution**: Either special-case MCP in `resolve_sandbox_backend()` or add `mcp_sandbox_url` to all factory signatures (adapter pattern).
+
+### M-4: `ThreadSandboxStatus` wrong file path in spec 003
+- Spec 003: `frontend/src/components/tools/ThreadSandboxStatus.tsx`
+- Actual: `frontend/src/components/status/ThreadSandboxStatus.tsx`
+- **Resolution**: Fix spec 003.
+
+### M-5: `upload_files()`/`download_files()` path validation
+- Task-Backend adds `invalid_path` error for paths not starting with `/`
+- PRD has no such validation
+- **Resolution**: Add path validation (defense in depth). Update Ralph ACs.
+
+### M-6: `execute()` timeout parameter type
+- `int | None` (PRD/Ralph) vs `float | None` (Spec 001)
+- **Resolution**: Use `int | None` (matches BaseSandbox convention). Update spec 001.
+
+### M-7: `clientInfo.name` in initialize payload
+- `"orchestra"` (Spec 001) vs `"orchestra-backend"` (Task-Backend)
+- **Resolution**: Use `"orchestra"` for brevity. Update task.
+
+### M-8: `_parse_meta` return type
+- `tuple[int | None, str | None]` (PRD) vs `tuple[int, str]` without Optional (Spec 005)
+- **Resolution**: Must be Optional since `_meta` may be absent. Use PRD version.
+
+### M-9: Exit code regex — first match vs last match
+- Spec 001 says "last match wins", PRD doesn't specify
+- **Resolution**: Document "first match" (simpler, `re.search` default). Update spec.
+
+### M-10: `is_mcp_sandbox_error()` — include McpSandboxError or not
+- PRD: includes it
+- Task-Dispatch: leaves as open question
+- **Resolution**: Include it (the purpose of the helper). Update task.
+
+---
+
+## STRUCTURAL Issues (Sequencing & Dependencies)
+
+### S-1: Phase 4 is in a different git repository
+Ralph processes stories sequentially in the orchestra repo. Phase 4 (US-024-035) operates in the `sandboxes/` submodule (separate `ruska-ai/sandboxes` repo). Ralph cannot:
+- Commit to the submodule
+- Build Docker images
+- Start containers
+- Run `conformance.sh`
+
+**Resolution**: Extract Phase 4 stories into a separate Ralph run targeting the sandboxes repo, OR execute Phase 4 manually before Ralph processes Phase 5.
+
+### S-2: Phase 3/4 parallelism wasted by priority ordering
+Ralph serializes P4 (priorities 24-35) entirely before P3 (priorities 36-45). Both are independent.
+
+**Resolution**: If sequential execution is required, this is acceptable (just slower). If parallelism is desired, Phase 3 priorities should be interleaved with Phase 4.
+
+### S-3: Integration gates lack service prerequisites
+- US-023 (P2 integration): Needs running API
+- US-045 (P3 integration): Needs running frontend + exec_server for health dot
+- US-059 (P5 integration): Needs running exec_server
+
+**Resolution**: Add notes to these stories clarifying what services must be running. Ralph can't start services, so these gates may need manual validation.
+
+### S-4: PRD task files use local US-XXX numbering
+Each PRD task resets to US-001. Cross-referencing with Ralph's global US-001-059 requires knowing the phase mapping.
+
+**Resolution**: Add a mapping header to each PRD task file: "This file covers Ralph US-015 through US-023."
+
+---
+
+## MINOR Issues
+
+1. Spec 003 health dot `bg-green-500, h-2 w-2` matches PRD exactly — no issue
+2. PRD notes field is empty on all 59 stories — Phase 4 submodule constraint only noted in last few
+3. Open design questions in PRD tasks (CORS proxying, file size limits) not tracked in Ralph
+4. Spec files use numbered requirements (1-16) instead of US-XXX IDs
+
+---
+
+## Recommended Fix Order
+
+1. **Resolve C-3 first** (sync vs async) — this is architectural and affects everything
+2. **Fix C-1 + C-2** (constructor + URL convention) — affects factory, health, id property
+3. **Fix C-5** (SSE event format) — check existing Daytona pattern for precedent
+4. **Fix C-6** (tool rename strategy) — decide alias vs dual-name-from-start
+5. **Fix C-4** (protocol version) — verify against actual exec_server
+6. **Fix C-7 + C-8** (method name + timeout) — straightforward standardization
+7. **Fix S-1** (Phase 4 execution strategy) — before Ralph starts
+8. **Apply all MAJOR fixes** — batch update to specs, PRD tasks, and prd.json
+9. **Re-run alignment audit** after fixes
+
+---
+
+## Verification
+
+After applying fixes:
+- `grep -r "base_url\|url=" .claude/specs/ tasks/` — confirm constructor param standardized
+- `grep -r "AsyncClient\|Client" .claude/specs/ tasks/` — confirm sync/async standardized
+- `grep -r "mcp_sandbox_unreachable" .claude/specs/ tasks/` — confirm SSE format standardized
+- `grep -r "2024-11-05\|2025-03-26" .claude/specs/ tasks/` — confirm protocol version standardized
+- `grep -r "_ensure_initialized\|_ensure_session" .claude/specs/ tasks/` — confirm method name standardized
+- Cross-check Ralph prd.json ACs against updated specs for consistency

--- a/.claude/specs/feat-890-mcp-sandbox/001-mcp-sandbox-backend.md
+++ b/.claude/specs/feat-890-mcp-sandbox/001-mcp-sandbox-backend.md
@@ -1,0 +1,243 @@
+---
+task: McpSandboxBackend Core Class (Feature #890)
+test_command: "cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v"
+---
+
+# Task: McpSandboxBackend Core Class (Feature #890)
+
+> **IMPORTANT**: Before implementing this feature, READ `/CLAUDE.md` first.
+
+Create `McpSandboxBackend(BaseSandbox)` in `backend/src/agents/mcp_sandbox.py` — a new sandbox backend that connects DeepAgents to the `ruska-ai/sandboxes` exec_server via MCP JSON-RPC 2.0 over Streamable HTTP. This is the foundation for all MCP sandbox functionality.
+
+## Architecture Context
+
+`BaseSandbox` (from `deepagents.backends.sandbox`) defines the sandbox contract. Only 4 methods are abstract — the remaining 6 are inherited and delegate to `execute()` via python3 heredoc commands:
+
+| Method | Abstract? | Implementation Strategy |
+|--------|-----------|------------------------|
+| `execute(command, *, timeout) -> ExecuteResponse` | **YES** | MCP JSON-RPC `tools/call` to `exec_command` tool |
+| `id -> str` | **YES** | Return sandbox URL or generated UUID |
+| `upload_files(files) -> list[FileUploadResponse]` | **YES** | Shell base64 encode via `execute()` |
+| `download_files(paths) -> list[FileDownloadResponse]` | **YES** | Shell base64 decode via `execute()` |
+| `read()`, `write()`, `edit()`, `grep_raw()`, `ls_info()`, `glob_info()` | Inherited | All work automatically via `execute()` delegation |
+
+**Critical**: All inherited methods depend on `execute()` returning a proper `ExecuteResponse` with integer `exit_code`. The python3 heredoc commands use `sys.exit(N)` for error signaling.
+
+**Sync convention**: `BaseSandbox.execute()` is a **synchronous** method. `DaytonaSandbox` uses sync `httpx.Client`. This backend follows the same pattern — all methods are sync, using `httpx.Client` for HTTP. The framework's `aexecute()` wraps sync `execute()` in `asyncio.to_thread()` automatically.
+
+## Requirements
+
+1. **Create `backend/src/agents/mcp_sandbox.py`** with `McpSandboxBackend(BaseSandbox)` class
+2. **Implement `execute(command, *, timeout=None) -> ExecuteResponse`**:
+   - POST JSON-RPC 2.0 `tools/call` to `{base_url}/mcp` with tool name `exec_command` and `{"cmd": command}`
+   - Parse text-embedded `exit_code: N` from the response text via regex (`r'exit_code:\s*(\d+)'`) — first match wins (`re.search` default)
+   - If no exit_code found in text, default to `exit_code=0`
+   - Forward `timeout` parameter to the httpx request timeout (exec_server enforces 120s max internally)
+   - Return `ExecuteResponse(output=<text>, exit_code=<parsed_int>)`
+3. **Implement `id` property**:
+   - Return a stable identifier for the sandbox (e.g., `f"mcp-sandbox:{base_url}"`)
+4. **Implement `upload_files(files) -> list[FileUploadResponse]`**:
+   - Each file is a tuple `(path, content_bytes)`
+   - Base64-encode content, execute `echo <base64> | base64 -d > <path>` via `execute()`
+   - Create parent dirs with `mkdir -p` before writing
+   - Return `FileUploadResponse(path=path)` on success, `FileUploadResponse(path=path, error=str)` on failure
+   - Handle per-file errors individually (don't abort batch on single failure)
+5. **Implement `download_files(paths) -> list[FileDownloadResponse]`**:
+   - Execute `base64 <path>` via `execute()` for each file
+   - Decode the base64 output to get file content
+   - Return `FileDownloadResponse(path=path, content=bytes)` on success
+   - Return `FileDownloadResponse(path=path, error="file_not_found")` when exit_code is non-zero
+6. **MCP session lifecycle — persistent with reconnect**:
+   - Lazy session initialization: first `execute()` call sends `initialize` JSON-RPC request to get `Mcp-Session-Id` header
+   - Reuse session across all subsequent calls by including `Mcp-Session-Id` header
+   - On session error (e.g., 400 "Invalid or missing session ID"), re-initialize session and retry once before raising
+   - Store `httpx.Client` instance for connection pooling
+7. **Health check**: Add `def health() -> bool` that GETs `{base_url}/health` endpoint
+8. **Use `httpx.Client`** (sync, matching DaytonaSandbox pattern) for all HTTP communication
+9. **Create unit tests** in `backend/tests/unit/agents/test_mcp_sandbox.py`
+
+## MCP JSON-RPC 2.0 Protocol Details
+
+### Session initialization:
+```json
+POST {base_url}/mcp
+Content-Type: application/json
+
+{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+  "protocolVersion": "2025-03-26",
+  "capabilities": {},
+  "clientInfo": {"name": "orchestra", "version": "1.0.0"}
+}}
+
+Response headers: Mcp-Session-Id: <uuid>
+Response body: {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "...", ...}}
+```
+
+### Tool call (execute):
+```json
+POST {base_url}/mcp
+Content-Type: application/json
+Mcp-Session-Id: <uuid>
+
+{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
+  "name": "exec_command",
+  "arguments": {"cmd": "echo hello"}
+}}
+
+Response body: {"jsonrpc": "2.0", "id": 2, "result": {
+  "content": [{"type": "text", "text": "stdout:\nhello\nexit_code: 0"}]
+}}
+```
+
+### Current exec_server exit_code format (text-embedded):
+- Success: text ends with nothing (no exit_code line means 0)
+- Failure: text contains `exit_code: N` where N is the exit code integer
+- Regex: `r'exit_code:\s*(\d+)'` — first match wins (`re.search` returns first match)
+
+## Class Skeleton
+
+```python
+import re
+import base64
+import httpx
+from deepagents.backends.sandbox import BaseSandbox, ExecuteResponse, FileUploadResponse, FileDownloadResponse
+
+EXIT_CODE_RE = re.compile(r'exit_code:\s*(\d+)')
+
+class McpSandboxBackend(BaseSandbox):
+    def __init__(self, *, base_url: str, api_key: str | None = None):
+        """
+        Args:
+            base_url: Exec_server base URL (e.g., "http://localhost:3005").
+                      The /mcp endpoint is appended internally.
+            api_key: Optional API key for x-api-key header authentication
+        """
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._session_id: str | None = None
+        self._client = httpx.Client(timeout=httpx.Timeout(120.0))
+        self._request_id = 0
+        self._initialized = False
+
+    @property
+    def id(self) -> str: ...
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse: ...
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]: ...
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]: ...
+
+    def _ensure_initialized(self) -> None:
+        """Lazy session init — sends initialize if not yet initialized."""
+
+    def _call_tool(self, tool_name: str, arguments: dict, *, timeout: int | None = None) -> dict:
+        """Send tools/call JSON-RPC request. Handles session reconnect on failure."""
+
+    def health(self) -> bool:
+        """Check exec_server health via GET {base_url}/health."""
+
+    @property
+    def _mcp_url(self) -> str:
+        """Return the full MCP endpoint URL: {base_url}/mcp."""
+        return f"{self._base_url}/mcp"
+```
+
+## Patterns to Follow
+
+- **Daytona backend pattern**: See `backend/src/agents/daytona.py` for validation pattern
+- **httpx usage**: See `backend/src/common/client/client.py` for existing httpx patterns in the project
+- **Error handling**: Wrap httpx errors in descriptive exceptions. Log with `src.utils.logger.logger`
+- **Sync convention**: `BaseSandbox.execute()` is sync. `DaytonaSandbox` uses sync `httpx.Client`. Follow this pattern.
+
+## Success Criteria
+
+1. [ ] `McpSandboxBackend` class exists in `backend/src/agents/mcp_sandbox.py` and extends `BaseSandbox`
+2. [ ] `execute()` sends MCP JSON-RPC `tools/call` with `exec_command` tool and parses text-embedded `exit_code: N` via regex
+3. [ ] `execute()` returns `ExecuteResponse` with integer `exit_code` (defaults to 0 when not found in text)
+4. [ ] `id` property returns a stable sandbox identifier string
+5. [ ] `upload_files()` encodes files as base64, executes shell commands via `execute()`, returns `FileUploadResponse` per file with error handling
+6. [ ] `download_files()` executes `base64 <path>` via `execute()`, decodes output, returns `FileDownloadResponse` per file with error handling
+7. [ ] Session lifecycle: lazy init on first call, reuse across calls, reconnect on session error (retry once)
+8. [ ] `health()` method pings `{base_url}/health` endpoint and returns bool
+9. [ ] All 6 inherited methods (`read`, `write`, `edit`, `grep_raw`, `ls_info`, `glob_info`) work via `execute()` delegation (no overrides needed — verify in tests)
+10. [ ] Unit tests in `backend/tests/unit/agents/test_mcp_sandbox.py` cover: execute success/failure, exit_code parsing, upload/download, session init/reconnect, health check
+11. [ ] `timeout` parameter forwarded to httpx request timeout in `execute()`
+12. [ ] Code passes `make format` and `make lint`
+
+## Example Output
+
+```python
+# Usage
+sandbox = McpSandboxBackend(base_url="http://localhost:3005")
+
+# Execute
+result = sandbox.execute("echo hello world")
+# ExecuteResponse(output="stdout:\nhello world", exit_code=0)
+
+# Execute with failure
+result = sandbox.execute("ls /nonexistent")
+# ExecuteResponse(output="stderr:\nls: cannot access ...\nexit_code: 2", exit_code=2)
+
+# Upload
+responses = sandbox.upload_files([("/tmp/test.txt", b"hello")])
+# [FileUploadResponse(path="/tmp/test.txt")]
+
+# Download
+responses = sandbox.download_files(["/tmp/test.txt"])
+# [FileDownloadResponse(path="/tmp/test.txt", content=b"hello")]
+
+# Health
+is_healthy = sandbox.health()
+# True
+
+# Inherited methods work automatically:
+content = sandbox.read("/tmp/test.txt")  # delegates to execute()
+```
+
+## QA Validation
+
+### Backend unit tests:
+```bash
+cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v
+```
+
+### Manual integration validation (requires exec_server at :3005):
+```bash
+# 1. Verify exec_server health
+curl http://localhost:3005/health
+# Expected: {"status":"ok","sessions":0}
+
+# 2. Test MCP JSON-RPC initialize
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' \
+  -D -
+# Expected: 200 OK with Mcp-Session-Id header
+
+# 3. Test execute via tools/call (use session from step 2)
+curl -s -X POST http://localhost:3005/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session_id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_command","arguments":{"cmd":"echo hello && echo exit_code: 0"}}}'
+# Expected: result.content[0].text contains "hello" and "exit_code: 0"
+```
+
+## Files
+
+| File | Action |
+|------|--------|
+| `backend/src/agents/mcp_sandbox.py` | CREATE |
+| `backend/tests/unit/agents/test_mcp_sandbox.py` | CREATE |
+
+---
+
+## Ralph Instructions
+
+1. Work on the next incomplete criterion (marked [ ])
+2. Check off completed criteria (change [ ] to [x])
+3. Run tests after changes: `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v`
+4. Run format after changes: `cd backend && make format`
+5. Commit your changes frequently
+6. When ALL criteria are [x], output: `<ralph>COMPLETE</ralph>`
+7. If stuck on the same issue 3+ times, output: `<ralph>GUTTER</ralph>`

--- a/.claude/specs/feat-890-mcp-sandbox/002-sandbox-dispatch.md
+++ b/.claude/specs/feat-890-mcp-sandbox/002-sandbox-dispatch.md
@@ -1,0 +1,225 @@
+---
+task: Sandbox Dispatch Wiring (Feature #890)
+test_command: "cd backend && uv run pytest tests/unit/agents/ -v"
+---
+
+# Task: Sandbox Dispatch Wiring (Feature #890)
+
+> **IMPORTANT**: Before implementing this feature, READ `/CLAUDE.md` first.
+
+Wire `McpSandboxBackend` into the existing sandbox dispatch system. The MCP sandbox URL is **user-configurable** via the settings page (stored in `UserSettings`), not a hardcoded env var. Update the fallback chain to Daytona -> MCP (if URL configured) -> State, and add MCP-specific error handling to controllers and stream generator.
+
+**Depends on**: Spec 001 (McpSandboxBackend class must exist)
+
+## Requirements
+
+1. **Add `MCP = "mcp"` to `SandboxType` enum** in `backend/src/schemas/entities/settings.py`
+2. **Add `default_mcp_sandbox_url` field to `UserSettings`**:
+   - `default_mcp_sandbox_url: Optional[str] = Field(default=None, description="User's MCP sandbox endpoint URL")`
+   - This is the user-configured sandbox URL (e.g., `http://localhost:3005/mcp`)
+3. **Add `mcp_sandbox_url` to API schemas**:
+   - Add to `DefaultsResponse`: `mcp_sandbox_url: Optional[str] = None`
+   - Add to `PatchDefaultsRequest`: `mcp_sandbox_url: Optional[str] = Field(default=None, description="MCP sandbox endpoint URL, or null to clear")`
+4. **Wire settings repo** to read/write `mcp_sandbox_url`:
+   - Update `backend/src/routes/v0/settings.py` to map `UserSettings.default_mcp_sandbox_url` <-> `DefaultsResponse.mcp_sandbox_url` and handle PATCH
+5. **Add `_create_mcp_backend_checked()` factory** in `backend/src/agents/__init__.py`:
+   - Accepts `runtime` and `mcp_sandbox_url: str` parameters
+   - Instantiates `McpSandboxBackend(base_url=mcp_sandbox_url)`
+   - Validates backend has `execute()` capability (same pattern as Daytona)
+   - Returns `(CompositeBackend(default=mcp_backend), None)` on success, `None` on failure
+6. **Register `"mcp"` in `_SANDBOX_FACTORIES`** — though MCP needs special handling since it requires the URL from user settings
+7. **Update `resolve_sandbox_backend()`**:
+   - Add `mcp_sandbox_url: str | None = None` parameter
+   - Updated dispatch rules:
+     - `None` / `"auto"` — try Daytona first, then MCP (if URL provided), then State
+     - `"state"` — StateBackend directly
+     - `"daytona"` — try Daytona, fall back to State
+     - `"mcp"` — try MCP (if URL provided), fall back to State
+   - Fallback chain: Daytona -> MCP -> State
+8. **Update callers of `resolve_sandbox_backend()`** to pass `mcp_sandbox_url`:
+   - `backend/src/controllers/llm.py` — read `default_mcp_sandbox_url` from settings, pass to dispatch
+   - `backend/src/utils/stream.py` — same pattern
+   - `backend/src/workers/tasks.py` — same pattern (if it calls resolve_sandbox_backend)
+9. **Add MCP error handling** in `controllers/llm.py` and `utils/stream.py`:
+   - Follow the existing Daytona error handling pattern
+   - When `sandbox_type == "mcp"` and MCP fails: return specific error type `mcp_sandbox_unreachable` in the SSE stream so frontend can show the user-approved fallback toast
+   - When `sandbox_type in (None, "auto")` and MCP fails: silently fall back to State (same as Daytona auto-fallback)
+10. **Add `is_mcp_sandbox_error()` helper** in `backend/src/agents/__init__.py`:
+    - Check if an exception is an MCP sandbox connection error (httpx.ConnectError, httpx.TimeoutException, etc.)
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `backend/src/schemas/entities/settings.py` | Add `MCP` to `SandboxType` enum, add `default_mcp_sandbox_url` to `UserSettings`, `DefaultsResponse`, `PatchDefaultsRequest` |
+| `backend/src/agents/__init__.py` | Add `_create_mcp_backend_checked()`, register in factories, update `resolve_sandbox_backend()` signature and logic, add `is_mcp_sandbox_error()` |
+| `backend/src/controllers/llm.py` | Read `default_mcp_sandbox_url` from settings, pass to `resolve_sandbox_backend()`, add MCP error handling with `mcp_sandbox_unreachable` error type |
+| `backend/src/utils/stream.py` | Accept and pass `mcp_sandbox_url`, add MCP error handling with `mcp_sandbox_unreachable` SSE event |
+| `backend/src/routes/v0/settings.py` | Map `default_mcp_sandbox_url` field in settings CRUD |
+| `backend/src/workers/tasks.py` | Pass `mcp_sandbox_url` if it calls `resolve_sandbox_backend()` |
+
+## Code Changes (Key Snippets)
+
+### settings.py — SandboxType enum:
+```python
+class SandboxType(str, Enum):
+    DAYTONA = "daytona"
+    STATE = "state"
+    MCP = "mcp"
+```
+
+### settings.py — UserSettings:
+```python
+class UserSettings(BaseEntity):
+    # ... existing fields ...
+    default_mcp_sandbox_url: Optional[str] = Field(
+        default=None, description="User's MCP sandbox endpoint URL"
+    )
+```
+
+### agents/__init__.py — factory:
+```python
+def _create_mcp_backend_checked(
+    runtime: ToolRuntime,
+    mcp_sandbox_url: str,
+) -> tuple[CompositeBackend, None] | None:
+    from src.agents.mcp_sandbox import McpSandboxBackend
+    try:
+        mcp_backend = McpSandboxBackend(base_url=mcp_sandbox_url)
+        backend = CompositeBackend(default=mcp_backend, routes={})
+        return backend, None
+    except Exception as exc:
+        logger.error(f"Failed to create MCP sandbox backend: {exc}")
+        return None
+```
+
+### agents/__init__.py — updated resolve_sandbox_backend:
+```python
+def resolve_sandbox_backend(
+    runtime: ToolRuntime,
+    sandbox_type: str | None = None,
+    mcp_sandbox_url: str | None = None,
+) -> tuple[CompositeBackend, Any, str]:
+    effective = sandbox_type if sandbox_type in _SANDBOX_FACTORIES else None
+
+    if effective == "state":
+        backend, sandbox = _create_state_backend(runtime)
+        return backend, sandbox, "state"
+
+    if effective == "mcp":
+        if mcp_sandbox_url:
+            result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+            if result is not None:
+                return result[0], result[1], "mcp"
+        # MCP requested but unavailable — fall back to state
+        backend, sandbox = _create_state_backend(runtime)
+        return backend, sandbox, "state"
+
+    # "daytona" or auto (None) — try Daytona first, then MCP, then State
+    result = _create_daytona_backend_checked(runtime)
+    if result is not None:
+        return result[0], result[1], "daytona"
+
+    # Try MCP if URL is configured
+    if mcp_sandbox_url:
+        result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+        if result is not None:
+            return result[0], result[1], "mcp"
+
+    # Fallback: plain StateBackend
+    backend, sandbox = _create_state_backend(runtime)
+    return backend, sandbox, "state"
+```
+
+### controllers/llm.py — MCP error handling:
+```python
+# In _resolve_user_settings, also read mcp_sandbox_url:
+default_mcp_sandbox_url = getattr(settings, "default_mcp_sandbox_url", None)
+return model, api_key, default_sandbox, default_mcp_sandbox_url
+
+# In llm_invoke/llm_stream, pass mcp_sandbox_url:
+backend, _sandbox, effective_type = resolve_sandbox_backend(
+    runtime, sandbox_type=default_sandbox, mcp_sandbox_url=default_mcp_sandbox_url
+)
+
+# MCP error handling (in except block):
+if is_mcp_sandbox_error(e):
+    if default_sandbox == "mcp":
+        # Explicit MCP mode: return mcp_sandbox_unreachable error
+        logger.error(f"MCP sandbox error (mcp mode): {e}")
+        raise  # Let frontend handle via toast
+    elif default_sandbox in (None, "auto") and effective_type == "mcp":
+        # Auto mode: silent fallback to State
+        logger.warning(f"MCP sandbox error in auto mode, falling back to state: {e}")
+        fallback_backend, _ = _create_state_backend(runtime)
+        # ... retry with fallback_backend ...
+```
+
+### utils/stream.py — MCP error SSE event:
+```python
+# In the except block, after Daytona error handling:
+elif is_mcp_sandbox_error(e):
+    if sandbox_type == "mcp":
+        logger.error(f"MCP sandbox error (mcp mode): {e}")
+        error_msg = ujson.dumps(("mcp_sandbox_unreachable", str(e)))
+        yield f"data: {error_msg}\n\n"
+    elif sandbox_type in (None, "auto") and effective_type == "mcp":
+        # Auto mode: silent fallback
+        logger.warning(f"MCP sandbox error in auto mode, falling back: {e}")
+        fallback_backend, _ = _create_state_backend(runtime)
+        agent = await construct_agent(...)
+        async for chunk in agent.astream(input, **astream_kwargs):
+            sse_line = _process_and_format_chunk(chunk, agent.model, state)
+            if sse_line:
+                yield sse_line
+```
+
+## Success Criteria
+
+1. [ ] `SandboxType` enum includes `MCP = "mcp"` value
+2. [ ] `UserSettings` has `default_mcp_sandbox_url: Optional[str]` field
+3. [ ] `DefaultsResponse` includes `mcp_sandbox_url` field
+4. [ ] `PatchDefaultsRequest` includes `mcp_sandbox_url` field
+5. [ ] Settings API PATCH endpoint accepts and persists `mcp_sandbox_url`
+6. [ ] Settings API GET endpoint returns `mcp_sandbox_url` in defaults
+7. [ ] `_create_mcp_backend_checked()` factory exists and creates `McpSandboxBackend` from user's URL
+8. [ ] `resolve_sandbox_backend()` accepts `mcp_sandbox_url` parameter
+9. [ ] Dispatch chain: Daytona -> MCP (if URL configured) -> State for auto/None
+10. [ ] Explicit `sandbox_type="mcp"` tries MCP, falls back to State if unavailable
+11. [ ] `is_mcp_sandbox_error()` helper correctly identifies MCP connection errors
+12. [ ] `controllers/llm.py` reads `default_mcp_sandbox_url` from settings and passes to dispatch
+13. [ ] `utils/stream.py` handles MCP errors with `mcp_sandbox_unreachable` SSE event type
+14. [ ] No hardcoded `MCP_SANDBOX_URL` env var — URL comes exclusively from user settings
+15. [ ] Existing Daytona and State sandbox flows are unaffected (regression-safe)
+16. [ ] Code passes `make format` and `make lint`
+
+## Example Output
+
+```bash
+# Verify SandboxType enum
+cd backend && uv run python -c "from src.schemas.entities.settings import SandboxType; print(SandboxType.MCP)"
+# SandboxType.MCP
+
+# Verify factory registration
+cd backend && uv run python -c "from src.agents import _SANDBOX_FACTORIES; print(list(_SANDBOX_FACTORIES.keys()))"
+# ['daytona', 'state', 'mcp']
+
+# API: Set MCP sandbox URL
+curl -X PATCH http://localhost:8000/api/settings/default \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"mcp_sandbox_url": "http://localhost:3005/mcp", "sandbox": "mcp"}'
+# {"defaults": {"sandbox": "mcp", "mcp_sandbox_url": "http://localhost:3005/mcp", ...}}
+```
+
+---
+
+## Ralph Instructions
+
+1. Work on the next incomplete criterion (marked [ ])
+2. Check off completed criteria (change [ ] to [x])
+3. Run tests after changes: `cd backend && uv run pytest tests/unit/agents/ -v`
+4. Run format after changes: `cd backend && make format`
+5. Commit your changes frequently
+6. When ALL criteria are [x], output: `<ralph>COMPLETE</ralph>`
+7. If stuck on the same issue 3+ times, output: `<ralph>GUTTER</ralph>`

--- a/.claude/specs/feat-890-mcp-sandbox/003-frontend-mcp-option.md
+++ b/.claude/specs/feat-890-mcp-sandbox/003-frontend-mcp-option.md
@@ -1,0 +1,213 @@
+---
+task: Frontend MCP Sandbox Option + Health + Fallback UX (Feature #890)
+test_command: "cd frontend && npm run test"
+---
+
+# Task: Frontend MCP Sandbox Option + Health Indicator + Fallback UX (Feature #890)
+
+> **IMPORTANT**: Before implementing this feature, READ `/CLAUDE.md` first.
+
+Add MCP Sandbox as a selectable option in the frontend sandbox selector with live health indicator (green/red dot) and user-approved fallback toast when the sandbox is unreachable. MCP option is only visible when the user has configured `mcp_sandbox_url` in their settings.
+
+**Independent**: Can be implemented in parallel with Specs 001 and 004.
+
+## Requirements
+
+### Type & Config Changes
+
+1. **Extend `SandboxType` union** in `frontend/src/lib/services/userSettingsService.ts`:
+   - Change from `"daytona" | "state"` to `"daytona" | "state" | "mcp"`
+2. **Add `mcp_sandbox_url` to `DefaultsResponse`** interface:
+   - `mcp_sandbox_url: string | null;`
+3. **Add `mcp_sandbox_url` to `patchDefaults` data type**:
+   - `mcp_sandbox_url: string | null;`
+4. **Add MCP entry to `SANDBOX_OPTIONS`** in `frontend/src/lib/config/sandbox.ts`:
+   ```typescript
+   {
+     value: "mcp",
+     label: "MCP Sandbox",
+     shortLabel: "MCP",
+     description: "Run agent code in an isolated MCP sandbox container.",
+   }
+   ```
+5. **Update `normalizeSandboxValue()`** to recognize `"mcp"` as a valid value
+
+### MCP Sandbox URL Configuration
+
+6. **Add "MCP Sandbox URL" input field in settings page**:
+   - Located in the SandboxSettings component, below the sandbox selector dropdown
+   - Text input with placeholder `http://localhost:3005/mcp`
+   - On blur or enter, persists via `patchDefaults({ mcp_sandbox_url: value })`
+   - Shows current saved URL on page load from `settings.defaults.mcp_sandbox_url`
+
+### Visibility Gating
+
+7. **MCP option visibility gating**:
+   - MCP Sandbox option ONLY appears in the sandbox selector dropdown when `mcp_sandbox_url` is set and non-empty in user settings
+   - Filter `SANDBOX_OPTIONS` based on user's configured `mcp_sandbox_url`
+   - Same pattern as Daytona (only shows when API key is set)
+
+### Health Indicator
+
+8. **Create `useSandboxHealth` hook** in `frontend/src/hooks/useSandboxHealth.ts`:
+   - Accepts the user's `mcp_sandbox_url` string
+   - Derives health endpoint: strip `/mcp` suffix from URL, append `/health`
+   - Pings health endpoint on:
+     - Page load (initial mount)
+     - When sandbox selector dropdown is opened
+   - Returns `{ isHealthy: boolean | null, isLoading: boolean, refresh: () => void }`
+   - `null` means not yet checked; `true` = reachable; `false` = unreachable
+   - No background polling — only on-demand checks
+9. **Display health dot** in `SandboxSettings.tsx`:
+   - Green dot (bg-green-500) next to "MCP Sandbox" label when `isHealthy === true`
+   - Red dot (bg-red-500) when `isHealthy === false`
+   - No dot when `isHealthy === null` (still loading or not checked)
+10. **Display health dot** in `ThreadSandboxStatus.tsx`:
+    - Same green/red dot pattern as settings page
+    - Refresh health when the sandbox selector popover is opened
+
+### User-Approved Fallback Toast
+
+11. **Handle `mcp_sandbox_unreachable` SSE event**:
+    - When the backend sends `("mcp_sandbox_unreachable", "<error message>")` via SSE stream
+    - Show a toast notification: "MCP sandbox unreachable"
+    - Toast includes an action button: "Use State for this message"
+    - Clicking the button retries the same user message with `sandbox_type=state` override (one-time)
+    - MCP stays selected as the default for future messages
+12. **SSE event handler integration**:
+    - Add `mcp_sandbox_unreachable` case to the existing stream event handler (wherever `"error"` events are handled)
+    - The retry with state override can be done by re-sending the message with a query param or request body field that forces `sandbox_type=state`
+
+## Existing Patterns to Follow
+
+### SandboxSettings component:
+- Located at `frontend/src/components/settings/SandboxSettings.tsx`
+- Uses `SANDBOX_OPTIONS` from `@/lib/config/sandbox`
+- Calls `patchDefaults({ sandbox: value })` on selection change
+- Shows toast on success/error
+
+### ThreadSandboxStatus component:
+- Located at `frontend/src/components/status/ThreadSandboxStatus.tsx`
+- Shows current sandbox in a popover with selection options
+- Uses `getSandboxOption()` to resolve display label
+
+### Stream error handling:
+- SSE events are parsed in the chat stream handler
+- Existing pattern handles `("error", "message")` tuples
+- Add parallel handling for `("mcp_sandbox_unreachable", "message")` tuples
+
+## Success Criteria
+
+1. [ ] `SandboxType` union includes `"mcp"` in `userSettingsService.ts`
+2. [ ] `DefaultsResponse` interface includes `mcp_sandbox_url: string | null`
+3. [ ] `patchDefaults` data type includes `mcp_sandbox_url` field
+4. [ ] `SANDBOX_OPTIONS` array includes MCP entry with label "MCP Sandbox", shortLabel "MCP"
+5. [ ] `normalizeSandboxValue()` recognizes `"mcp"` and returns it as-is
+6. [ ] MCP Sandbox URL input field exists in SandboxSettings component
+7. [ ] MCP Sandbox URL is persisted via `patchDefaults({ mcp_sandbox_url: value })`
+8. [ ] MCP option only visible in dropdown when `mcp_sandbox_url` is configured
+9. [ ] `useSandboxHealth` hook pings health endpoint on mount and dropdown open
+10. [ ] Green dot displayed when exec_server is reachable, red dot when not
+11. [ ] Health dot visible in both `SandboxSettings.tsx` and `ThreadSandboxStatus.tsx`
+12. [ ] `mcp_sandbox_unreachable` SSE event triggers toast with "Use State for this message" action
+13. [ ] Clicking "Use State" retries the message with state backend (one-time override)
+14. [ ] MCP stays selected as default after using the State fallback button
+15. [ ] Existing State and Daytona options are unaffected
+16. [ ] All frontend tests pass: `npm run test`
+
+## Example Output
+
+### Settings page with MCP URL configured:
+```
+Default Sandbox
+┌─────────────────────────────────────────────┐
+│ MCP Sandbox                              ▼  │
+│ Run agent code in an isolated MCP sandbox   │
+│ container.                                  │
+└─────────────────────────────────────────────┘
+
+MCP Sandbox URL
+┌─────────────────────────────────────────────┐
+│ http://localhost:3005/mcp                    │
+└─────────────────────────────────────────────┘
+```
+
+### Dropdown with health indicator:
+```
+┌─────────────────────────────────────────┐
+│ ○ State (Default)                       │
+│   Run agent code with the state sandbox │
+│                                         │
+│ ○ Daytona                               │
+│   Run agent code in the Daytona sandbox │
+│                                         │
+│ ● MCP Sandbox  🟢                       │
+│   Run agent code in an isolated MCP     │
+│   sandbox container.                    │
+└─────────────────────────────────────────┘
+```
+
+### Fallback toast:
+```
+┌─────────────────────────────────────────┐
+│ ⚠ MCP sandbox unreachable              │
+│                    [Use State for this   │
+│                     message]            │
+└─────────────────────────────────────────┘
+```
+
+## QA Validation
+
+### Frontend unit tests:
+```bash
+cd frontend && npm run test
+```
+
+### agent-browser UI validation (step-by-step):
+
+**Story 1: User configures MCP URL and selects MCP sandbox**
+1. Navigate to `http://localhost:5173/settings`
+2. Scroll to "Default Sandbox" card
+3. Verify MCP option is NOT visible (no URL configured yet)
+4. Enter `http://localhost:3005/mcp` in the MCP Sandbox URL input
+5. Save — verify toast confirms save
+6. Click sandbox selector dropdown — verify "MCP Sandbox" now appears
+7. Verify green dot next to MCP (exec_server running)
+8. Select "MCP Sandbox" — verify selection persists
+9. Refresh page — verify both URL and MCP selection persist
+
+**Story 2: Thread status bar MCP selector**
+1. Navigate to chat page
+2. Click sandbox selector button in utility row
+3. Verify "MCP Sandbox" option listed with green dot
+4. Select it — verify button updates to "Sandbox MCP"
+
+**Story 3: Fallback toast when unreachable**
+1. Stop exec_server
+2. Send a message with MCP selected
+3. Verify toast: "MCP sandbox unreachable" with "Use State for this message" button
+4. Click the button — verify message processes with state backend
+5. Verify MCP still selected as default
+
+## Files
+
+| File | Action |
+|------|--------|
+| `frontend/src/lib/services/userSettingsService.ts` | MODIFY (SandboxType union, DefaultsResponse, patchDefaults) |
+| `frontend/src/lib/config/sandbox.ts` | MODIFY (SANDBOX_OPTIONS, normalizeSandboxValue) |
+| `frontend/src/hooks/useSandboxHealth.ts` | CREATE |
+| `frontend/src/components/settings/SandboxSettings.tsx` | MODIFY (MCP URL input, health dot, visibility gating) |
+| `frontend/src/components/tools/ThreadSandboxStatus.tsx` | MODIFY (health dot, MCP option) |
+| Chat stream event handler (locate existing SSE handler) | MODIFY (mcp_sandbox_unreachable event) |
+
+---
+
+## Ralph Instructions
+
+1. Work on the next incomplete criterion (marked [ ])
+2. Check off completed criteria (change [ ] to [x])
+3. Run tests after changes: `cd frontend && npm run test`
+4. Run format after changes: `cd frontend && npm run format`
+5. Commit your changes frequently
+6. When ALL criteria are [x], output: `<ralph>COMPLETE</ralph>`
+7. If stuck on the same issue 3+ times, output: `<ralph>GUTTER</ralph>`

--- a/.claude/specs/feat-890-mcp-sandbox/004-exec-server-structured.md
+++ b/.claude/specs/feat-890-mcp-sandbox/004-exec-server-structured.md
@@ -1,0 +1,263 @@
+---
+task: exec_server BaseSandbox-Conformant MCP Tools (Feature #890 + sandboxes#3)
+test_command: "cd sandboxes && bash tests/conformance.sh http://localhost:3005"
+---
+
+# Task: exec_server BaseSandbox-Conformant MCP Tools (Feature #890 + sandboxes#3)
+
+> **IMPORTANT**: Before implementing this feature, READ `/CLAUDE.md` first.
+
+Enhance `sandboxes/ubuntu/index.js` to expose MCP tools that mirror the full `BaseSandbox` protocol 1:1. Rename `exec_command` to `execute`. Add 8 new tools. Add structured `_meta` with `exit_code` and `sandbox_id` to all tool responses. Create a conformance test suite. Any sandbox that passes this suite is a drop-in DeepAgents sandbox backend.
+
+**Independent**: Can be implemented in parallel with Specs 001, 002, and 003. This is in the `sandboxes/` submodule (separate `ruska-ai/sandboxes` repo).
+
+## Requirements
+
+### Tool Rename + New Tools
+
+1. **Rename `exec_command` to `execute`** — add `exec_command` as a backward-compatibility alias that delegates to the same handler. This prevents a breakage window between Phase 4 deploy (tool rename) and Phase 5 deploy (dual-name support in Python client). The alias can be removed in a future cleanup pass once all consumers use `execute`.
+2. **Add structured `_meta` to ALL tool responses**:
+   ```json
+   {
+     "content": [{"type": "text", "text": "..."}],
+     "_meta": {"exit_code": 0, "sandbox_id": "<uuid>"}
+   }
+   ```
+   - `exit_code`: integer (not text-embedded)
+   - `sandbox_id`: UUID generated once at server startup via `crypto.randomUUID()`
+3. **`execute` tool** (renamed from `exec_command`):
+   - Params: `{cmd: string, timeout?: number}`
+   - Keep text-embedded `exit_code: N` in output text for backward compat (Phase 1)
+   - Also include `_meta.exit_code` as structured integer
+   - Timeout: use provided timeout or default 120s, cap at 120s max
+4. **`read` tool** (NEW):
+   - Params: `{path: string, offset?: number, limit?: number}`
+   - Returns file content in `cat -n` format (line numbers + tab + content)
+   - `offset`: 0-based line offset, default 0
+   - `limit`: max lines to return, default 2000
+   - `_meta.exit_code`: 0 on success, 1 if file not found
+5. **`write` tool** (NEW):
+   - Params: `{path: string, content: string}`
+   - Creates parent directories with `mkdir -p`
+   - Writes content to file (overwrites if exists)
+   - `_meta.exit_code`: 0 on success, 1 on error
+6. **`edit` tool** (NEW):
+   - Params: `{path: string, old_string: string, new_string: string, replace_all?: boolean}`
+   - Exit code semantics matching BaseSandbox's `_EDIT_COMMAND_TEMPLATE`:
+     - 0: success (replacement made)
+     - 1: `old_string` not found in file
+     - 2: `old_string` found multiple times (and `replace_all` is false)
+     - 3: file not found
+   - Returns occurrence count as text content
+7. **`grep` tool** (NEW):
+   - Params: `{pattern: string, path?: string, glob?: string}`
+   - Returns newline-delimited JSON objects: `{"path": "...", "line": N, "text": "..."}`
+   - Uses fixed-string grep (`grep -rHnF`)
+   - Default path: `/workspace` (or cwd)
+   - `_meta.exit_code`: 0 on matches found, 1 on no matches
+8. **`glob` tool** (NEW):
+   - Params: `{pattern: string, path?: string}`
+   - Returns newline-delimited JSON objects: `{"path": "...", "is_dir": bool, "size": N, "mtime": "ISO"}`
+   - Default path: `/workspace`
+   - `_meta.exit_code`: 0 on success
+9. **`ls` tool** (NEW):
+   - Params: `{path: string}`
+   - Returns newline-delimited JSON objects: `{"path": "...", "is_dir": bool}`
+   - `_meta.exit_code`: 0 on success, 1 if path not found
+10. **`upload_file` tool** (NEW):
+    - Params: `{path: string, content_base64: string}`
+    - Decodes base64, creates parent dirs, writes binary file
+    - Returns: `"Written N bytes to <path>"`
+    - `_meta.exit_code`: 0 on success, 1 on error
+11. **`download_file` tool** (NEW):
+    - Params: `{path: string}`
+    - Reads file, returns base64-encoded content as text
+    - `_meta.exit_code`: 0 on success, 1 if file not found
+
+### Infrastructure Changes
+
+12. **Sandbox ID**: Generate `crypto.randomUUID()` once at server startup. Include in:
+    - `/health` response: `{"status": "ok", "sessions": N, "sandbox_id": "<uuid>"}`
+    - Every tool response `_meta.sandbox_id`
+13. **Ensure python3 available**: Update Dockerfile to install `python3`:
+    ```dockerfile
+    RUN apt-get update && apt-get install -y --no-install-recommends python3
+    ```
+    (Debian bookworm-slim may already have python3 — verify and add if missing)
+14. **Working directory (OpenClaw model)**: Change default cwd from `/home/executor` to `/workspace`:
+    - Update Dockerfile/entrypoint to create `/workspace` directory structure:
+      ```
+      /workspace/
+      ├── AGENTS.md
+      ├── SOUL.md
+      ├── USER.md
+      ├── IDENTITY.md
+      ├── TOOLS.md
+      ├── MEMORY.md
+      ├── memory/
+      ├── skills/
+      └── canvas/
+      ```
+    - Create empty template files on container startup (in `entrypoint.sh`)
+    - Set `cwd: "/workspace"` in `exec()` calls instead of `/home/executor`
+    - Ensure `/workspace` is writable by the `executor` user
+15. **Update `tools/list` response**: All 9 tools should be listed with descriptions and Zod schemas
+
+### Conformance Test Suite
+
+16. **Create `sandboxes/tests/conformance.sh`**:
+    - Accepts server URL as argument: `bash tests/conformance.sh http://localhost:3005`
+    - Tests ALL 9 MCP tools are registered and functional
+    - Tests exit_code semantics for each tool (success + error cases)
+    - Tests `sandbox_id` in `/health` and `_meta`
+    - Tests `python3` availability via execute tool
+    - Tests timeout behavior
+    - Tests `/workspace` as default working directory with OpenClaw layout
+    - Tests session lifecycle: init, reuse across calls, concurrent requests, session cleanup (DELETE `/mcp`), reconnect after session expiry
+    - Output format: `PASS: <test_name>` or `FAIL: <test_name> - <reason>`
+    - Exit code 0 if all pass, 1 if any fail
+    - Summary at end: `N/M tests passed`
+
+## Tool Registration Pattern
+
+```javascript
+const SANDBOX_ID = crypto.randomUUID();
+
+function makeResult(text, exitCode) {
+  return {
+    content: [{ type: "text", text }],
+    _meta: { exit_code: exitCode, sandbox_id: SANDBOX_ID },
+  };
+}
+
+function registerTools(server) {
+  server.tool("execute", "Execute a shell command", { cmd: z.string(), timeout: z.number().optional() }, executeHandler);
+  server.tool("exec_command", "Execute a shell command (backward-compat alias)", { cmd: z.string(), timeout: z.number().optional() }, executeHandler);
+  server.tool("read", "Read file with line numbers", { path: z.string(), offset: z.number().optional(), limit: z.number().optional() }, readHandler);
+  server.tool("write", "Write content to file", { path: z.string(), content: z.string() }, writeHandler);
+  server.tool("edit", "Replace string in file", { path: z.string(), old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }, editHandler);
+  server.tool("grep", "Search for pattern in files", { pattern: z.string(), path: z.string().optional(), glob: z.string().optional() }, grepHandler);
+  server.tool("glob", "Find files by glob pattern", { pattern: z.string(), path: z.string().optional() }, globHandler);
+  server.tool("ls", "List directory contents", { path: z.string() }, lsHandler);
+  server.tool("upload_file", "Upload base64 file", { path: z.string(), content_base64: z.string() }, uploadHandler);
+  server.tool("download_file", "Download file as base64", { path: z.string() }, downloadHandler);
+}
+```
+
+## Success Criteria
+
+1. [ ] `exec_command` renamed to `execute` with `exec_command` kept as backward-compat alias (same handler)
+2. [ ] `execute` tool includes both text-embedded `exit_code: N` and `_meta.exit_code` (integer)
+3. [ ] `read` tool returns `cat -n` formatted content with `offset`/`limit` support
+4. [ ] `write` tool creates files with parent dirs, `exit_code=1` on error
+5. [ ] `edit` tool implements exit codes 0-3 matching BaseSandbox semantics
+6. [ ] `grep` tool returns JSON lines format `{path, line, text}` with fixed-string search
+7. [ ] `glob` tool returns JSON lines format `{path, is_dir, size, mtime}`
+8. [ ] `ls` tool returns JSON lines format `{path, is_dir}`
+9. [ ] `upload_file` tool decodes base64, writes binary, returns byte count
+10. [ ] `download_file` tool reads file, returns base64-encoded content
+11. [ ] `_meta.sandbox_id` present in ALL tool responses (UUID generated at startup)
+12. [ ] `_meta.exit_code` is integer (not string) in ALL tool responses
+13. [ ] `/health` endpoint returns `sandbox_id` field
+14. [ ] `tools/list` returns all 9 tools with correct names and schemas
+15. [ ] Dockerfile ensures `python3` is available in the container
+16. [ ] `/workspace` is the default working directory with OpenClaw layout (AGENTS.md, SOUL.md, etc.)
+17. [ ] Conformance test suite `sandboxes/tests/conformance.sh` exists and tests all 9 tools
+18. [ ] Conformance tests validate exit_code semantics, sandbox_id, python3, /workspace, session lifecycle
+19. [ ] Conformance tests pass when run against the updated exec_server
+20. [ ] All tool handlers run commands as `executor` user (unprivileged)
+
+## Example Output
+
+### Health check:
+```json
+{"status": "ok", "sessions": 0, "sandbox_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
+```
+
+### execute tool response:
+```json
+{
+  "content": [{"type": "text", "text": "stdout:\nhello\nexit_code: 0"}],
+  "_meta": {"exit_code": 0, "sandbox_id": "a1b2c3d4..."}
+}
+```
+
+### read tool response:
+```json
+{
+  "content": [{"type": "text", "text": "     1\tHello World\n     2\tLine 2"}],
+  "_meta": {"exit_code": 0, "sandbox_id": "a1b2c3d4..."}
+}
+```
+
+### grep tool response:
+```json
+{
+  "content": [{"type": "text", "text": "{\"path\":\"/workspace/test.txt\",\"line\":1,\"text\":\"Hello World\"}\n{\"path\":\"/workspace/test.txt\",\"line\":3,\"text\":\"Hello Again\"}"}],
+  "_meta": {"exit_code": 0, "sandbox_id": "a1b2c3d4..."}
+}
+```
+
+### Conformance test output:
+```
+Running conformance tests against http://localhost:3005
+PASS: health_check - status ok, sandbox_id present
+PASS: session_init - got Mcp-Session-Id header
+PASS: tools_list - all 9 tools registered
+PASS: execute_success - exit_code=0, output contains expected text
+PASS: execute_failure - exit_code=2 for ls /nonexistent
+PASS: read_success - cat -n format, exit_code=0
+PASS: read_not_found - exit_code=1
+PASS: write_success - file created, exit_code=0
+PASS: edit_success - replacement made, exit_code=0
+PASS: edit_not_found - exit_code=1
+PASS: edit_multiple - exit_code=2 (replace_all=false)
+PASS: edit_file_missing - exit_code=3
+PASS: grep_match - JSON lines output, exit_code=0
+PASS: grep_no_match - exit_code=1
+PASS: glob_success - JSON lines with metadata
+PASS: ls_success - JSON lines with is_dir
+PASS: upload_file - binary round-trip preserved
+PASS: download_file - base64 content returned
+PASS: download_not_found - exit_code=1
+PASS: python3_available - python3 --version succeeds
+PASS: workspace_default - pwd returns /workspace
+PASS: workspace_layout - AGENTS.md, SOUL.md, etc. exist
+PASS: session_reuse - multiple calls on same session
+PASS: session_cleanup - DELETE /mcp removes session
+24/24 tests passed
+```
+
+## QA Validation
+
+### Build and start updated exec_server:
+```bash
+cd sandboxes/ubuntu && docker build -t exec-server-test . && docker run -d -p 3005:3005 --name exec-server-test exec-server-test
+```
+
+### Run conformance tests:
+```bash
+cd sandboxes && bash tests/conformance.sh http://localhost:3005
+```
+
+### Manual tool validation (see plan QA-004 for full curl commands)
+
+## Files
+
+| File | Action |
+|------|--------|
+| `sandboxes/ubuntu/index.js` | MODIFY (rename exec_command, add 8 tools, add _meta, add sandbox_id) |
+| `sandboxes/ubuntu/Dockerfile` | MODIFY (ensure python3, create /workspace) |
+| `sandboxes/ubuntu/entrypoint.sh` | MODIFY (create /workspace OpenClaw layout on startup) |
+| `sandboxes/tests/conformance.sh` | CREATE (full conformance test suite) |
+
+---
+
+## Ralph Instructions
+
+1. Work on the next incomplete criterion (marked [ ])
+2. Check off completed criteria (change [ ] to [x])
+3. Run tests after changes: build the Docker image and run `cd sandboxes && bash tests/conformance.sh http://localhost:3005`
+4. Commit your changes frequently (commit inside `sandboxes/` directory, it's a separate git repo)
+5. When ALL criteria are [x], output: `<ralph>COMPLETE</ralph>`
+6. If stuck on the same issue 3+ times, output: `<ralph>GUTTER</ralph>`

--- a/.claude/specs/feat-890-mcp-sandbox/005-mcp-sandbox-v2.md
+++ b/.claude/specs/feat-890-mcp-sandbox/005-mcp-sandbox-v2.md
@@ -1,0 +1,279 @@
+---
+task: McpSandboxBackend v2 Native MCP Tools (Feature #890)
+test_command: "cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v"
+---
+
+# Task: McpSandboxBackend v2 — Native MCP Tools for Full BaseSandbox (Feature #890)
+
+> **IMPORTANT**: Before implementing this feature, READ `/CLAUDE.md` first.
+
+Upgrade `McpSandboxBackend` to use native MCP tools for ALL BaseSandbox operations, overriding the inherited shell-delegation implementations when the exec_server supports them. This enables direct MCP tool calls for `read`, `write`, `edit`, `grep`, `glob`, `ls`, `upload_file`, and `download_file` instead of routing everything through `execute()`.
+
+**Depends on**: Spec 002 (dispatch wiring) + Spec 004 (exec_server structured tools)
+
+## Architecture
+
+Spec 001 implemented `McpSandboxBackend` with only `execute()` as the core MCP call — all other tools work via inherited shell-delegation through `execute()`. This spec adds **native MCP tool overrides** that call the server's tools directly, with automatic fallback to inherited implementations when the server doesn't have the tools.
+
+### Method Override Table
+
+| BaseSandbox Method | Spec 001 (shell fallback via execute) | Spec 005 (native MCP tool) |
+|---|---|---|
+| `execute()` | `exec_command` + text-parse exit_code | `execute` + `_meta.exit_code` |
+| `read()` | Inherited python3 heredoc via `execute()` | Native `read` MCP tool |
+| `write()` | Inherited python3 heredoc via `execute()` | Native `write` MCP tool |
+| `edit()` | Inherited python3 heredoc via `execute()` | Native `edit` MCP tool |
+| `grep_raw()` | Inherited `grep -rHnF` via `execute()` | Native `grep` MCP tool |
+| `glob_info()` | Inherited python3 heredoc via `execute()` | Native `glob` MCP tool |
+| `ls_info()` | Inherited python3 scandir via `execute()` | Native `ls` MCP tool |
+| `upload_files()` | Shell base64 via `execute()` | Native `upload_file` MCP tool |
+| `download_files()` | Shell base64 via `execute()` | Native `download_file` MCP tool |
+
+## Requirements
+
+### Tool Discovery
+
+1. **Discover available tools on session init**:
+   - After `initialize`, call `tools/list` JSON-RPC method
+   - Cache the set of available tool names (e.g., `{"execute", "read", "write", "edit", "grep", "glob", "ls", "upload_file", "download_file"}`)
+   - Store as `self._available_tools: set[str]`
+2. **Use native tool when available, fall back to inherited when not**:
+   - Check `self._available_tools` before each call
+   - If tool is available: call it directly via `_call_tool()`
+   - If not available: call `super().method()` (inherited shell-delegation via `execute()`)
+
+### Dual-Mode Exit Code
+
+3. **Prefer `_meta.exit_code`** (structured int from Spec 004 exec_server):
+   - When response contains `_meta.exit_code`, use it directly
+   - Fall back to text-parsing regex (`r'exit_code:\s*(\d+)'`) for older exec_servers that only have text-embedded exit codes
+   - This makes `McpSandboxBackend` work with both old and new exec_servers
+
+### Sandbox ID from _meta
+
+4. **Use `_meta.sandbox_id`** for the `id` property when available:
+   - On first tool call, extract `_meta.sandbox_id` from the response
+   - Cache it as `self._sandbox_id`
+   - `id` property returns `_meta.sandbox_id` if available, otherwise the generated fallback from Spec 001
+
+### Native Tool Overrides
+
+5. **Override `execute(command, *, timeout=None) -> ExecuteResponse`**:
+   - Call `execute` MCP tool (renamed from `exec_command` in Spec 004)
+   - Also support `exec_command` fallback for old servers (check `_available_tools`)
+   - Parse `_meta.exit_code` first, fall back to text regex
+   - Return `ExecuteResponse(output=text, exit_code=int)`
+
+6. **Override `read(file_path, offset=0, limit=2000) -> str`**:
+   - If `"read"` in `_available_tools`: call `read` MCP tool with `{path, offset, limit}`
+   - Parse text content (already in cat -n format from server)
+   - Otherwise: fall back to `super().read()` (inherited python3 heredoc via execute)
+
+7. **Override `write(file_path, content) -> WriteResult`**:
+   - If `"write"` in `_available_tools`: call `write` MCP tool with `{path, content}`
+   - Parse `_meta.exit_code` for success/error
+   - Return `WriteResult(error=None, path=file_path)` on success
+   - Otherwise: fall back to `super().write()`
+
+8. **Override `edit(file_path, old_string, new_string, replace_all=False) -> EditResult`**:
+   - If `"edit"` in `_available_tools`: call `edit` MCP tool with `{path, old_string, new_string, replace_all}`
+   - Parse `_meta.exit_code` (0=ok, 1=not found, 2=multiple, 3=file missing)
+   - Parse occurrence count from text content
+   - Return `EditResult(error=None, path=file_path, occurrences=N)` on success
+   - Return `EditResult(error="...", path=file_path)` on error codes 1-3
+   - Otherwise: fall back to `super().edit()`
+
+9. **Override `grep_raw(pattern, path, glob_pattern) -> list[GrepMatch]`**:
+   - If `"grep"` in `_available_tools`: call `grep` MCP tool with `{pattern, path, glob}`
+   - Parse JSON lines response: each line is `{"path": "...", "line": N, "text": "..."}`
+   - Return list of `GrepMatch(path=..., line=..., text=...)`
+   - Otherwise: fall back to `super().grep_raw()`
+
+10. **Override `glob_info(pattern, path) -> list[FileInfo]`**:
+    - If `"glob"` in `_available_tools`: call `glob` MCP tool with `{pattern, path}`
+    - Parse JSON lines: `{"path": "...", "is_dir": bool, "size": N, "mtime": "ISO"}`
+    - Return list of `FileInfo(path=..., is_dir=..., size=..., mtime=...)`
+    - Otherwise: fall back to `super().glob_info()`
+
+11. **Override `ls_info(path) -> list[FileInfo]`**:
+    - If `"ls"` in `_available_tools`: call `ls` MCP tool with `{path}`
+    - Parse JSON lines: `{"path": "...", "is_dir": bool}`
+    - Return list of `FileInfo(path=..., is_dir=...)`
+    - Otherwise: fall back to `super().ls_info()`
+
+12. **Override `upload_files(files) -> list[FileUploadResponse]`**:
+    - If `"upload_file"` in `_available_tools`: for each `(path, content_bytes)`, call `upload_file` MCP tool with `{path, content_base64: base64.b64encode(content).decode()}`
+    - Parse `_meta.exit_code` for success/error
+    - Otherwise: fall back to Spec 001's shell-based base64 implementation
+
+13. **Override `download_files(paths) -> list[FileDownloadResponse]`**:
+    - If `"download_file"` in `_available_tools`: for each path, call `download_file` MCP tool with `{path}`
+    - Decode base64 text content to bytes
+    - Parse `_meta.exit_code` for file_not_found errors
+    - Otherwise: fall back to Spec 001's shell-based base64 implementation
+
+### Return Type Parity
+
+14. **All native tool overrides must return the exact same types** as the inherited implementations:
+    - `ExecuteResponse(output: str, exit_code: int, truncated: bool)`
+    - `WriteResult(error: str | None, path: str | None)`
+    - `EditResult(error: str | None, path: str | None, occurrences: int | None)`
+    - `GrepMatch(path: str, line: int, text: str)`
+    - `FileInfo(path: str, is_dir: bool, size: int | None, mtime: str | None)`
+    - `FileUploadResponse(path: str, error: str | None)`
+    - `FileDownloadResponse(path: str, content: bytes | None, error: str | None)`
+
+### Graceful Degradation
+
+15. **If exec_server only has `execute` (no native tools)**: all inherited methods still work via `execute()` delegation — zero regression from Spec 001 behavior
+
+## Implementation Approach
+
+Update `backend/src/agents/mcp_sandbox.py` to:
+
+1. Add `_available_tools: set[str]` attribute, populated during `_ensure_initialized()`
+2. Add helper `_has_tool(name: str) -> bool` that checks the cached set
+3. Add response parser `_parse_meta(result: dict) -> tuple[int | None, str | None]` that extracts `exit_code` and `sandbox_id` from `_meta`
+4. Add JSON lines parser `_parse_json_lines(text: str) -> list[dict]` for grep/glob/ls responses
+5. Override each method with the native-first, fallback-second pattern
+
+### Session Init Update
+
+```python
+def _ensure_initialized(self) -> None:
+    if self._initialized:
+        return
+    # ... existing initialize call ...
+
+    # Discover available tools
+    tools_response = self._jsonrpc("tools/list", {})
+    self._available_tools = {
+        tool["name"] for tool in tools_response.get("tools", [])
+    }
+```
+
+### Override Pattern
+
+```python
+def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+    if self._has_tool("read"):
+        result = self._call_tool("read", {"path": file_path, "offset": offset, "limit": limit})
+        return self._extract_text(result)
+    return super().read(file_path, offset, limit)
+```
+
+## Success Criteria
+
+1. [ ] `_ensure_initialized()` calls `tools/list` and caches available tool names in `_available_tools`
+2. [ ] `execute()` prefers `_meta.exit_code` over text-parsed exit code
+3. [ ] `execute()` supports both `execute` (new) and `exec_command` (old) tool names based on `_available_tools`
+4. [ ] `id` property uses `_meta.sandbox_id` when available
+5. [ ] `read()` override calls native `read` MCP tool when available, returns cat -n formatted text
+6. [ ] `write()` override calls native `write` MCP tool when available, returns `WriteResult`
+7. [ ] `edit()` override calls native `edit` MCP tool when available, returns `EditResult` with correct exit code semantics (0-3)
+8. [ ] `grep_raw()` override calls native `grep` MCP tool when available, parses JSON lines, returns `list[GrepMatch]`
+9. [ ] `glob_info()` override calls native `glob` MCP tool when available, parses JSON lines, returns `list[FileInfo]`
+10. [ ] `ls_info()` override calls native `ls` MCP tool when available, parses JSON lines, returns `list[FileInfo]`
+11. [ ] `upload_files()` override calls native `upload_file` MCP tool when available, returns `list[FileUploadResponse]`
+12. [ ] `download_files()` override calls native `download_file` MCP tool when available, returns `list[FileDownloadResponse]`
+13. [ ] All overrides fall back to inherited implementations when the tool is not in `_available_tools`
+14. [ ] Return type parity: all native overrides return the exact same types as inherited implementations
+15. [ ] Graceful degradation: old exec_server (only `exec_command`) still works — all inherited methods function via `execute()`
+16. [ ] Unit tests cover: native tool paths, fallback paths, mixed availability, _meta parsing, JSON lines parsing
+17. [ ] Code passes `make format` and `make lint`
+
+## Example Output
+
+```python
+# With updated exec_server (Spec 004) — uses native tools
+sandbox = McpSandboxBackend(base_url="http://localhost:3005")
+
+# execute() — uses _meta.exit_code
+result = sandbox.execute("echo hello")
+# ExecuteResponse(output="stdout:\nhello\nexit_code: 0", exit_code=0)
+# exit_code=0 came from _meta, not text parsing
+
+# read() — native MCP tool
+content = sandbox.read("/workspace/AGENTS.md")
+# "     1\t# Agent Instructions\n     2\t..."
+
+# write() — native MCP tool
+result = sandbox.write("/workspace/test.py", "print('hello')")
+# WriteResult(error=None, path="/workspace/test.py")
+
+# edit() — native MCP tool
+result = sandbox.edit("/workspace/test.py", "hello", "world")
+# EditResult(error=None, path="/workspace/test.py", occurrences=1)
+
+# grep_raw() — native MCP tool
+matches = sandbox.grep_raw("world", "/workspace")
+# [GrepMatch(path="/workspace/test.py", line=1, text="print('world')")]
+
+# id — from _meta.sandbox_id
+print(sandbox.id)  # "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+# With OLD exec_server (only exec_command, no _meta) — uses fallback
+sandbox_old = McpSandboxBackend(base_url="http://old-server:3005")
+result = sandbox_old.execute("echo hello")
+# Still works — text-parsed exit_code
+content = sandbox_old.read("/tmp/test.txt")
+# Still works — inherited python3 heredoc via execute()
+```
+
+## QA Validation
+
+### Backend unit tests:
+```bash
+cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v
+```
+
+### Integration validation (requires updated exec_server from Spec 004):
+```bash
+# 1. Verify structured _meta parsing
+cd backend && uv run python -c "
+from src.agents.mcp_sandbox import McpSandboxBackend
+sb = McpSandboxBackend(base_url='http://localhost:3005')
+result = sb.execute('echo structured test')
+print(f'exit_code={result.exit_code}, output={result.output[:50]}')
+print(f'sandbox_id={sb.id}')
+print(f'available_tools={sb._available_tools}')
+"
+# Expected: exit_code=0, sandbox_id=<uuid>, available_tools includes all 9 tools
+
+# 2. Verify native read
+cd backend && uv run python -c "
+from src.agents.mcp_sandbox import McpSandboxBackend
+sb = McpSandboxBackend(base_url='http://localhost:3005')
+content = sb.read('/workspace/AGENTS.md')
+print(f'content_preview={content[:100]}')
+"
+
+# 3. Verify native upload + download round-trip
+cd backend && uv run python -c "
+from src.agents.mcp_sandbox import McpSandboxBackend
+sb = McpSandboxBackend(base_url='http://localhost:3005')
+sb.upload_files([('/tmp/v2-test.txt', b'native upload works')])
+files = sb.download_files(['/tmp/v2-test.txt'])
+print(f'downloaded={files[0].content.decode()}')
+"
+# Expected: downloaded=native upload works
+```
+
+## Files
+
+| File | Action |
+|------|--------|
+| `backend/src/agents/mcp_sandbox.py` | MODIFY (add tool discovery, override all methods, dual-mode exit_code) |
+| `backend/tests/unit/agents/test_mcp_sandbox.py` | MODIFY (add tests for native tool paths, fallback, _meta parsing) |
+
+---
+
+## Ralph Instructions
+
+1. Work on the next incomplete criterion (marked [ ])
+2. Check off completed criteria (change [ ] to [x])
+3. Run tests after changes: `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v`
+4. Run format after changes: `cd backend && make format`
+5. Commit your changes frequently
+6. When ALL criteria are [x], output: `<ralph>COMPLETE</ralph>`
+7. If stuck on the same issue 3+ times, output: `<ralph>GUTTER</ralph>`

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -313,6 +313,7 @@ def _create_state_backend(
 def _create_mcp_backend_checked(
     runtime: ToolRuntime,
     mcp_sandbox_url: str | None = None,
+    mcp_api_key: str | None = None,
 ) -> tuple[CompositeBackend, None] | None:
     """Try to create an MCP-backed CompositeBackend.
 
@@ -324,7 +325,7 @@ def _create_mcp_backend_checked(
     try:
         from src.agents.mcp_sandbox import McpSandboxBackend
 
-        mcp_backend = McpSandboxBackend(base_url=mcp_sandbox_url)
+        mcp_backend = McpSandboxBackend(base_url=mcp_sandbox_url, api_key=mcp_api_key)
         backend = CompositeBackend(default=mcp_backend, routes={})
         return backend, None
     except Exception as exc:
@@ -358,6 +359,7 @@ def resolve_sandbox_backend(
     runtime: ToolRuntime,
     sandbox_type: str | None = None,
     mcp_sandbox_url: str | None = None,
+    mcp_api_key: str | None = None,
 ) -> tuple[CompositeBackend, Any, str]:
     """Resolve a sandbox backend based on *sandbox_type*.
 
@@ -378,7 +380,7 @@ def resolve_sandbox_backend(
         return backend, sandbox, "state"
 
     if effective == "mcp":
-        result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+        result = _create_mcp_backend_checked(runtime, mcp_sandbox_url, mcp_api_key=mcp_api_key)
         if result is not None:
             return result[0], result[1], "mcp"
         backend, sandbox = _create_state_backend(runtime)
@@ -397,7 +399,7 @@ def resolve_sandbox_backend(
         return result[0], result[1], "daytona"
 
     if mcp_sandbox_url:
-        mcp_result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+        mcp_result = _create_mcp_backend_checked(runtime, mcp_sandbox_url, mcp_api_key=mcp_api_key)
         if mcp_result is not None:
             return mcp_result[0], mcp_result[1], "mcp"
 

--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -310,8 +310,46 @@ def _create_state_backend(
     return backend, None
 
 
+def _create_mcp_backend_checked(
+    runtime: ToolRuntime,
+    mcp_sandbox_url: str | None = None,
+) -> tuple[CompositeBackend, None] | None:
+    """Try to create an MCP-backed CompositeBackend.
+
+    Returns ``(backend, None)`` on success, or ``None`` if URL is missing.
+    """
+    if not mcp_sandbox_url or not mcp_sandbox_url.strip():
+        return None
+
+    try:
+        from src.agents.mcp_sandbox import McpSandboxBackend
+
+        mcp_backend = McpSandboxBackend(base_url=mcp_sandbox_url)
+        backend = CompositeBackend(default=mcp_backend, routes={})
+        return backend, None
+    except Exception as exc:
+        logger.error(f"Failed to create MCP sandbox backend: {exc}")
+        return None
+
+
+def is_mcp_sandbox_error(exc: Exception) -> bool:
+    """Check if an exception is an MCP sandbox communication error."""
+    try:
+        from src.agents.mcp_sandbox import McpSandboxError
+
+        if isinstance(exc, McpSandboxError):
+            return True
+    except ImportError:
+        pass
+    return isinstance(exc, (ConnectionError, TimeoutError, OSError))
+
+
+MCP_SANDBOX_UNREACHABLE = "mcp_sandbox_unreachable"
+
+
 _SANDBOX_FACTORIES: dict[str, Callable] = {
     "daytona": _create_daytona_backend_checked,
+    "mcp": _create_mcp_backend_checked,
     "state": _create_state_backend,
 }
 
@@ -319,17 +357,19 @@ _SANDBOX_FACTORIES: dict[str, Callable] = {
 def resolve_sandbox_backend(
     runtime: ToolRuntime,
     sandbox_type: str | None = None,
+    mcp_sandbox_url: str | None = None,
 ) -> tuple[CompositeBackend, Any, str]:
     """Resolve a sandbox backend based on *sandbox_type*.
 
     Dispatch rules:
-    * ``None`` / ``"auto"`` — try Daytona first, fall back to State.
-    * ``"state"`` — use StateBackend directly (never attempts Daytona).
-    * ``"daytona"`` — try Daytona, fall back to State if unavailable.
+    * ``None`` / ``"auto"`` — try Daytona, then MCP (if URL), then State.
+    * ``"state"`` — use StateBackend directly.
+    * ``"daytona"`` — try Daytona, fall back to State.
+    * ``"mcp"`` — try MCP (if URL), fall back to State.
     * Any unknown value — treated as ``"auto"``.
 
-    Returns ``(backend, daytona_sandbox_or_None, effective_type)``
-    where effective_type is ``"daytona"`` or ``"state"``.
+    Returns ``(backend, sandbox_or_None, effective_type)``
+    where effective_type is ``"daytona"``, ``"mcp"``, or ``"state"``.
     """
     effective = sandbox_type if sandbox_type in _SANDBOX_FACTORIES else None
 
@@ -337,10 +377,29 @@ def resolve_sandbox_backend(
         backend, sandbox = _create_state_backend(runtime)
         return backend, sandbox, "state"
 
-    # "daytona" or auto (None) — try Daytona first
+    if effective == "mcp":
+        result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+        if result is not None:
+            return result[0], result[1], "mcp"
+        backend, sandbox = _create_state_backend(runtime)
+        return backend, sandbox, "state"
+
+    if effective == "daytona":
+        result = _create_daytona_backend_checked(runtime)
+        if result is not None:
+            return result[0], result[1], "daytona"
+        backend, sandbox = _create_state_backend(runtime)
+        return backend, sandbox, "state"
+
+    # auto (None) — try Daytona, then MCP, then State
     result = _create_daytona_backend_checked(runtime)
     if result is not None:
         return result[0], result[1], "daytona"
+
+    if mcp_sandbox_url:
+        mcp_result = _create_mcp_backend_checked(runtime, mcp_sandbox_url)
+        if mcp_result is not None:
+            return mcp_result[0], mcp_result[1], "mcp"
 
     # Fallback: plain StateBackend (silent, no messages)
     backend, sandbox = _create_state_backend(runtime)

--- a/backend/src/agents/mcp_sandbox.py
+++ b/backend/src/agents/mcp_sandbox.py
@@ -161,7 +161,9 @@ class McpSandboxBackend(BaseSandbox):
             try:
                 resp = self.execute(f"base64 '{path}'")
                 if resp.exit_code == 0:
-                    decoded = base64.b64decode(resp.output.strip())
+                    # Strip the exit_code line from output before decoding
+                    clean = re.sub(r"\n?exit_code:\s*\d+\s*$", "", resp.output).strip()
+                    decoded = base64.b64decode(clean)
                     results.append(FileDownloadResponse(path=path, content=decoded, error=None))
                 else:
                     results.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))

--- a/backend/src/agents/mcp_sandbox.py
+++ b/backend/src/agents/mcp_sandbox.py
@@ -18,9 +18,14 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 
+from deepagents.backends.utils import create_file_data
+
 from src.utils.logger import logger
 
 EXIT_CODE_RE = re.compile(r"exit_code:\s*(\d+)")
+
+# SSE data line pattern: "data: {json}"
+_SSE_DATA_RE = re.compile(r"^data:\s*(.+)$", re.MULTILINE)
 
 
 class McpSandboxError(Exception):
@@ -58,6 +63,22 @@ class McpSandboxBackend(BaseSandbox):
         logger.debug(f"McpSandboxBackend created for {self._base_url}")
 
     # -- Private helpers --
+
+    @staticmethod
+    def _parse_sse_json(resp: httpx.Response) -> dict:
+        """Parse a JSON-RPC response that may be wrapped in SSE framing.
+
+        The MCP Streamable HTTP transport returns ``event: message\\ndata: {json}``
+        instead of raw JSON.  This helper handles both formats transparently.
+        """
+        text = resp.text.strip()
+        if text.startswith("{"):
+            return json.loads(text)
+        # SSE format — extract the first data line
+        match = _SSE_DATA_RE.search(text)
+        if match:
+            return json.loads(match.group(1))
+        raise ValueError(f"Unable to parse MCP response: {text[:200]}")
 
     def _build_headers(self, *, include_session: bool = False) -> dict[str, str]:
         """Build common request headers."""
@@ -137,7 +158,7 @@ class McpSandboxBackend(BaseSandbox):
             }
             tools_resp = self._client.post(url, json=tools_payload, headers=self._build_headers(include_session=True))
             tools_resp.raise_for_status()
-            tools_data = tools_resp.json()
+            tools_data = self._parse_sse_json(tools_resp)
             tool_list = tools_data.get("result", {}).get("tools", [])
             self._available_tools = {t["name"] for t in tool_list if isinstance(t, dict) and "name" in t}
             logger.debug(f"MCP tools discovered: {self._available_tools}")
@@ -162,7 +183,7 @@ class McpSandboxBackend(BaseSandbox):
             kwargs["timeout"] = timeout
         resp = self._client.post(url, **kwargs)
         resp.raise_for_status()
-        return resp.json()
+        return self._parse_sse_json(resp)
 
     def _get_text_and_meta(self, data: dict) -> tuple[str, int]:
         """Extract text content and exit code from a tool call response."""
@@ -227,7 +248,11 @@ class McpSandboxBackend(BaseSandbox):
             data = self._send_tool_call("write", {"path": file_path, "content": content})
             _, exit_code = self._get_text_and_meta(data)
             if exit_code == 0:
-                return WriteResult(error=None, path=file_path)
+                return WriteResult(
+                    error=None,
+                    path=file_path,
+                    files_update={file_path: create_file_data(content)},
+                )
             text = data.get("result", {}).get("content", [{}])[0].get("text", "write failed")
             return WriteResult(error=text, path=file_path)
         return super().write(file_path, content)
@@ -244,7 +269,16 @@ class McpSandboxBackend(BaseSandbox):
                 # Parse occurrence count from text like "Replaced 1 occurrence(s)"
                 occ_match = re.search(r"(\d+)\s+occurrence", text)
                 occurrences = int(occ_match.group(1)) if occ_match else 1
-                return EditResult(error=None, path=file_path, occurrences=occurrences)
+                # Read back the edited file to sync to frontend
+                files_update = None
+                try:
+                    content = self.read(file_path)
+                    # read() returns line-numbered text; strip line numbers
+                    lines = [line.split("\t", 1)[1] if "\t" in line else line for line in content.split("\n")]
+                    files_update = {file_path: create_file_data("\n".join(lines))}
+                except Exception:
+                    pass
+                return EditResult(error=None, path=file_path, occurrences=occurrences, files_update=files_update)
             error_msgs = {
                 1: "old_string not found in file",
                 2: "multiple matches found (use replace_all=true)",

--- a/backend/src/agents/mcp_sandbox.py
+++ b/backend/src/agents/mcp_sandbox.py
@@ -3,13 +3,24 @@
 from __future__ import annotations
 
 import base64
+import json
 import re
 
 import httpx
 from deepagents.backends.sandbox import BaseSandbox
-from deepagents.backends.protocol import ExecuteResponse, FileUploadResponse, FileDownloadResponse
+from deepagents.backends.protocol import (
+    EditResult,
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileInfo,
+    FileUploadResponse,
+    GrepMatch,
+    WriteResult,
+)
 
 from src.utils.logger import logger
+
+EXIT_CODE_RE = re.compile(r"exit_code:\s*(\d+)")
 
 
 class McpSandboxError(Exception):
@@ -17,6 +28,19 @@ class McpSandboxError(Exception):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+def _parse_json_lines(text: str) -> list[dict]:
+    """Parse newline-delimited JSON into a list of dicts."""
+    results: list[dict] = []
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                results.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return results
 
 
 class McpSandboxBackend(BaseSandbox):
@@ -29,6 +53,8 @@ class McpSandboxBackend(BaseSandbox):
         self._session_id: str | None = None
         self._request_id: int = 0
         self._initialized: bool = False
+        self._available_tools: set[str] = set()
+        self._sandbox_id: str | None = None
         logger.debug(f"McpSandboxBackend created for {self._base_url}")
 
     # -- Private helpers --
@@ -44,6 +70,19 @@ class McpSandboxBackend(BaseSandbox):
         if include_session and self._session_id:
             headers["Mcp-Session-Id"] = self._session_id
         return headers
+
+    def _has_tool(self, name: str) -> bool:
+        """Check if a tool is available on the connected exec_server."""
+        return name in self._available_tools
+
+    def _parse_meta(self, result: dict) -> tuple[int | None, str | None]:
+        """Extract exit_code and sandbox_id from _meta if present."""
+        meta = result.get("_meta", {})
+        exit_code = meta.get("exit_code")
+        sandbox_id = meta.get("sandbox_id")
+        if sandbox_id and isinstance(sandbox_id, str):
+            self._sandbox_id = sandbox_id
+        return exit_code, sandbox_id
 
     def _ensure_initialized(self) -> None:
         """Perform MCP initialize handshake if not already done."""
@@ -87,11 +126,26 @@ class McpSandboxBackend(BaseSandbox):
         except httpx.HTTPError as exc:
             logger.warning(f"notifications/initialized failed (non-fatal): {exc}")
 
-    # -- Abstract method implementations --
+        # Discover available tools
+        try:
+            self._request_id += 1
+            tools_payload = {
+                "jsonrpc": "2.0",
+                "id": self._request_id,
+                "method": "tools/list",
+                "params": {},
+            }
+            tools_resp = self._client.post(url, json=tools_payload, headers=self._build_headers(include_session=True))
+            tools_resp.raise_for_status()
+            tools_data = tools_resp.json()
+            tool_list = tools_data.get("result", {}).get("tools", [])
+            self._available_tools = {t["name"] for t in tool_list if isinstance(t, dict) and "name" in t}
+            logger.debug(f"MCP tools discovered: {self._available_tools}")
+        except Exception as exc:
+            logger.warning(f"tools/list failed (non-fatal, fallback mode): {exc}")
+            self._available_tools = set()
 
-    @property
-    def id(self) -> str:
-        return f"mcp-sandbox:{self._base_url}"
+    # -- Tool call helpers --
 
     def _send_tool_call(self, tool_name: str, arguments: dict, *, timeout: int | None = None) -> dict:
         """Send a tools/call JSON-RPC request and return the parsed result."""
@@ -110,10 +164,38 @@ class McpSandboxBackend(BaseSandbox):
         resp.raise_for_status()
         return resp.json()
 
+    def _get_text_and_meta(self, data: dict) -> tuple[str, int]:
+        """Extract text content and exit code from a tool call response."""
+        result = data.get("result", {})
+        text = result.get("content", [{}])[0].get("text", "")
+        meta_exit, _ = self._parse_meta(result)
+        if meta_exit is not None:
+            return text, meta_exit
+        # Fallback: parse exit code from text
+        match = EXIT_CODE_RE.search(text)
+        return text, int(match.group(1)) if match else 0
+
+    # -- Abstract method implementations --
+
+    @property
+    def id(self) -> str:
+        if self._sandbox_id:
+            return self._sandbox_id
+        return f"mcp-sandbox:{self._base_url}"
+
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         self._ensure_initialized()
+
+        # Determine which tool name to use
+        if self._has_tool("execute"):
+            tool_name = "execute"
+        elif self._has_tool("exec_command"):
+            tool_name = "exec_command"
+        else:
+            raise McpSandboxError("No execute tool available on exec_server")
+
         try:
-            data = self._send_tool_call("exec_command", {"cmd": command}, timeout=timeout)
+            data = self._send_tool_call(tool_name, {"cmd": command}, timeout=timeout)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 400:
                 logger.warning("MCP session error on execute, resetting and retrying")
@@ -122,54 +204,181 @@ class McpSandboxBackend(BaseSandbox):
                 self._request_id = 0
                 try:
                     self._ensure_initialized()
-                    data = self._send_tool_call("exec_command", {"cmd": command}, timeout=timeout)
+                    data = self._send_tool_call(tool_name, {"cmd": command}, timeout=timeout)
                 except (httpx.HTTPError, McpSandboxError) as retry_exc:
                     raise McpSandboxError(f"MCP execute failed after retry: {retry_exc}") from retry_exc
             else:
                 raise McpSandboxError(f"MCP execute failed: HTTP {exc.response.status_code}") from exc
 
-        text = data["result"]["content"][0]["text"]
-        match = re.search(r"exit_code:\s*(\d+)", text)
-        exit_code = int(match.group(1)) if match else 0
+        text, exit_code = self._get_text_and_meta(data)
         return ExecuteResponse(output=text, exit_code=exit_code, truncated=False)
 
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+        self._ensure_initialized()
+        if self._has_tool("read"):
+            data = self._send_tool_call("read", {"path": file_path, "offset": offset, "limit": limit})
+            text, _ = self._get_text_and_meta(data)
+            return text
+        return super().read(file_path, offset, limit)
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        self._ensure_initialized()
+        if self._has_tool("write"):
+            data = self._send_tool_call("write", {"path": file_path, "content": content})
+            _, exit_code = self._get_text_and_meta(data)
+            if exit_code == 0:
+                return WriteResult(error=None, path=file_path)
+            text = data.get("result", {}).get("content", [{}])[0].get("text", "write failed")
+            return WriteResult(error=text, path=file_path)
+        return super().write(file_path, content)
+
+    def edit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False) -> EditResult:
+        self._ensure_initialized()
+        if self._has_tool("edit"):
+            data = self._send_tool_call(
+                "edit",
+                {"path": file_path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all},
+            )
+            text, exit_code = self._get_text_and_meta(data)
+            if exit_code == 0:
+                # Parse occurrence count from text like "Replaced 1 occurrence(s)"
+                occ_match = re.search(r"(\d+)\s+occurrence", text)
+                occurrences = int(occ_match.group(1)) if occ_match else 1
+                return EditResult(error=None, path=file_path, occurrences=occurrences)
+            error_msgs = {
+                1: "old_string not found in file",
+                2: "multiple matches found (use replace_all=true)",
+                3: f"file not found: {file_path}",
+            }
+            return EditResult(error=error_msgs.get(exit_code, text), path=file_path, occurrences=None)
+        return super().edit(file_path, old_string, new_string, replace_all)
+
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None) -> list[GrepMatch] | str:
+        self._ensure_initialized()
+        if self._has_tool("grep"):
+            args: dict = {"pattern": pattern}
+            if path:
+                args["path"] = path
+            if glob:
+                args["glob"] = glob
+            data = self._send_tool_call("grep", args)
+            _, exit_code = self._get_text_and_meta(data)
+            if exit_code == 1:
+                return []
+            text = data.get("result", {}).get("content", [{}])[0].get("text", "")
+            parsed = _parse_json_lines(text)
+            return [GrepMatch(path=m["path"], line=m["line"], text=m["text"]) for m in parsed]
+        return super().grep_raw(pattern, path, glob)
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        self._ensure_initialized()
+        if self._has_tool("glob"):
+            data = self._send_tool_call("glob", {"pattern": pattern, "path": path})
+            text = data.get("result", {}).get("content", [{}])[0].get("text", "")
+            self._parse_meta(data.get("result", {}))
+            parsed = _parse_json_lines(text)
+            results: list[FileInfo] = []
+            for entry in parsed:
+                fi = FileInfo(path=entry["path"])
+                if "is_dir" in entry:
+                    fi["is_dir"] = entry["is_dir"]
+                if "size" in entry:
+                    fi["size"] = entry["size"]
+                if "mtime" in entry:
+                    fi["modified_at"] = entry["mtime"]
+                results.append(fi)
+            return results
+        return super().glob_info(pattern, path)
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        self._ensure_initialized()
+        if self._has_tool("ls"):
+            data = self._send_tool_call("ls", {"path": path})
+            _, exit_code = self._get_text_and_meta(data)
+            if exit_code == 1:
+                return []
+            text = data.get("result", {}).get("content", [{}])[0].get("text", "")
+            parsed = _parse_json_lines(text)
+            return [FileInfo(path=entry["path"], is_dir=entry.get("is_dir", False)) for entry in parsed]
+        return super().ls_info(path)
+
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        results: list[FileUploadResponse] = []
-        for path, content in files:
-            if not path.startswith("/"):
-                results.append(FileUploadResponse(path=path, error="invalid_path"))
+        self._ensure_initialized()
+        if self._has_tool("upload_file"):
+            results: list[FileUploadResponse] = []
+            for file_path, content in files:
+                if not file_path.startswith("/"):
+                    results.append(FileUploadResponse(path=file_path, error="invalid_path"))
+                    continue
+                try:
+                    encoded = base64.b64encode(content).decode()
+                    data = self._send_tool_call("upload_file", {"path": file_path, "content_base64": encoded})
+                    _, exit_code = self._get_text_and_meta(data)
+                    if exit_code == 0:
+                        results.append(FileUploadResponse(path=file_path, error=None))
+                    else:
+                        results.append(FileUploadResponse(path=file_path, error="permission_denied"))
+                except Exception as exc:
+                    logger.error(f"upload_files error for {file_path}: {exc}")
+                    results.append(FileUploadResponse(path=file_path, error="permission_denied"))
+            return results
+        # Fallback to shell-based base64 implementation
+        results = []
+        for file_path, content in files:
+            if not file_path.startswith("/"):
+                results.append(FileUploadResponse(path=file_path, error="invalid_path"))
                 continue
             try:
                 encoded = base64.b64encode(content).decode()
-                cmd = f"mkdir -p $(dirname '{path}') && echo '{encoded}' | base64 -d > '{path}'"
+                cmd = f"mkdir -p $(dirname '{file_path}') && echo '{encoded}' | base64 -d > '{file_path}'"
                 resp = self.execute(cmd)
                 if resp.exit_code == 0:
-                    results.append(FileUploadResponse(path=path, error=None))
+                    results.append(FileUploadResponse(path=file_path, error=None))
                 else:
-                    results.append(FileUploadResponse(path=path, error="permission_denied"))
+                    results.append(FileUploadResponse(path=file_path, error="permission_denied"))
             except Exception as exc:
-                logger.error(f"upload_files error for {path}: {exc}")
-                results.append(FileUploadResponse(path=path, error="permission_denied"))
+                logger.error(f"upload_files error for {file_path}: {exc}")
+                results.append(FileUploadResponse(path=file_path, error="permission_denied"))
         return results
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        results: list[FileDownloadResponse] = []
-        for path in paths:
-            if not path.startswith("/"):
-                results.append(FileDownloadResponse(path=path, content=None, error="invalid_path"))
+        self._ensure_initialized()
+        if self._has_tool("download_file"):
+            results: list[FileDownloadResponse] = []
+            for file_path in paths:
+                if not file_path.startswith("/"):
+                    results.append(FileDownloadResponse(path=file_path, content=None, error="invalid_path"))
+                    continue
+                try:
+                    data = self._send_tool_call("download_file", {"path": file_path})
+                    _, exit_code = self._get_text_and_meta(data)
+                    if exit_code == 0:
+                        text = data.get("result", {}).get("content", [{}])[0].get("text", "")
+                        decoded = base64.b64decode(text.strip())
+                        results.append(FileDownloadResponse(path=file_path, content=decoded, error=None))
+                    else:
+                        results.append(FileDownloadResponse(path=file_path, content=None, error="file_not_found"))
+                except Exception as exc:
+                    logger.error(f"download_files error for {file_path}: {exc}")
+                    results.append(FileDownloadResponse(path=file_path, content=None, error="file_not_found"))
+            return results
+        # Fallback to shell-based base64 implementation
+        results = []
+        for file_path in paths:
+            if not file_path.startswith("/"):
+                results.append(FileDownloadResponse(path=file_path, content=None, error="invalid_path"))
                 continue
             try:
-                resp = self.execute(f"base64 '{path}'")
+                resp = self.execute(f"base64 '{file_path}'")
                 if resp.exit_code == 0:
-                    # Strip the exit_code line from output before decoding
                     clean = re.sub(r"\n?exit_code:\s*\d+\s*$", "", resp.output).strip()
                     decoded = base64.b64decode(clean)
-                    results.append(FileDownloadResponse(path=path, content=decoded, error=None))
+                    results.append(FileDownloadResponse(path=file_path, content=decoded, error=None))
                 else:
-                    results.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                    results.append(FileDownloadResponse(path=file_path, content=None, error="file_not_found"))
             except Exception as exc:
-                logger.error(f"download_files error for {path}: {exc}")
-                results.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                logger.error(f"download_files error for {file_path}: {exc}")
+                results.append(FileDownloadResponse(path=file_path, content=None, error="file_not_found"))
         return results
 
     def health(self) -> bool:

--- a/backend/src/agents/mcp_sandbox.py
+++ b/backend/src/agents/mcp_sandbox.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import re
+
 import httpx
 from deepagents.backends.sandbox import BaseSandbox
 from deepagents.backends.protocol import ExecuteResponse, FileUploadResponse, FileDownloadResponse
@@ -28,17 +31,175 @@ class McpSandboxBackend(BaseSandbox):
         self._initialized: bool = False
         logger.debug(f"McpSandboxBackend created for {self._base_url}")
 
-    # -- Abstract method stubs (implemented in later stories) --
+    # -- Private helpers --
+
+    def _build_headers(self, *, include_session: bool = False) -> dict[str, str]:
+        """Build common request headers."""
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+        if include_session and self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        return headers
+
+    def _ensure_initialized(self) -> None:
+        """Perform MCP initialize handshake if not already done."""
+        if self._initialized:
+            return
+
+        url = f"{self._base_url}/mcp"
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "orchestra-mcp-sandbox", "version": "1.0.0"},
+            },
+        }
+
+        try:
+            resp = self._client.post(url, json=payload, headers=self._build_headers())
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.error(f"MCP initialize failed: HTTP {exc.response.status_code}")
+            raise McpSandboxError(f"MCP initialize failed: HTTP {exc.response.status_code}") from exc
+        except httpx.HTTPError as exc:
+            logger.error(f"MCP initialize failed: {exc}")
+            raise McpSandboxError(f"MCP initialize failed: {exc}") from exc
+
+        self._session_id = resp.headers.get("Mcp-Session-Id")
+        self._initialized = True
+        self._request_id = 1
+        logger.debug(f"MCP session initialized: {self._session_id}")
+
+        # Send notifications/initialized
+        notification = {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        }
+        try:
+            self._client.post(url, json=notification, headers=self._build_headers(include_session=True))
+        except httpx.HTTPError as exc:
+            logger.warning(f"notifications/initialized failed (non-fatal): {exc}")
+
+    # -- Abstract method implementations --
 
     @property
     def id(self) -> str:
         return f"mcp-sandbox:{self._base_url}"
 
+    def _send_tool_call(self, tool_name: str, arguments: dict, *, timeout: int | None = None) -> dict:
+        """Send a tools/call JSON-RPC request and return the parsed result."""
+        self._request_id += 1
+        url = f"{self._base_url}/mcp"
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._request_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+        kwargs: dict = {"json": payload, "headers": self._build_headers(include_session=True)}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        resp = self._client.post(url, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
-        raise NotImplementedError("US-004")
+        self._ensure_initialized()
+        try:
+            data = self._send_tool_call("exec_command", {"cmd": command}, timeout=timeout)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400:
+                logger.warning("MCP session error on execute, resetting and retrying")
+                self._session_id = None
+                self._initialized = False
+                self._request_id = 0
+                try:
+                    self._ensure_initialized()
+                    data = self._send_tool_call("exec_command", {"cmd": command}, timeout=timeout)
+                except (httpx.HTTPError, McpSandboxError) as retry_exc:
+                    raise McpSandboxError(f"MCP execute failed after retry: {retry_exc}") from retry_exc
+            else:
+                raise McpSandboxError(f"MCP execute failed: HTTP {exc.response.status_code}") from exc
+
+        text = data["result"]["content"][0]["text"]
+        match = re.search(r"exit_code:\s*(\d+)", text)
+        exit_code = int(match.group(1)) if match else 0
+        return ExecuteResponse(output=text, exit_code=exit_code, truncated=False)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
-        raise NotImplementedError("US-006")
+        results: list[FileUploadResponse] = []
+        for path, content in files:
+            if not path.startswith("/"):
+                results.append(FileUploadResponse(path=path, error="invalid_path"))
+                continue
+            try:
+                encoded = base64.b64encode(content).decode()
+                cmd = f"mkdir -p $(dirname '{path}') && echo '{encoded}' | base64 -d > '{path}'"
+                resp = self.execute(cmd)
+                if resp.exit_code == 0:
+                    results.append(FileUploadResponse(path=path, error=None))
+                else:
+                    results.append(FileUploadResponse(path=path, error="permission_denied"))
+            except Exception as exc:
+                logger.error(f"upload_files error for {path}: {exc}")
+                results.append(FileUploadResponse(path=path, error="permission_denied"))
+        return results
 
     def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
-        raise NotImplementedError("US-007")
+        results: list[FileDownloadResponse] = []
+        for path in paths:
+            if not path.startswith("/"):
+                results.append(FileDownloadResponse(path=path, content=None, error="invalid_path"))
+                continue
+            try:
+                resp = self.execute(f"base64 '{path}'")
+                if resp.exit_code == 0:
+                    decoded = base64.b64decode(resp.output.strip())
+                    results.append(FileDownloadResponse(path=path, content=decoded, error=None))
+                else:
+                    results.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+            except Exception as exc:
+                logger.error(f"download_files error for {path}: {exc}")
+                results.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+        return results
+
+    def health(self) -> bool:
+        """Check if exec_server is reachable."""
+        try:
+            headers: dict[str, str] = {}
+            if self._api_key:
+                headers["x-api-key"] = self._api_key
+            resp = self._client.get(f"{self._base_url}/health", headers=headers, timeout=5.0)
+            return resp.status_code == 200 and resp.json().get("status") == "ok"
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        """Close the HTTP client and MCP session."""
+        if self._session_id:
+            try:
+                self._client.delete(
+                    f"{self._base_url}/mcp",
+                    headers=self._build_headers(include_session=True),
+                )
+            except Exception as exc:
+                logger.warning(f"MCP session cleanup failed (non-fatal): {exc}")
+        try:
+            self._client.close()
+        except Exception:
+            pass
+        self._session_id = None
+        self._initialized = False
+
+    def __enter__(self) -> McpSandboxBackend:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/agents/mcp_sandbox.py
+++ b/backend/src/agents/mcp_sandbox.py
@@ -1,0 +1,44 @@
+"""MCP Sandbox backend — communicates with exec_server via MCP JSON-RPC 2.0."""
+
+from __future__ import annotations
+
+import httpx
+from deepagents.backends.sandbox import BaseSandbox
+from deepagents.backends.protocol import ExecuteResponse, FileUploadResponse, FileDownloadResponse
+
+from src.utils.logger import logger
+
+
+class McpSandboxError(Exception):
+    """Raised when MCP sandbox communication fails after retries."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class McpSandboxBackend(BaseSandbox):
+    """Sandbox backend that delegates execution to an exec_server via MCP protocol."""
+
+    def __init__(self, *, base_url: str, api_key: str | None = None) -> None:
+        self._base_url: str = base_url.rstrip("/")
+        self._api_key: str | None = api_key
+        self._client: httpx.Client = httpx.Client(timeout=httpx.Timeout(120.0))
+        self._session_id: str | None = None
+        self._request_id: int = 0
+        self._initialized: bool = False
+        logger.debug(f"McpSandboxBackend created for {self._base_url}")
+
+    # -- Abstract method stubs (implemented in later stories) --
+
+    @property
+    def id(self) -> str:
+        return f"mcp-sandbox:{self._base_url}"
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        raise NotImplementedError("US-004")
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        raise NotImplementedError("US-006")
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        raise NotImplementedError("US-007")

--- a/backend/src/constants/__init__.py
+++ b/backend/src/constants/__init__.py
@@ -92,6 +92,7 @@ class UserTokenKey(Enum):
     ARCADE_API_KEY = "ARCADE_API_KEY"
     LANGCONNECT_SERVER_URL = "LANGCONNECT_SERVER_URL"
     DAYTONA_API_KEY = "DAYTONA_API_KEY"
+    MCP_SANDBOX_API_KEY = "MCP_SANDBOX_API_KEY"
 
     @classmethod
     def values(cls) -> list[str]:
@@ -115,6 +116,7 @@ TAVILY_API_KEY = os.getenv(UserTokenKey.TAVILY_API_KEY.value)
 EXA_API_KEY = os.getenv(UserTokenKey.EXA_API_KEY.value)
 LANGCONNECT_SERVER_URL = os.getenv(UserTokenKey.LANGCONNECT_SERVER_URL.value)
 DAYTONA_API_KEY = os.getenv(UserTokenKey.DAYTONA_API_KEY.value)
+MCP_SANDBOX_API_KEY = os.getenv(UserTokenKey.MCP_SANDBOX_API_KEY.value)
 
 # Storage
 MINIO_HOST = os.getenv("MINIO_HOST")

--- a/backend/src/controllers/llm.py
+++ b/backend/src/controllers/llm.py
@@ -68,15 +68,15 @@ class LLMController:
         )
         logger.info(f"checkpoint: {ujson.dumps(configurable)}")
 
-    async def _resolve_user_settings(self, model: str) -> tuple[str, str | None, str | None, str | None]:
-        """Resolve user default model, API key, sandbox preference, and MCP URL.
+    async def _resolve_user_settings(self, model: str) -> tuple[str, str | None, str | None, str | None, str | None]:
+        """Resolve user default model, API key, sandbox preference, MCP URL, and MCP API key.
 
-        Returns (model, api_key, default_sandbox, mcp_sandbox_url).
+        Returns (model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key).
         """
         if not self.user_id:
             if not model:
                 model = DEFAULT_CHAT_MODEL
-            return model, None, None, None
+            return model, None, None, None, None
 
         settings_repo = UserSettingsRepo(self.user_id, self.store)
         settings = await settings_repo._get_or_create()
@@ -89,12 +89,13 @@ class LLMController:
 
         default_sandbox = getattr(settings, "default_sandbox", None)
         mcp_sandbox_url = getattr(settings, "default_mcp_sandbox_url", None)
+        mcp_api_key = user_keys.get("MCP_SANDBOX_API_KEY") if user_keys else None
 
         if not model:
-            return model, None, default_sandbox, mcp_sandbox_url
+            return model, None, default_sandbox, mcp_sandbox_url, mcp_api_key
 
         api_key = resolve_api_key(model, user_keys if user_keys else None)
-        return model, api_key, default_sandbox, mcp_sandbox_url
+        return model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key
 
     async def llm_invoke(self, params: LLMRequest):
         """Invoke the agent synchronously and return the final response.
@@ -111,8 +112,10 @@ class LLMController:
             config = init_config(params, user_id=self.user_id)
             params = await self.service_context.llm_service.assistant(params)
 
-            # Resolve user-configured API key, default model, sandbox, and MCP URL
-            params.model, api_key, default_sandbox, mcp_sandbox_url = await self._resolve_user_settings(params.model)
+            # Resolve user-configured API key, default model, sandbox, MCP URL, and MCP API key
+            params.model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key = await self._resolve_user_settings(
+                params.model
+            )
 
             # Load user memories into files_map for MemoryMiddleware
             memory_files, _memory_sources = await prepare_memory_files(
@@ -134,7 +137,7 @@ class LLMController:
             async with get_checkpoint_db() as checkpointer:
                 runtime = self._init_runtime(params)
                 backend, _sandbox, effective_type = resolve_sandbox_backend(
-                    runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url
+                    runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url, mcp_api_key=mcp_api_key
                 )
                 agent: Orchestra = await construct_agent(
                     instructions=params.instructions,
@@ -235,8 +238,10 @@ class LLMController:
     async def llm_stream(self, params: LLMRequest):
         assistant = await self.service_context.llm_service.assistant(params)
 
-        # Resolve user-configured API key, default model, sandbox, and MCP URL
-        assistant.model, api_key, default_sandbox, mcp_sandbox_url = await self._resolve_user_settings(assistant.model)
+        # Resolve user-configured API key, default model, sandbox, MCP URL, and MCP API key
+        assistant.model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key = await self._resolve_user_settings(
+            assistant.model
+        )
 
         return stream_generator(
             input=assistant.input,
@@ -250,6 +255,7 @@ class LLMController:
             api_key=api_key,
             sandbox_type=default_sandbox,
             mcp_sandbox_url=mcp_sandbox_url,
+            mcp_api_key=mcp_api_key,
             stream_mode=assistant.resolved_stream_mode,
         )
 

--- a/backend/src/controllers/llm.py
+++ b/backend/src/controllers/llm.py
@@ -12,6 +12,7 @@ from src.agents import (
     construct_agent,
     init_config,
     is_daytona_error,
+    is_mcp_sandbox_error,
     prepare_memory_files,
     resolve_sandbox_backend,
     _create_state_backend,
@@ -67,40 +68,33 @@ class LLMController:
         )
         logger.info(f"checkpoint: {ujson.dumps(configurable)}")
 
-    async def _resolve_user_settings(self, model: str) -> tuple[str, str | None, str | None]:
-        """Resolve user default model, API key, and sandbox preference.
+    async def _resolve_user_settings(self, model: str) -> tuple[str, str | None, str | None, str | None]:
+        """Resolve user default model, API key, sandbox preference, and MCP URL.
 
-        Returns (model, api_key, default_sandbox) where model may be overridden
-        by user default, api_key is the resolved key for the provider, and
-        default_sandbox is the user's sandbox backend preference.
+        Returns (model, api_key, default_sandbox, mcp_sandbox_url).
         """
         if not self.user_id:
-            # Unauthenticated users: fall back to system default if no model
             if not model:
                 model = DEFAULT_CHAT_MODEL
-            return model, None, None
+            return model, None, None, None
 
         settings_repo = UserSettingsRepo(self.user_id, self.store)
         settings = await settings_repo._get_or_create()
         user_keys = settings_repo._decrypt_keys(settings)
 
-        # Apply user default model when request has no explicit model
         if not model and settings.default_model:
             model = settings.default_model
-
-        # Final fallback to system default
         if not model:
             model = DEFAULT_CHAT_MODEL
 
-        # Read sandbox preference from settings
         default_sandbox = getattr(settings, "default_sandbox", None)
+        mcp_sandbox_url = getattr(settings, "default_mcp_sandbox_url", None)
 
-        # Guard against None model before resolving API key
         if not model:
-            return model, None, default_sandbox
+            return model, None, default_sandbox, mcp_sandbox_url
 
         api_key = resolve_api_key(model, user_keys if user_keys else None)
-        return model, api_key, default_sandbox
+        return model, api_key, default_sandbox, mcp_sandbox_url
 
     async def llm_invoke(self, params: LLMRequest):
         """Invoke the agent synchronously and return the final response.
@@ -117,8 +111,8 @@ class LLMController:
             config = init_config(params, user_id=self.user_id)
             params = await self.service_context.llm_service.assistant(params)
 
-            # Resolve user-configured API key, default model, and sandbox
-            params.model, api_key, default_sandbox = await self._resolve_user_settings(params.model)
+            # Resolve user-configured API key, default model, sandbox, and MCP URL
+            params.model, api_key, default_sandbox, mcp_sandbox_url = await self._resolve_user_settings(params.model)
 
             # Load user memories into files_map for MemoryMiddleware
             memory_files, _memory_sources = await prepare_memory_files(
@@ -139,7 +133,9 @@ class LLMController:
 
             async with get_checkpoint_db() as checkpointer:
                 runtime = self._init_runtime(params)
-                backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
+                backend, _sandbox, effective_type = resolve_sandbox_backend(
+                    runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url
+                )
                 agent: Orchestra = await construct_agent(
                     instructions=params.instructions,
                     system_prompt=params.system_prompt,
@@ -161,13 +157,11 @@ class LLMController:
         except Exception as e:
             if is_daytona_error(e):
                 if default_sandbox == "daytona":
-                    # Explicit daytona mode: surface the detailed error
                     logger.error(f"Daytona sandbox error (daytona mode): {e}")
                     if agent and config:
                         await self._update_store(agent, config)
                     raise
                 elif default_sandbox in (None, "auto") and effective_type == "daytona":
-                    # Auto mode: fallback to local StateBackend and retry
                     logger.warning(f"Daytona sandbox error in auto mode, falling back to local: {e}")
                     try:
                         fallback_backend, _ = _create_state_backend(runtime)
@@ -195,6 +189,40 @@ class LLMController:
                             await self._update_store(agent, config)
                         raise fallback_err
 
+            if is_mcp_sandbox_error(e):
+                if default_sandbox == "mcp":
+                    logger.error(f"MCP sandbox error (mcp mode): {e}")
+                    if agent and config:
+                        await self._update_store(agent, config)
+                    raise
+                elif default_sandbox in (None, "auto") and effective_type == "mcp":
+                    logger.warning(f"MCP sandbox error in auto mode, falling back to local: {e}")
+                    try:
+                        fallback_backend, _ = _create_state_backend(runtime)
+                        agent = await construct_agent(
+                            instructions=params.instructions,
+                            system_prompt=params.system_prompt,
+                            model=params.model,
+                            tools=params.tools,
+                            subagents=params.subagents,
+                            checkpointer=checkpointer,
+                            backend=fallback_backend,
+                            service_context=self.service_context,
+                            api_key=api_key,
+                            memory=memory_sources,
+                        )
+                        response = await agent.invoke(
+                            params.input,
+                            config=config,
+                            context=self._init_context(params),
+                        )
+                        return response
+                    except Exception as fallback_err:
+                        logger.exception(f"MCP fallback also failed in llm_invoke: {fallback_err}")
+                        if agent and config:
+                            await self._update_store(agent, config)
+                        raise fallback_err
+
             logger.exception(f"Error in llm_invoke: {e}")
             if agent and config:
                 await self._update_store(agent, config)
@@ -207,8 +235,8 @@ class LLMController:
     async def llm_stream(self, params: LLMRequest):
         assistant = await self.service_context.llm_service.assistant(params)
 
-        # Resolve user-configured API key, default model, and sandbox
-        assistant.model, api_key, default_sandbox = await self._resolve_user_settings(assistant.model)
+        # Resolve user-configured API key, default model, sandbox, and MCP URL
+        assistant.model, api_key, default_sandbox, mcp_sandbox_url = await self._resolve_user_settings(assistant.model)
 
         return stream_generator(
             input=assistant.input,
@@ -221,6 +249,7 @@ class LLMController:
             instructions=assistant.instructions,
             api_key=api_key,
             sandbox_type=default_sandbox,
+            mcp_sandbox_url=mcp_sandbox_url,
             stream_mode=assistant.resolved_stream_mode,
         )
 

--- a/backend/src/repos/user_settings_repo.py
+++ b/backend/src/repos/user_settings_repo.py
@@ -197,6 +197,7 @@ class UserSettingsRepo(BaseRepo):
         "deleted_files": "default_deleted_files",
         "onboarding_completed": "onboarding_completed",
         "timezone": "default_timezone",
+        "mcp_sandbox_url": "default_mcp_sandbox_url",
     }
 
     async def patch_defaults(self, data: dict) -> UserSettings:

--- a/backend/src/routes/v0/settings.py
+++ b/backend/src/routes/v0/settings.py
@@ -35,6 +35,7 @@ def _build_response(settings: UserSettings, statuses: list[ProviderKeyStatus]) -
             deleted_files=settings.default_deleted_files,
             onboarding_completed=settings.onboarding_completed,
             timezone=settings.default_timezone,
+            mcp_sandbox_url=settings.default_mcp_sandbox_url,
         ),
         provider_keys=statuses,
     )

--- a/backend/src/routes/v0/settings.py
+++ b/backend/src/routes/v0/settings.py
@@ -1,3 +1,4 @@
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from langgraph.store.base import BaseStore
 
@@ -95,3 +96,34 @@ async def delete_provider_key(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     settings, statuses = await repo.get_settings()
     return _build_response(settings, statuses)
+
+
+@router.get("/settings/mcp-sandbox-health")
+async def mcp_sandbox_health(
+    user: User = Depends(verify_credentials),
+    store: BaseStore = Depends(get_store),
+):
+    """Proxy health check to the user's configured MCP sandbox URL.
+
+    The frontend can't reach the sandbox directly (CORS / Docker networking),
+    so the backend proxies the request.
+    """
+    repo = _get_repo(user, store)
+    settings = await repo._get_or_create()
+    mcp_url = getattr(settings, "default_mcp_sandbox_url", None)
+    if not mcp_url:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No MCP sandbox URL configured")
+
+    # Derive health URL: strip trailing /mcp, append /health
+    base = mcp_url.rstrip("/")
+    if base.endswith("/mcp"):
+        base = base[: -len("/mcp")]
+    health_url = f"{base}/health"
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(health_url)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="MCP sandbox unreachable")

--- a/backend/src/schemas/entities/settings.py
+++ b/backend/src/schemas/entities/settings.py
@@ -12,6 +12,7 @@ class SandboxType(str, Enum):
 
     DAYTONA = "daytona"
     STATE = "state"
+    MCP = "mcp"
 
 
 class ProviderKeyStatus(BaseModel):
@@ -59,6 +60,7 @@ class UserSettings(BaseEntity):
         default=None, description="Whether the user has completed the onboarding tour"
     )
     default_timezone: Optional[str] = Field(default=None, description="User's preferred IANA timezone identifier")
+    default_mcp_sandbox_url: Optional[str] = Field(default=None, description="User MCP sandbox server URL")
 
 
 class DefaultsResponse(BaseModel):
@@ -75,6 +77,7 @@ class DefaultsResponse(BaseModel):
     deleted_files: Optional[list[str]] = None
     onboarding_completed: Optional[bool] = None
     timezone: Optional[str] = None
+    mcp_sandbox_url: Optional[str] = None
 
 
 class UserSettingsResponse(BaseModel):
@@ -106,6 +109,7 @@ class PatchDefaultsRequest(BaseModel):
         default=None, description="Whether the user has completed the onboarding tour"
     )
     timezone: Optional[str] = Field(default=None, description="IANA timezone identifier, or null to clear")
+    mcp_sandbox_url: Optional[str] = Field(default=None, description="MCP sandbox server URL, or null to clear")
 
 
 class UpsertProviderKeyRequest(BaseModel):

--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -20,6 +20,8 @@ from src.agents import (
     resolve_sandbox_backend,
     prepare_memory_files,
     is_daytona_error,
+    is_mcp_sandbox_error,
+    MCP_SANDBOX_UNREACHABLE,
     _create_state_backend,
 )
 from src.services.db import get_checkpoint_db
@@ -329,6 +331,7 @@ async def stream_generator(
     instructions: str = None,
     api_key: str | None = None,
     sandbox_type: str | None = None,
+    mcp_sandbox_url: str | None = None,
     stream_mode: list[str] | None = None,
 ):
     """Stream agent responses as Server-Sent Events.
@@ -373,7 +376,9 @@ async def stream_generator(
                 stream_writer=lambda _: None,
                 config=config,
             )
-            backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=sandbox_type)
+            backend, _sandbox, effective_type = resolve_sandbox_backend(
+                runtime, sandbox_type=sandbox_type, mcp_sandbox_url=mcp_sandbox_url
+            )
             agent = await construct_agent(
                 instructions=instructions,
                 system_prompt=system_prompt,
@@ -438,6 +443,39 @@ async def stream_generator(
                                 yield sse_line
                     except Exception as fallback_err:
                         logger.exception("Fallback also failed in stream_generator: %s", fallback_err)
+                        error_msg = ujson.dumps(("error", str(fallback_err)))
+                        yield f"data: {error_msg}\n\n"
+                else:
+                    logger.exception("Error in stream_generator: %s", e)
+                    error_msg = ujson.dumps(("error", str(e)))
+                    yield f"data: {error_msg}\n\n"
+            elif is_mcp_sandbox_error(e):
+                if sandbox_type == "mcp":
+                    logger.error(f"MCP sandbox error (mcp mode): {e}")
+                    error_msg = ujson.dumps((MCP_SANDBOX_UNREACHABLE, f"MCP sandbox unreachable: {e}"))
+                    yield f"data: {error_msg}\n\n"
+                elif sandbox_type in (None, "auto") and effective_type == "mcp":
+                    logger.warning(f"MCP sandbox error in auto mode, falling back to local: {e}")
+                    try:
+                        fallback_backend, _ = _create_state_backend(runtime)
+                        agent = await construct_agent(
+                            instructions=instructions,
+                            system_prompt=system_prompt,
+                            model=model,
+                            tools=tools,
+                            subagents=subagents,
+                            checkpointer=checkpointer,
+                            backend=fallback_backend,
+                            service_context=service_context,
+                            api_key=api_key,
+                            memory=memory_sources,
+                        )
+                        async for chunk in agent.astream(input, **astream_kwargs):
+                            sse_line = _process_and_format_chunk(chunk, agent.model, state)
+                            if sse_line:
+                                yield sse_line
+                    except Exception as fallback_err:
+                        logger.exception("MCP fallback also failed in stream_generator: %s", fallback_err)
                         error_msg = ujson.dumps(("error", str(fallback_err)))
                         yield f"data: {error_msg}\n\n"
                 else:

--- a/backend/src/utils/stream.py
+++ b/backend/src/utils/stream.py
@@ -332,6 +332,7 @@ async def stream_generator(
     api_key: str | None = None,
     sandbox_type: str | None = None,
     mcp_sandbox_url: str | None = None,
+    mcp_api_key: str | None = None,
     stream_mode: list[str] | None = None,
 ):
     """Stream agent responses as Server-Sent Events.
@@ -377,7 +378,7 @@ async def stream_generator(
                 config=config,
             )
             backend, _sandbox, effective_type = resolve_sandbox_backend(
-                runtime, sandbox_type=sandbox_type, mcp_sandbox_url=mcp_sandbox_url
+                runtime, sandbox_type=sandbox_type, mcp_sandbox_url=mcp_sandbox_url, mcp_api_key=mcp_api_key
             )
             agent = await construct_agent(
                 instructions=instructions,

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -420,12 +420,14 @@ async def _execute_agent_stream(
 
     api_key = None
     default_sandbox = None
+    mcp_api_key = None
     if user_id:
         settings_repo = UserSettingsRepo(user_id, service_context.store)
         settings = await settings_repo._get_or_create()
         user_keys = settings_repo._decrypt_keys(settings)
         default_sandbox = getattr(settings, "default_sandbox", None)
         mcp_sandbox_url = getattr(settings, "default_mcp_sandbox_url", None)
+        mcp_api_key = user_keys.get("MCP_SANDBOX_API_KEY") if user_keys else None
         if not params.model and settings.default_model:
             params.model = settings.default_model
         if not params.model:
@@ -457,7 +459,7 @@ async def _execute_agent_stream(
         config=config,
     )
     backend, _sandbox, effective_type = resolve_sandbox_backend(
-        runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url
+        runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url, mcp_api_key=mcp_api_key
     )
 
     agent = await construct_agent(

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -399,6 +399,8 @@ async def _execute_agent_stream(
         resolve_sandbox_backend,
         prepare_memory_files,
         is_daytona_error,
+        is_mcp_sandbox_error,
+        MCP_SANDBOX_UNREACHABLE,
         _create_state_backend,
     )
     from src.utils.format import get_time
@@ -423,6 +425,7 @@ async def _execute_agent_stream(
         settings = await settings_repo._get_or_create()
         user_keys = settings_repo._decrypt_keys(settings)
         default_sandbox = getattr(settings, "default_sandbox", None)
+        mcp_sandbox_url = getattr(settings, "default_mcp_sandbox_url", None)
         if not params.model and settings.default_model:
             params.model = settings.default_model
         if not params.model:
@@ -430,6 +433,7 @@ async def _execute_agent_stream(
         if params.model:
             api_key = resolve_api_key(params.model, user_keys if user_keys else None)
     else:
+        mcp_sandbox_url = None
         if not params.model:
             params.model = DEFAULT_CHAT_MODEL
 
@@ -452,7 +456,9 @@ async def _execute_agent_stream(
         stream_writer=lambda _: None,
         config=config,
     )
-    backend, _sandbox, effective_type = resolve_sandbox_backend(runtime, sandbox_type=default_sandbox)
+    backend, _sandbox, effective_type = resolve_sandbox_backend(
+        runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url
+    )
 
     agent = await construct_agent(
         instructions=params.instructions,
@@ -542,6 +548,61 @@ async def _execute_agent_stream(
                 return {"status": "error", "stream_key": stream_key}
             elif default_sandbox in (None, "auto") and effective_type == "daytona":
                 logger.warning(f"Daytona sandbox error in auto mode worker, falling back to local: {e}")
+                fallback_backend, _ = _create_state_backend(runtime)
+                agent = await construct_agent(
+                    instructions=params.instructions,
+                    system_prompt=params.system_prompt,
+                    tools=params.tools,
+                    model=params.model,
+                    subagents=params.subagents,
+                    checkpointer=checkpointer,
+                    service_context=service_context,
+                    backend=fallback_backend,
+                    memory=memory_sources,
+                    api_key=api_key,
+                )
+                await _stream_chunks_to_redis(
+                    agent=agent,
+                    input=params.input,
+                    stream_mode=stream_mode,
+                    config=config,
+                    ctx_schema=ctx_schema,
+                    files_map=files_map,
+                    todos_list=todos_list,
+                    redis_client=redis_client,
+                    stream_key=stream_key,
+                    service_context=service_context,
+                    thread_id=thread_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    started_at=started_at,
+                )
+            else:
+                raise
+        elif is_mcp_sandbox_error(e):
+            if default_sandbox == "mcp":
+                logger.error(f"MCP sandbox error (mcp mode) in worker: {e}")
+                error_msg = ujson.dumps((MCP_SANDBOX_UNREACHABLE, f"MCP sandbox unreachable: {e}"))
+                await redis_client.xadd(stream_key, {"data": error_msg})
+                await redis_client.xadd(stream_key, {"done": "true"})
+                await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
+                await _update_thread_stream_state(
+                    service_context=service_context,
+                    thread_id=thread_id,
+                    config=config,
+                    files_map=files_map,
+                    todos_list=todos_list,
+                    metadata=_build_stream_metadata(
+                        run_id=run_id,
+                        status="error",
+                        started_at=started_at,
+                        finished_at=get_time(),
+                        error=f"MCP sandbox unreachable: {e}",
+                    ),
+                )
+                return {"status": "error", "stream_key": stream_key}
+            elif default_sandbox in (None, "auto") and effective_type == "mcp":
+                logger.warning(f"MCP sandbox error in auto mode worker, falling back to local: {e}")
                 fallback_backend, _ = _create_state_backend(runtime)
                 agent = await construct_agent(
                     instructions=params.instructions,

--- a/backend/tests/unit/agents/test_mcp_sandbox.py
+++ b/backend/tests/unit/agents/test_mcp_sandbox.py
@@ -19,9 +19,13 @@ from src.agents.mcp_sandbox import McpSandboxBackend, McpSandboxError, _parse_js
 
 def _mock_response(status_code: int = 200, json_data: dict | None = None, headers: dict | None = None):
     """Create a mock httpx.Response."""
+    import json
+
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
-    resp.json.return_value = json_data or {}
+    data = json_data or {}
+    resp.json.return_value = data
+    resp.text = json.dumps(data)
     resp.headers = headers or {}
     resp.raise_for_status = MagicMock()
     if status_code >= 400:

--- a/backend/tests/unit/agents/test_mcp_sandbox.py
+++ b/backend/tests/unit/agents/test_mcp_sandbox.py
@@ -1,4 +1,4 @@
-"""Unit tests for McpSandboxBackend (US-010 through US-014)."""
+"""Unit tests for McpSandboxBackend (US-010 through US-014, US-046 through US-059)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import httpx
 import pytest
 from deepagents.backends.protocol import ExecuteResponse
 
-from src.agents.mcp_sandbox import McpSandboxBackend, McpSandboxError
+from src.agents.mcp_sandbox import McpSandboxBackend, McpSandboxError, _parse_json_lines
 
 
 # ---------------------------------------------------------------------------
@@ -42,10 +42,34 @@ def _init_response(session_id: str = "test-session-123"):
     )
 
 
-def _tool_response(text: str = "hello world\nexit_code: 0"):
-    """Standard successful tool call response."""
+def _tools_list_response(tools: list[str] | None = None):
+    """Standard tools/list response."""
+    if tools is None:
+        tools = [
+            "execute",
+            "exec_command",
+            "read",
+            "write",
+            "edit",
+            "grep",
+            "glob",
+            "ls",
+            "upload_file",
+            "download_file",
+        ]
+    tool_list = [{"name": t} for t in tools]
     return _mock_response(
-        json_data={"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": text}]}},
+        json_data={"jsonrpc": "2.0", "id": 2, "result": {"tools": tool_list}},
+    )
+
+
+def _tool_response(text: str = "hello world\nexit_code: 0", meta: dict | None = None):
+    """Standard successful tool call response."""
+    result: dict = {"content": [{"type": "text", "text": text}]}
+    if meta is not None:
+        result["_meta"] = meta
+    return _mock_response(
+        json_data={"jsonrpc": "2.0", "id": 1, "result": result},
     )
 
 
@@ -54,6 +78,36 @@ def _make_backend(base_url: str = "http://localhost:3005", api_key: str | None =
     backend = McpSandboxBackend(base_url=base_url, api_key=api_key)
     backend._client = MagicMock(spec=httpx.Client)
     return backend
+
+
+def _make_initialized_backend(
+    tools: list[str] | None = None,
+    **kwargs,
+) -> McpSandboxBackend:
+    """Create a backend already initialized with tools."""
+    backend = _make_backend(**kwargs)
+    backend._initialized = True
+    backend._session_id = "sess"
+    if tools is None:
+        tools = [
+            "execute",
+            "exec_command",
+            "read",
+            "write",
+            "edit",
+            "grep",
+            "glob",
+            "ls",
+            "upload_file",
+            "download_file",
+        ]
+    backend._available_tools = set(tools)
+    return backend
+
+
+def _init_side_effects(tools: list[str] | None = None):
+    """Return side_effect list for init + notification + tools/list."""
+    return [_init_response(), _mock_response(), _tools_list_response(tools)]
 
 
 # ===========================================================================
@@ -87,6 +141,7 @@ class TestConstructorAndId:
         assert b._initialized is False
         assert b._session_id is None
         assert b._request_id == 0
+        assert b._available_tools == set()
 
 
 # ===========================================================================
@@ -97,7 +152,7 @@ class TestConstructorAndId:
 class TestEnsureInitialized:
     def test_sends_initialize_payload(self):
         backend = _make_backend()
-        backend._client.post.return_value = _init_response()
+        backend._client.post.side_effect = _init_side_effects()
 
         backend._ensure_initialized()
 
@@ -109,7 +164,11 @@ class TestEnsureInitialized:
 
     def test_extracts_session_id(self):
         backend = _make_backend()
-        backend._client.post.return_value = _init_response("my-session-456")
+        backend._client.post.side_effect = [
+            _init_response("my-session-456"),
+            _mock_response(),
+            _tools_list_response(),
+        ]
 
         backend._ensure_initialized()
 
@@ -117,12 +176,13 @@ class TestEnsureInitialized:
 
     def test_sets_initialized_true(self):
         backend = _make_backend()
-        backend._client.post.return_value = _init_response()
+        backend._client.post.side_effect = _init_side_effects()
 
         backend._ensure_initialized()
 
         assert backend._initialized is True
-        assert backend._request_id == 1
+        # request_id incremented: 0 (init) -> 1 (after init) -> 2 (tools/list)
+        assert backend._request_id == 2
 
     def test_no_op_when_already_initialized(self):
         backend = _make_backend()
@@ -134,12 +194,12 @@ class TestEnsureInitialized:
 
     def test_sends_notifications_initialized(self):
         backend = _make_backend()
-        backend._client.post.return_value = _init_response()
+        backend._client.post.side_effect = _init_side_effects()
 
         backend._ensure_initialized()
 
-        # Second POST call is the notification
-        assert backend._client.post.call_count == 2
+        # 3 POST calls: init, notification, tools/list
+        assert backend._client.post.call_count == 3
         second_call = backend._client.post.call_args_list[1]
         payload = second_call[1]["json"]
         assert payload["method"] == "notifications/initialized"
@@ -153,13 +213,34 @@ class TestEnsureInitialized:
 
     def test_includes_api_key_header(self):
         backend = _make_backend(api_key="my-key")
-        backend._client.post.return_value = _init_response()
+        backend._client.post.side_effect = _init_side_effects()
 
         backend._ensure_initialized()
 
         first_call = backend._client.post.call_args_list[0]
         headers = first_call[1]["headers"]
         assert headers["x-api-key"] == "my-key"
+
+    def test_discovers_tools(self):
+        backend = _make_backend()
+        backend._client.post.side_effect = _init_side_effects(["execute", "read", "write"])
+
+        backend._ensure_initialized()
+
+        assert backend._available_tools == {"execute", "read", "write"}
+
+    def test_tools_list_failure_is_nonfatal(self):
+        backend = _make_backend()
+        backend._client.post.side_effect = [
+            _init_response(),
+            _mock_response(),
+            _mock_response(status_code=500),
+        ]
+
+        backend._ensure_initialized()
+
+        assert backend._initialized is True
+        assert backend._available_tools == set()
 
 
 # ===========================================================================
@@ -168,11 +249,11 @@ class TestEnsureInitialized:
 
 
 class TestExecute:
-    def _init_and_exec(self, backend: McpSandboxBackend, exec_response=None):
-        """Helper: set up client to return init then exec responses."""
+    def _init_and_exec(self, backend: McpSandboxBackend, exec_response=None, tools=None):
+        """Helper: set up client to return init, notification, tools/list, then exec responses."""
         if exec_response is None:
             exec_response = _tool_response("hello world\nexit_code: 0")
-        backend._client.post.side_effect = [_init_response(), _mock_response(), exec_response]
+        backend._client.post.side_effect = [*_init_side_effects(tools), exec_response]
 
     def test_sends_correct_tool_call_payload(self):
         backend = _make_backend()
@@ -180,11 +261,11 @@ class TestExecute:
 
         backend.execute("echo hello")
 
-        # Third call is the tool call (after init + notification)
-        tool_call = backend._client.post.call_args_list[2]
+        # 4th call is the tool call (init + notification + tools/list + tool call)
+        tool_call = backend._client.post.call_args_list[3]
         payload = tool_call[1]["json"]
         assert payload["method"] == "tools/call"
-        assert payload["params"]["name"] == "exec_command"
+        assert payload["params"]["name"] == "execute"
         assert payload["params"]["arguments"] == {"cmd": "echo hello"}
 
     def test_includes_session_id_header(self):
@@ -193,7 +274,7 @@ class TestExecute:
 
         backend.execute("echo hello")
 
-        tool_call = backend._client.post.call_args_list[2]
+        tool_call = backend._client.post.call_args_list[3]
         headers = tool_call[1]["headers"]
         assert "Mcp-Session-Id" in headers
 
@@ -225,14 +306,11 @@ class TestExecute:
 
     def test_retries_on_http_400(self):
         backend = _make_backend()
-        # First init succeeds, notification ok, tool call returns 400, then re-init, notification, retry succeeds
         error_resp = _mock_response(status_code=400)
         backend._client.post.side_effect = [
-            _init_response(),  # init
-            _mock_response(),  # notification
+            *_init_side_effects(),  # init + notification + tools/list
             error_resp,  # tool call -> 400
-            _init_response(),  # re-init
-            _mock_response(),  # notification
+            *_init_side_effects(),  # re-init + notification + tools/list
             _tool_response("retry output\nexit_code: 0"),  # retry tool call
         ]
 
@@ -244,8 +322,7 @@ class TestExecute:
         backend = _make_backend()
         error_resp = _mock_response(status_code=400)
         backend._client.post.side_effect = [
-            _init_response(),  # init
-            _mock_response(),  # notification
+            *_init_side_effects(),  # init + notification + tools/list
             error_resp,  # tool call -> 400
             _mock_response(status_code=500),  # re-init fails
         ]
@@ -259,8 +336,43 @@ class TestExecute:
 
         backend.execute("echo hello", timeout=30)
 
-        tool_call = backend._client.post.call_args_list[2]
+        tool_call = backend._client.post.call_args_list[3]
         assert tool_call[1]["timeout"] == 30
+
+    def test_uses_exec_command_on_old_server(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("output\nexit_code: 0")
+
+        result = backend.execute("echo old")
+
+        tool_call = backend._client.post.call_args_list[0]
+        assert tool_call[1]["json"]["params"]["name"] == "exec_command"
+        assert result.exit_code == 0
+
+    def test_prefers_execute_over_exec_command(self):
+        backend = _make_initialized_backend(tools=["execute", "exec_command"])
+        backend._client.post.return_value = _tool_response("output")
+
+        backend.execute("echo test")
+
+        tool_call = backend._client.post.call_args_list[0]
+        assert tool_call[1]["json"]["params"]["name"] == "execute"
+
+    def test_raises_when_no_execute_tool(self):
+        backend = _make_initialized_backend(tools=["read", "write"])
+
+        with pytest.raises(McpSandboxError, match="No execute tool"):
+            backend.execute("echo fail")
+
+    def test_meta_exit_code_preferred(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response(
+            "output\nexit_code: 1", meta={"exit_code": 42, "sandbox_id": "abc"}
+        )
+
+        result = backend.execute("test")
+
+        assert result.exit_code == 42
 
 
 # ===========================================================================
@@ -270,10 +382,8 @@ class TestExecute:
 
 class TestUploadFiles:
     def test_upload_success(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
-        backend._client.post.return_value = _tool_response("ok\nexit_code: 0")
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("ok", meta={"exit_code": 0, "sandbox_id": "x"})
 
         results = backend.upload_files([("/tmp/test.txt", b"hello")])
 
@@ -282,22 +392,18 @@ class TestUploadFiles:
         assert results[0].error is None
 
     def test_upload_permission_denied(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
-        backend._client.post.return_value = _tool_response("permission denied\nexit_code: 1")
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("denied", meta={"exit_code": 1, "sandbox_id": "x"})
 
         results = backend.upload_files([("/root/secret.txt", b"nope")])
 
         assert results[0].error == "permission_denied"
 
     def test_upload_partial_success(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
+        backend = _make_initialized_backend()
         backend._client.post.side_effect = [
-            _tool_response("ok\nexit_code: 0"),
-            _tool_response("fail\nexit_code: 1"),
+            _tool_response("ok", meta={"exit_code": 0, "sandbox_id": "x"}),
+            _tool_response("fail", meta={"exit_code": 1, "sandbox_id": "x"}),
         ]
 
         results = backend.upload_files([("/tmp/a.txt", b"a"), ("/tmp/b.txt", b"b")])
@@ -306,20 +412,27 @@ class TestUploadFiles:
         assert results[1].error == "permission_denied"
 
     def test_upload_invalid_path(self):
-        backend = _make_backend()
+        backend = _make_initialized_backend()
 
         results = backend.upload_files([("relative/path.txt", b"data")])
 
         assert results[0].error == "invalid_path"
 
+    def test_upload_fallback_shell(self):
+        """When upload_file tool not available, falls back to shell base64."""
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("ok\nexit_code: 0")
+
+        results = backend.upload_files([("/tmp/test.txt", b"hello")])
+
+        assert results[0].error is None
+
 
 class TestDownloadFiles:
     def test_download_success(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
+        backend = _make_initialized_backend()
         encoded = base64.b64encode(b"file content").decode()
-        backend._client.post.return_value = _tool_response(f"{encoded}\nexit_code: 0")
+        backend._client.post.return_value = _tool_response(encoded, meta={"exit_code": 0, "sandbox_id": "x"})
 
         results = backend.download_files(["/tmp/test.txt"])
 
@@ -327,10 +440,8 @@ class TestDownloadFiles:
         assert results[0].error is None
 
     def test_download_file_not_found(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
-        backend._client.post.return_value = _tool_response("No such file\nexit_code: 1")
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("not found", meta={"exit_code": 1, "sandbox_id": "x"})
 
         results = backend.download_files(["/tmp/missing.txt"])
 
@@ -338,23 +449,32 @@ class TestDownloadFiles:
         assert results[0].error == "file_not_found"
 
     def test_download_strips_whitespace(self):
-        backend = _make_backend()
-        backend._initialized = True
-        backend._session_id = "sess"
+        backend = _make_initialized_backend()
         encoded = base64.b64encode(b"data").decode()
-        backend._client.post.return_value = _tool_response(f"{encoded}  \n\nexit_code: 0")
+        backend._client.post.return_value = _tool_response(f"{encoded}  \n", meta={"exit_code": 0, "sandbox_id": "x"})
 
         results = backend.download_files(["/tmp/test.txt"])
 
         assert results[0].content == b"data"
 
     def test_download_invalid_path(self):
-        backend = _make_backend()
+        backend = _make_initialized_backend()
 
         results = backend.download_files(["relative/path.txt"])
 
         assert results[0].error == "invalid_path"
         assert results[0].content is None
+
+    def test_download_fallback_shell(self):
+        """When download_file tool not available, falls back to shell base64."""
+        backend = _make_initialized_backend(tools=["exec_command"])
+        encoded = base64.b64encode(b"data").decode()
+        # Fallback uses execute(f"base64 '/path'") which returns raw base64 output
+        backend._client.post.return_value = _tool_response(f"{encoded}\nexit_code: 0")
+
+        results = backend.download_files(["/tmp/test.txt"])
+
+        assert results[0].content == b"data"
 
 
 # ===========================================================================
@@ -438,3 +558,265 @@ class TestClose:
             pass
 
         backend._client.close.assert_called_once()
+
+
+# ===========================================================================
+# US-046: Tool discovery
+# ===========================================================================
+
+
+class TestToolDiscovery:
+    def test_has_tool_true(self):
+        backend = _make_initialized_backend(tools=["execute", "read"])
+        assert backend._has_tool("execute") is True
+        assert backend._has_tool("read") is True
+
+    def test_has_tool_false(self):
+        backend = _make_initialized_backend(tools=["execute"])
+        assert backend._has_tool("write") is False
+
+
+# ===========================================================================
+# US-047: _parse_meta
+# ===========================================================================
+
+
+class TestParseMeta:
+    def test_meta_present(self):
+        backend = _make_initialized_backend()
+        exit_code, sandbox_id = backend._parse_meta({"_meta": {"exit_code": 42, "sandbox_id": "abc-123"}})
+        assert exit_code == 42
+        assert sandbox_id == "abc-123"
+
+    def test_meta_absent(self):
+        backend = _make_initialized_backend()
+        exit_code, sandbox_id = backend._parse_meta({})
+        assert exit_code is None
+        assert sandbox_id is None
+
+    def test_meta_caches_sandbox_id(self):
+        backend = _make_initialized_backend()
+        backend._parse_meta({"_meta": {"sandbox_id": "cached-id"}})
+        assert backend._sandbox_id == "cached-id"
+
+
+# ===========================================================================
+# US-048: Sandbox ID from _meta
+# ===========================================================================
+
+
+class TestSandboxId:
+    def test_id_fallback_before_tool_call(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005")
+        assert b.id == "mcp-sandbox:http://localhost:3005"
+
+    def test_id_uses_meta_sandbox_id(self):
+        backend = _make_initialized_backend()
+        backend._sandbox_id = "remote-uuid"
+        assert backend.id == "remote-uuid"
+
+
+# ===========================================================================
+# US-050-055: Native tool overrides
+# ===========================================================================
+
+
+class TestReadOverride:
+    def test_native_read(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("     1\tline1\n     2\tline2", meta={"exit_code": 0})
+
+        result = backend.read("/workspace/file.txt")
+
+        assert "line1" in result
+
+    def test_fallback_read(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("stdout:\n     1\tline1\nexit_code: 0")
+
+        result = backend.read("/workspace/file.txt")
+
+        assert "line1" in result
+
+
+class TestWriteOverride:
+    def test_native_write_success(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("Written to /workspace/f.txt", meta={"exit_code": 0})
+
+        result = backend.write("/workspace/f.txt", "content")
+
+        assert result.error is None
+        assert result.path == "/workspace/f.txt"
+
+    def test_native_write_error(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("Permission denied", meta={"exit_code": 1})
+
+        result = backend.write("/workspace/f.txt", "content")
+
+        assert result.error is not None
+
+
+class TestEditOverride:
+    def test_native_edit_success(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("Replaced 1 occurrence(s)", meta={"exit_code": 0})
+
+        result = backend.edit("/workspace/f.txt", "old", "new")
+
+        assert result.error is None
+        assert result.occurrences == 1
+
+    def test_native_edit_not_found(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("not found", meta={"exit_code": 1})
+
+        result = backend.edit("/workspace/f.txt", "old", "new")
+
+        assert result.error == "old_string not found in file"
+
+    def test_native_edit_multiple(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("3 occurrences", meta={"exit_code": 2})
+
+        result = backend.edit("/workspace/f.txt", "old", "new")
+
+        assert result.error == "multiple matches found (use replace_all=true)"
+
+    def test_native_edit_file_not_found(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("no file", meta={"exit_code": 3})
+
+        result = backend.edit("/workspace/f.txt", "old", "new")
+
+        assert "file not found" in result.error
+
+
+class TestGrepOverride:
+    def test_native_grep_matches(self):
+        backend = _make_initialized_backend()
+        line1 = '{"path":"/workspace/a.py","line":1,"text":"hello"}'
+        line2 = '{"path":"/workspace/b.py","line":2,"text":"hello world"}'
+        backend._client.post.return_value = _tool_response(f"{line1}\n{line2}", meta={"exit_code": 0})
+
+        result = backend.grep_raw("hello")
+
+        assert len(result) == 2
+        assert result[0]["path"] == "/workspace/a.py"
+
+    def test_native_grep_no_matches(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("", meta={"exit_code": 1})
+
+        result = backend.grep_raw("nonexistent")
+
+        assert result == []
+
+
+class TestGlobOverride:
+    def test_native_glob(self):
+        backend = _make_initialized_backend()
+        text = '{"path":"/workspace/a.py","is_dir":false,"size":100,"mtime":"2025-01-01T00:00:00Z"}'
+        backend._client.post.return_value = _tool_response(text, meta={"exit_code": 0})
+
+        result = backend.glob_info("*.py")
+
+        assert len(result) == 1
+        assert result[0]["path"] == "/workspace/a.py"
+
+    def test_native_glob_empty(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("", meta={"exit_code": 0})
+
+        result = backend.glob_info("*.xyz")
+
+        assert result == []
+
+
+class TestLsOverride:
+    def test_native_ls(self):
+        backend = _make_initialized_backend()
+        text = '{"path":"/workspace/file.py","is_dir":false}\n{"path":"/workspace/dir","is_dir":true}'
+        backend._client.post.return_value = _tool_response(text, meta={"exit_code": 0})
+
+        result = backend.ls_info("/workspace")
+
+        assert len(result) == 2
+        assert result[1]["is_dir"] is True
+
+    def test_native_ls_not_found(self):
+        backend = _make_initialized_backend()
+        backend._client.post.return_value = _tool_response("not found", meta={"exit_code": 1})
+
+        result = backend.ls_info("/nonexistent")
+
+        assert result == []
+
+
+# ===========================================================================
+# US-058: Graceful degradation — old exec_server
+# ===========================================================================
+
+
+class TestGracefulDegradation:
+    def test_old_server_execute_uses_exec_command(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("output\nexit_code: 0")
+
+        result = backend.execute("echo test")
+
+        assert result.exit_code == 0
+        call = backend._client.post.call_args_list[0]
+        assert call[1]["json"]["params"]["name"] == "exec_command"
+
+    def test_old_server_read_falls_back(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("stdout:\n     1\tline\nexit_code: 0")
+
+        result = backend.read("/file.txt")
+
+        # Falls back to super().read() which calls execute()
+        assert "line" in result
+
+    def test_old_server_upload_falls_back(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        backend._client.post.return_value = _tool_response("ok\nexit_code: 0")
+
+        results = backend.upload_files([("/tmp/f.txt", b"data")])
+
+        assert results[0].error is None
+
+    def test_old_server_download_falls_back(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        encoded = base64.b64encode(b"data").decode()
+        backend._client.post.return_value = _tool_response(f"{encoded}\nexit_code: 0")
+
+        results = backend.download_files(["/tmp/f.txt"])
+
+        assert results[0].content == b"data"
+
+    def test_old_server_id_is_fallback(self):
+        backend = _make_initialized_backend(tools=["exec_command"])
+        assert backend.id == "mcp-sandbox:http://localhost:3005"
+
+
+# ===========================================================================
+# Helper tests
+# ===========================================================================
+
+
+class TestParseJsonLines:
+    def test_valid_lines(self):
+        text = '{"a":1}\n{"b":2}\n'
+        result = _parse_json_lines(text)
+        assert len(result) == 2
+        assert result[0] == {"a": 1}
+
+    def test_empty_string(self):
+        assert _parse_json_lines("") == []
+
+    def test_invalid_json_skipped(self):
+        text = '{"a":1}\nnot json\n{"b":2}'
+        result = _parse_json_lines(text)
+        assert len(result) == 2

--- a/backend/tests/unit/agents/test_mcp_sandbox.py
+++ b/backend/tests/unit/agents/test_mcp_sandbox.py
@@ -1,0 +1,440 @@
+"""Unit tests for McpSandboxBackend (US-010 through US-014)."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from deepagents.backends.protocol import ExecuteResponse
+
+from src.agents.mcp_sandbox import McpSandboxBackend, McpSandboxError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None, headers: dict | None = None):
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        http_error = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(spec=httpx.Request),
+            response=resp,
+        )
+        resp.raise_for_status.side_effect = http_error
+    return resp
+
+
+def _init_response(session_id: str = "test-session-123"):
+    """Standard successful initialize response."""
+    return _mock_response(
+        json_data={"jsonrpc": "2.0", "id": 0, "result": {"protocolVersion": "2025-03-26"}},
+        headers={"Mcp-Session-Id": session_id},
+    )
+
+
+def _tool_response(text: str = "hello world\nexit_code: 0"):
+    """Standard successful tool call response."""
+    return _mock_response(
+        json_data={"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": text}]}},
+    )
+
+
+def _make_backend(base_url: str = "http://localhost:3005", api_key: str | None = None) -> McpSandboxBackend:
+    """Create a backend with a mocked httpx.Client."""
+    backend = McpSandboxBackend(base_url=base_url, api_key=api_key)
+    backend._client = MagicMock(spec=httpx.Client)
+    return backend
+
+
+# ===========================================================================
+# US-010: Constructor and id property
+# ===========================================================================
+
+
+class TestConstructorAndId:
+    def test_base_url_trailing_slash_stripped(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005/")
+        assert b._base_url == "http://localhost:3005"
+
+    def test_base_url_stored_without_trailing_slash(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005")
+        assert b._base_url == "http://localhost:3005"
+
+    def test_api_key_none_when_not_provided(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005")
+        assert b._api_key is None
+
+    def test_api_key_stored_when_provided(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005", api_key="secret")
+        assert b._api_key == "secret"
+
+    def test_id_property_format(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005")
+        assert b.id == "mcp-sandbox:http://localhost:3005"
+
+    def test_initial_state(self):
+        b = McpSandboxBackend(base_url="http://localhost:3005")
+        assert b._initialized is False
+        assert b._session_id is None
+        assert b._request_id == 0
+
+
+# ===========================================================================
+# US-011: MCP initialize handshake
+# ===========================================================================
+
+
+class TestEnsureInitialized:
+    def test_sends_initialize_payload(self):
+        backend = _make_backend()
+        backend._client.post.return_value = _init_response()
+
+        backend._ensure_initialized()
+
+        first_call = backend._client.post.call_args_list[0]
+        assert first_call[0][0] == "http://localhost:3005/mcp"
+        payload = first_call[1]["json"]
+        assert payload["method"] == "initialize"
+        assert payload["params"]["protocolVersion"] == "2025-03-26"
+
+    def test_extracts_session_id(self):
+        backend = _make_backend()
+        backend._client.post.return_value = _init_response("my-session-456")
+
+        backend._ensure_initialized()
+
+        assert backend._session_id == "my-session-456"
+
+    def test_sets_initialized_true(self):
+        backend = _make_backend()
+        backend._client.post.return_value = _init_response()
+
+        backend._ensure_initialized()
+
+        assert backend._initialized is True
+        assert backend._request_id == 1
+
+    def test_no_op_when_already_initialized(self):
+        backend = _make_backend()
+        backend._initialized = True
+
+        backend._ensure_initialized()
+
+        backend._client.post.assert_not_called()
+
+    def test_sends_notifications_initialized(self):
+        backend = _make_backend()
+        backend._client.post.return_value = _init_response()
+
+        backend._ensure_initialized()
+
+        # Second POST call is the notification
+        assert backend._client.post.call_count == 2
+        second_call = backend._client.post.call_args_list[1]
+        payload = second_call[1]["json"]
+        assert payload["method"] == "notifications/initialized"
+
+    def test_raises_on_http_error(self):
+        backend = _make_backend()
+        backend._client.post.return_value = _mock_response(status_code=500)
+
+        with pytest.raises(McpSandboxError, match="MCP initialize failed"):
+            backend._ensure_initialized()
+
+    def test_includes_api_key_header(self):
+        backend = _make_backend(api_key="my-key")
+        backend._client.post.return_value = _init_response()
+
+        backend._ensure_initialized()
+
+        first_call = backend._client.post.call_args_list[0]
+        headers = first_call[1]["headers"]
+        assert headers["x-api-key"] == "my-key"
+
+
+# ===========================================================================
+# US-012: execute method
+# ===========================================================================
+
+
+class TestExecute:
+    def _init_and_exec(self, backend: McpSandboxBackend, exec_response=None):
+        """Helper: set up client to return init then exec responses."""
+        if exec_response is None:
+            exec_response = _tool_response("hello world\nexit_code: 0")
+        backend._client.post.side_effect = [_init_response(), _mock_response(), exec_response]
+
+    def test_sends_correct_tool_call_payload(self):
+        backend = _make_backend()
+        self._init_and_exec(backend)
+
+        backend.execute("echo hello")
+
+        # Third call is the tool call (after init + notification)
+        tool_call = backend._client.post.call_args_list[2]
+        payload = tool_call[1]["json"]
+        assert payload["method"] == "tools/call"
+        assert payload["params"]["name"] == "exec_command"
+        assert payload["params"]["arguments"] == {"cmd": "echo hello"}
+
+    def test_includes_session_id_header(self):
+        backend = _make_backend()
+        self._init_and_exec(backend)
+
+        backend.execute("echo hello")
+
+        tool_call = backend._client.post.call_args_list[2]
+        headers = tool_call[1]["headers"]
+        assert "Mcp-Session-Id" in headers
+
+    def test_parses_exit_code_from_text(self):
+        backend = _make_backend()
+        self._init_and_exec(backend, _tool_response("some output\nexit_code: 1"))
+
+        result = backend.execute("false")
+
+        assert result.exit_code == 1
+
+    def test_exit_code_defaults_to_zero(self):
+        backend = _make_backend()
+        self._init_and_exec(backend, _tool_response("just some output with no exit code"))
+
+        result = backend.execute("echo hello")
+
+        assert result.exit_code == 0
+
+    def test_returns_execute_response(self):
+        backend = _make_backend()
+        self._init_and_exec(backend, _tool_response("hello world\nexit_code: 0"))
+
+        result = backend.execute("echo hello")
+
+        assert isinstance(result, ExecuteResponse)
+        assert result.output == "hello world\nexit_code: 0"
+        assert result.truncated is False
+
+    def test_retries_on_http_400(self):
+        backend = _make_backend()
+        # First init succeeds, notification ok, tool call returns 400, then re-init, notification, retry succeeds
+        error_resp = _mock_response(status_code=400)
+        backend._client.post.side_effect = [
+            _init_response(),  # init
+            _mock_response(),  # notification
+            error_resp,  # tool call -> 400
+            _init_response(),  # re-init
+            _mock_response(),  # notification
+            _tool_response("retry output\nexit_code: 0"),  # retry tool call
+        ]
+
+        result = backend.execute("echo retry")
+
+        assert result.output == "retry output\nexit_code: 0"
+
+    def test_raises_when_retry_fails(self):
+        backend = _make_backend()
+        error_resp = _mock_response(status_code=400)
+        backend._client.post.side_effect = [
+            _init_response(),  # init
+            _mock_response(),  # notification
+            error_resp,  # tool call -> 400
+            _mock_response(status_code=500),  # re-init fails
+        ]
+
+        with pytest.raises(McpSandboxError, match="retry"):
+            backend.execute("echo fail")
+
+    def test_passes_timeout_to_httpx(self):
+        backend = _make_backend()
+        self._init_and_exec(backend)
+
+        backend.execute("echo hello", timeout=30)
+
+        tool_call = backend._client.post.call_args_list[2]
+        assert tool_call[1]["timeout"] == 30
+
+
+# ===========================================================================
+# US-013: upload_files and download_files
+# ===========================================================================
+
+
+class TestUploadFiles:
+    def test_upload_success(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        backend._client.post.return_value = _tool_response("ok\nexit_code: 0")
+
+        results = backend.upload_files([("/tmp/test.txt", b"hello")])
+
+        assert len(results) == 1
+        assert results[0].path == "/tmp/test.txt"
+        assert results[0].error is None
+
+    def test_upload_permission_denied(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        backend._client.post.return_value = _tool_response("permission denied\nexit_code: 1")
+
+        results = backend.upload_files([("/root/secret.txt", b"nope")])
+
+        assert results[0].error == "permission_denied"
+
+    def test_upload_partial_success(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        backend._client.post.side_effect = [
+            _tool_response("ok\nexit_code: 0"),
+            _tool_response("fail\nexit_code: 1"),
+        ]
+
+        results = backend.upload_files([("/tmp/a.txt", b"a"), ("/tmp/b.txt", b"b")])
+
+        assert results[0].error is None
+        assert results[1].error == "permission_denied"
+
+    def test_upload_invalid_path(self):
+        backend = _make_backend()
+
+        results = backend.upload_files([("relative/path.txt", b"data")])
+
+        assert results[0].error == "invalid_path"
+
+
+class TestDownloadFiles:
+    def test_download_success(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        encoded = base64.b64encode(b"file content").decode()
+        backend._client.post.return_value = _tool_response(f"{encoded}\nexit_code: 0")
+
+        results = backend.download_files(["/tmp/test.txt"])
+
+        assert results[0].content == b"file content"
+        assert results[0].error is None
+
+    def test_download_file_not_found(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        backend._client.post.return_value = _tool_response("No such file\nexit_code: 1")
+
+        results = backend.download_files(["/tmp/missing.txt"])
+
+        assert results[0].content is None
+        assert results[0].error == "file_not_found"
+
+    def test_download_strips_whitespace(self):
+        backend = _make_backend()
+        backend._initialized = True
+        backend._session_id = "sess"
+        encoded = base64.b64encode(b"data").decode()
+        backend._client.post.return_value = _tool_response(f"{encoded}  \n\nexit_code: 0")
+
+        results = backend.download_files(["/tmp/test.txt"])
+
+        assert results[0].content == b"data"
+
+    def test_download_invalid_path(self):
+        backend = _make_backend()
+
+        results = backend.download_files(["relative/path.txt"])
+
+        assert results[0].error == "invalid_path"
+        assert results[0].content is None
+
+
+# ===========================================================================
+# US-014: health check and cleanup
+# ===========================================================================
+
+
+class TestHealth:
+    def test_health_returns_true(self):
+        backend = _make_backend()
+        backend._client.get.return_value = _mock_response(json_data={"status": "ok"})
+
+        assert backend.health() is True
+
+    def test_health_returns_false_on_error(self):
+        backend = _make_backend()
+        backend._client.get.side_effect = httpx.ConnectError("refused")
+
+        assert backend.health() is False
+
+    def test_health_returns_false_on_bad_status(self):
+        backend = _make_backend()
+        backend._client.get.return_value = _mock_response(json_data={"status": "degraded"})
+
+        assert backend.health() is False
+
+    def test_health_uses_short_timeout(self):
+        backend = _make_backend()
+        backend._client.get.return_value = _mock_response(json_data={"status": "ok"})
+
+        backend.health()
+
+        backend._client.get.assert_called_once()
+        _, kwargs = backend._client.get.call_args
+        assert kwargs["timeout"] == 5.0
+
+
+class TestClose:
+    def test_close_sends_delete_with_session(self):
+        backend = _make_backend()
+        backend._session_id = "sess-123"
+        backend._initialized = True
+
+        backend.close()
+
+        backend._client.delete.assert_called_once()
+        call_args = backend._client.delete.call_args
+        assert "/mcp" in call_args[0][0]
+        assert call_args[1]["headers"]["Mcp-Session-Id"] == "sess-123"
+
+    def test_close_calls_client_close(self):
+        backend = _make_backend()
+
+        backend.close()
+
+        backend._client.close.assert_called_once()
+
+    def test_close_resets_state(self):
+        backend = _make_backend()
+        backend._session_id = "sess"
+        backend._initialized = True
+
+        backend.close()
+
+        assert backend._session_id is None
+        assert backend._initialized is False
+
+    def test_close_safe_without_session(self):
+        backend = _make_backend()
+        backend._session_id = None
+
+        backend.close()  # should not raise
+
+        backend._client.delete.assert_not_called()
+
+    def test_context_manager_calls_close(self):
+        backend = _make_backend()
+        backend._session_id = "sess"
+
+        with backend:
+            pass
+
+        backend._client.close.assert_called_once()

--- a/backend/tests/unit/controllers/test_llm_context_files.py
+++ b/backend/tests/unit/controllers/test_llm_context_files.py
@@ -26,7 +26,7 @@ async def test_llm_invoke_uses_resolved_context_files():
     with (
         patch("src.controllers.llm.init_config", return_value={"configurable": {}, "metadata": {}}),
         patch.object(controller.service_context.llm_service, "assistant", AsyncMock(return_value=params)),
-        patch.object(controller, "_resolve_user_settings", AsyncMock(return_value=("openai:gpt-4o", None, None))),
+        patch.object(controller, "_resolve_user_settings", AsyncMock(return_value=("openai:gpt-4o", None, None, None))),
         patch(
             "src.controllers.llm.prepare_memory_files",
             AsyncMock(

--- a/backend/tests/unit/controllers/test_llm_context_files.py
+++ b/backend/tests/unit/controllers/test_llm_context_files.py
@@ -26,7 +26,9 @@ async def test_llm_invoke_uses_resolved_context_files():
     with (
         patch("src.controllers.llm.init_config", return_value={"configurable": {}, "metadata": {}}),
         patch.object(controller.service_context.llm_service, "assistant", AsyncMock(return_value=params)),
-        patch.object(controller, "_resolve_user_settings", AsyncMock(return_value=("openai:gpt-4o", None, None, None))),
+        patch.object(
+            controller, "_resolve_user_settings", AsyncMock(return_value=("openai:gpt-4o", None, None, None, None))
+        ),
         patch(
             "src.controllers.llm.prepare_memory_files",
             AsyncMock(

--- a/backend/tests/unit/controllers/test_llm_model_resolution.py
+++ b/backend/tests/unit/controllers/test_llm_model_resolution.py
@@ -57,6 +57,7 @@ class TestResolveUserSettings:
                     api_key,
                     default_sandbox,
                     mcp_sandbox_url,
+                    mcp_api_key,
                 ) = await controller._resolve_user_settings("openai:gpt-4o")
 
         assert model == "openai:gpt-4o"
@@ -71,7 +72,7 @@ class TestResolveUserSettings:
             instance._get_or_create = AsyncMock(return_value=FakeSettings(default_model="anthropic:claude-sonnet-4"))
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, _, _ = await controller._resolve_user_settings("")
+            model, _, _, _, _ = await controller._resolve_user_settings("")
 
         assert model == "anthropic:claude-sonnet-4"
 
@@ -85,7 +86,7 @@ class TestResolveUserSettings:
             instance._get_or_create = AsyncMock(return_value=FakeSettings(default_model=None))
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, _, _ = await controller._resolve_user_settings("")
+            model, _, _, _, _ = await controller._resolve_user_settings("")
 
         assert model == DEFAULT_CHAT_MODEL
 
@@ -101,7 +102,7 @@ class TestResolveUserSettings:
             )
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, default_sandbox, _ = await controller._resolve_user_settings("openai:gpt-4o")
+            model, _, default_sandbox, _, _ = await controller._resolve_user_settings("openai:gpt-4o")
 
         assert model == "openai:gpt-4o"
         assert default_sandbox == "daytona"
@@ -111,24 +112,28 @@ class TestResolveUserSettings:
         """Unauthenticated users (no user_id) should get DEFAULT_CHAT_MODEL."""
         controller = LLMController(user_id=None, store=mock_store, config=mock_config)
 
-        model, api_key, default_sandbox, mcp_sandbox_url = await controller._resolve_user_settings("")
+        model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key = await controller._resolve_user_settings("")
 
         assert model == DEFAULT_CHAT_MODEL
         assert api_key is None
         assert default_sandbox is None
         assert mcp_sandbox_url is None
+        assert mcp_api_key is None
 
     @pytest.mark.asyncio
     async def test_unauthenticated_user_explicit_model_preserved(self, mock_store, mock_config):
         """Unauthenticated users with explicit model should keep it."""
         controller = LLMController(user_id=None, store=mock_store, config=mock_config)
 
-        model, api_key, default_sandbox, mcp_sandbox_url = await controller._resolve_user_settings("openai:gpt-4o")
+        model, api_key, default_sandbox, mcp_sandbox_url, mcp_api_key = await controller._resolve_user_settings(
+            "openai:gpt-4o"
+        )
 
         assert model == "openai:gpt-4o"
         assert api_key is None
         assert default_sandbox is None
         assert mcp_sandbox_url is None
+        assert mcp_api_key is None
 
 
 class TestLLMRequestModelDefault:

--- a/backend/tests/unit/controllers/test_llm_model_resolution.py
+++ b/backend/tests/unit/controllers/test_llm_model_resolution.py
@@ -16,9 +16,10 @@ from src.constants.llm import DEFAULT_CHAT_MODEL
 class FakeSettings:
     """Minimal stand-in for user settings."""
 
-    def __init__(self, default_model=None, default_sandbox=None):
+    def __init__(self, default_model=None, default_sandbox=None, default_mcp_sandbox_url=None):
         self.default_model = default_model
         self.default_sandbox = default_sandbox
+        self.default_mcp_sandbox_url = default_mcp_sandbox_url
 
 
 @pytest.fixture
@@ -55,6 +56,7 @@ class TestResolveUserSettings:
                     model,
                     api_key,
                     default_sandbox,
+                    mcp_sandbox_url,
                 ) = await controller._resolve_user_settings("openai:gpt-4o")
 
         assert model == "openai:gpt-4o"
@@ -69,7 +71,7 @@ class TestResolveUserSettings:
             instance._get_or_create = AsyncMock(return_value=FakeSettings(default_model="anthropic:claude-sonnet-4"))
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, _ = await controller._resolve_user_settings("")
+            model, _, _, _ = await controller._resolve_user_settings("")
 
         assert model == "anthropic:claude-sonnet-4"
 
@@ -83,7 +85,7 @@ class TestResolveUserSettings:
             instance._get_or_create = AsyncMock(return_value=FakeSettings(default_model=None))
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, _ = await controller._resolve_user_settings("")
+            model, _, _, _ = await controller._resolve_user_settings("")
 
         assert model == DEFAULT_CHAT_MODEL
 
@@ -99,7 +101,7 @@ class TestResolveUserSettings:
             )
             instance._decrypt_keys = MagicMock(return_value={})
 
-            model, _, default_sandbox = await controller._resolve_user_settings("openai:gpt-4o")
+            model, _, default_sandbox, _ = await controller._resolve_user_settings("openai:gpt-4o")
 
         assert model == "openai:gpt-4o"
         assert default_sandbox == "daytona"
@@ -109,22 +111,24 @@ class TestResolveUserSettings:
         """Unauthenticated users (no user_id) should get DEFAULT_CHAT_MODEL."""
         controller = LLMController(user_id=None, store=mock_store, config=mock_config)
 
-        model, api_key, default_sandbox = await controller._resolve_user_settings("")
+        model, api_key, default_sandbox, mcp_sandbox_url = await controller._resolve_user_settings("")
 
         assert model == DEFAULT_CHAT_MODEL
         assert api_key is None
         assert default_sandbox is None
+        assert mcp_sandbox_url is None
 
     @pytest.mark.asyncio
     async def test_unauthenticated_user_explicit_model_preserved(self, mock_store, mock_config):
         """Unauthenticated users with explicit model should keep it."""
         controller = LLMController(user_id=None, store=mock_store, config=mock_config)
 
-        model, api_key, default_sandbox = await controller._resolve_user_settings("openai:gpt-4o")
+        model, api_key, default_sandbox, mcp_sandbox_url = await controller._resolve_user_settings("openai:gpt-4o")
 
         assert model == "openai:gpt-4o"
         assert api_key is None
         assert default_sandbox is None
+        assert mcp_sandbox_url is None
 
 
 class TestLLMRequestModelDefault:

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -13,6 +13,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import {
 	DEFAULT_SANDBOX,
@@ -26,21 +28,29 @@ import {
 	getSettings,
 	patchDefaults,
 } from "@/lib/services/userSettingsService";
+import { useSandboxHealth } from "@/hooks/useSandboxHealth";
 
 export function SandboxSettings() {
 	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(false);
 	const [providerKeys, setProviderKeys] = useState<ProviderKeyStatus[]>([]);
+	const [mcpSandboxUrl, setMcpSandboxUrl] = useState<string>("");
+	const { isHealthy, refresh } = useSandboxHealth(mcpSandboxUrl || null);
 
 	const visibleOptions = useMemo(
 		() =>
 			SANDBOX_OPTIONS.filter((opt) => {
-				if (opt.value !== "daytona") return true;
-				return providerKeys.some(
-					(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
-				);
+				if (opt.value === "daytona") {
+					return providerKeys.some(
+						(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
+					);
+				}
+				if (opt.value === "mcp") {
+					return !!mcpSandboxUrl;
+				}
+				return true;
 			}),
-		[providerKeys],
+		[providerKeys, mcpSandboxUrl],
 	);
 
 	useEffect(() => {
@@ -48,6 +58,7 @@ export function SandboxSettings() {
 			.then((res) => {
 				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
 				setProviderKeys(res.provider_keys ?? []);
+				setMcpSandboxUrl(res.defaults.mcp_sandbox_url ?? "");
 			})
 			.catch(() => {});
 	}, []);
@@ -68,6 +79,21 @@ export function SandboxSettings() {
 		}
 	};
 
+	const handleMcpUrlSave = async () => {
+		const url = mcpSandboxUrl.trim() || null;
+		try {
+			await patchDefaults({ mcp_sandbox_url: url });
+			toast.success(url ? "MCP sandbox URL saved" : "MCP sandbox URL cleared");
+			// If MCP was selected but URL is now cleared, revert to state
+			if (!url && sandbox === "mcp") {
+				const res = await patchDefaults({ sandbox: "state" });
+				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
+			}
+		} catch {
+			toast.error("Failed to save MCP sandbox URL");
+		}
+	};
+
 	return (
 		<Card>
 			<CardHeader>
@@ -76,19 +102,49 @@ export function SandboxSettings() {
 					Choose the sandbox backend for agent code execution.
 				</CardDescription>
 			</CardHeader>
-			<CardContent>
-				<Select value={sandbox} onValueChange={handleChange} disabled={loading}>
+			<CardContent className="space-y-4">
+				<Select
+					value={sandbox}
+					onValueChange={handleChange}
+					disabled={loading}
+					onOpenChange={(open) => {
+						if (open) refresh();
+					}}
+				>
 					<SelectTrigger className="w-full max-w-sm">
 						<SelectValue />
 					</SelectTrigger>
 					<SelectContent>
 						{visibleOptions.map((opt) => (
 							<SelectItem key={opt.value} value={opt.value}>
-								{opt.label}
+								<span className="flex items-center gap-2">
+									{opt.label}
+									{opt.value === "mcp" && isHealthy !== null && (
+										<span
+											className={`h-2 w-2 rounded-full ${isHealthy ? "bg-green-500" : "bg-red-500"}`}
+										/>
+									)}
+								</span>
 							</SelectItem>
 						))}
 					</SelectContent>
 				</Select>
+
+				<div className="space-y-2">
+					<Label htmlFor="mcp-sandbox-url">MCP Sandbox URL</Label>
+					<Input
+						id="mcp-sandbox-url"
+						type="text"
+						placeholder="http://localhost:3005/mcp"
+						value={mcpSandboxUrl}
+						onChange={(e) => setMcpSandboxUrl(e.target.value)}
+						onBlur={handleMcpUrlSave}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleMcpUrlSave();
+						}}
+						className="max-w-sm"
+					/>
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { CheckCircle, Loader2, XCircle } from "lucide-react";
 import {
 	Card,
 	CardContent,
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import {
 	DEFAULT_SANDBOX,
@@ -27,6 +29,8 @@ import {
 	type SandboxType,
 	getSettings,
 	patchDefaults,
+	upsertProviderKey,
+	deleteProviderKey,
 } from "@/lib/services/userSettingsService";
 import { useSandboxHealth } from "@/hooks/useSandboxHealth";
 
@@ -34,8 +38,19 @@ export function SandboxSettings() {
 	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(false);
 	const [providerKeys, setProviderKeys] = useState<ProviderKeyStatus[]>([]);
-	const [mcpSandboxUrl, setMcpSandboxUrl] = useState<string>("");
-	const { isHealthy, refresh } = useSandboxHealth(mcpSandboxUrl || null);
+
+	// MCP config local state
+	const [mcpUrl, setMcpUrl] = useState("");
+	const [mcpApiKey, setMcpApiKey] = useState("");
+	const [savedMcpUrl, setSavedMcpUrl] = useState<string | null>(null);
+	const [mcpApiKeyIsSet, setMcpApiKeyIsSet] = useState(false);
+	const [saving, setSaving] = useState(false);
+
+	const {
+		isHealthy,
+		isLoading: healthLoading,
+		refresh,
+	} = useSandboxHealth(savedMcpUrl || null);
 
 	const visibleOptions = useMemo(
 		() =>
@@ -45,12 +60,9 @@ export function SandboxSettings() {
 						(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
 					);
 				}
-				if (opt.value === "mcp") {
-					return !!mcpSandboxUrl;
-				}
 				return true;
 			}),
-		[providerKeys, mcpSandboxUrl],
+		[providerKeys],
 	);
 
 	useEffect(() => {
@@ -58,7 +70,14 @@ export function SandboxSettings() {
 			.then((res) => {
 				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
 				setProviderKeys(res.provider_keys ?? []);
-				setMcpSandboxUrl(res.defaults.mcp_sandbox_url ?? "");
+				const url = res.defaults.mcp_sandbox_url ?? "";
+				setMcpUrl(url);
+				setSavedMcpUrl(url || null);
+				setMcpApiKeyIsSet(
+					res.provider_keys?.some(
+						(k) => k.provider === "MCP_SANDBOX_API_KEY" && k.is_set,
+					) ?? false,
+				);
 			})
 			.catch(() => {});
 	}, []);
@@ -79,18 +98,52 @@ export function SandboxSettings() {
 		}
 	};
 
-	const handleMcpUrlSave = async () => {
-		const url = mcpSandboxUrl.trim() || null;
+	const handleMcpSave = async () => {
+		const url = mcpUrl.trim() || null;
+		setSaving(true);
 		try {
+			// Save URL
 			await patchDefaults({ mcp_sandbox_url: url });
-			toast.success(url ? "MCP sandbox URL saved" : "MCP sandbox URL cleared");
-			// If MCP was selected but URL is now cleared, revert to state
+			setSavedMcpUrl(url);
+
+			// Save or clear API key
+			if (mcpApiKey.trim()) {
+				const res = await upsertProviderKey(
+					"MCP_SANDBOX_API_KEY",
+					mcpApiKey.trim(),
+				);
+				setMcpApiKeyIsSet(true);
+				setProviderKeys(res.provider_keys);
+				setMcpApiKey("");
+			}
+
+			toast.success("MCP sandbox configuration saved");
+
+			// If URL was cleared while MCP is selected, revert to state
 			if (!url && sandbox === "mcp") {
 				const res = await patchDefaults({ sandbox: "state" });
 				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
 			}
+
+			// Trigger health check after save
+			if (url) {
+				setTimeout(() => refresh(), 500);
+			}
 		} catch {
-			toast.error("Failed to save MCP sandbox URL");
+			toast.error("Failed to save MCP sandbox configuration");
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleClearApiKey = async () => {
+		try {
+			const res = await deleteProviderKey("MCP_SANDBOX_API_KEY");
+			setMcpApiKeyIsSet(false);
+			setProviderKeys(res.provider_keys);
+			toast.success("MCP API key removed");
+		} catch {
+			toast.error("Failed to remove MCP API key");
 		}
 	};
 
@@ -119,7 +172,7 @@ export function SandboxSettings() {
 							<SelectItem key={opt.value} value={opt.value}>
 								<span className="flex items-center gap-2">
 									{opt.label}
-									{opt.value === "mcp" && isHealthy !== null && (
+									{opt.value === "mcp" && savedMcpUrl && isHealthy !== null && (
 										<span
 											className={`h-2 w-2 rounded-full ${isHealthy ? "bg-green-500" : "bg-red-500"}`}
 										/>
@@ -130,21 +183,113 @@ export function SandboxSettings() {
 					</SelectContent>
 				</Select>
 
-				<div className="space-y-2">
-					<Label htmlFor="mcp-sandbox-url">MCP Sandbox URL</Label>
-					<Input
-						id="mcp-sandbox-url"
-						type="text"
-						placeholder="http://localhost:3005/mcp"
-						value={mcpSandboxUrl}
-						onChange={(e) => setMcpSandboxUrl(e.target.value)}
-						onBlur={handleMcpUrlSave}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") handleMcpUrlSave();
-						}}
-						className="max-w-sm"
-					/>
-				</div>
+				{sandbox === "mcp" && (
+					<div className="rounded-lg border border-border p-4 space-y-4">
+						<div className="space-y-1">
+							<p className="text-sm font-medium">MCP Sandbox Configuration</p>
+							<p className="text-xs text-muted-foreground">
+								Configure the URL and optional API key for your MCP sandbox
+								server.
+							</p>
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="mcp-sandbox-url">Server URL</Label>
+							<Input
+								id="mcp-sandbox-url"
+								type="text"
+								placeholder="http://localhost:3005/mcp"
+								value={mcpUrl}
+								onChange={(e) => setMcpUrl(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleMcpSave();
+								}}
+							/>
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="mcp-sandbox-api-key">
+								API Key{" "}
+								<span className="text-muted-foreground font-normal">
+									(optional)
+								</span>
+							</Label>
+							<Input
+								id="mcp-sandbox-api-key"
+								type="password"
+								placeholder={
+									mcpApiKeyIsSet
+										? "Key configured - enter new value to update"
+										: "Enter API key if server requires authentication"
+								}
+								value={mcpApiKey}
+								onChange={(e) => setMcpApiKey(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleMcpSave();
+								}}
+							/>
+							{mcpApiKeyIsSet && (
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-muted-foreground">
+										API key is configured
+									</span>
+									<button
+										type="button"
+										onClick={handleClearApiKey}
+										className="text-xs text-destructive hover:underline"
+									>
+										Remove
+									</button>
+								</div>
+							)}
+						</div>
+
+						<div className="flex items-center gap-3">
+							<Button
+								onClick={handleMcpSave}
+								disabled={saving || !mcpUrl.trim()}
+								size="sm"
+							>
+								{saving ? (
+									<>
+										<Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+										Saving...
+									</>
+								) : (
+									"Save"
+								)}
+							</Button>
+
+							{savedMcpUrl && (
+								<div className="flex items-center gap-1.5 text-xs">
+									{healthLoading ? (
+										<>
+											<Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+											<span className="text-muted-foreground">Checking...</span>
+										</>
+									) : isHealthy === true ? (
+										<>
+											<CheckCircle className="h-3.5 w-3.5 text-green-500" />
+											<span className="text-green-500">Connected</span>
+										</>
+									) : isHealthy === false ? (
+										<>
+											<XCircle className="h-3.5 w-3.5 text-red-500" />
+											<span className="text-red-500">Unreachable</span>
+										</>
+									) : null}
+									<button
+										type="button"
+										onClick={refresh}
+										className="text-xs text-muted-foreground hover:underline ml-1"
+									>
+										Refresh
+									</button>
+								</div>
+							)}
+						</div>
+					</div>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/frontend/src/components/status/ThreadSandboxStatus.test.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.test.tsx
@@ -20,6 +20,14 @@ vi.mock("sonner", () => ({
 	},
 }));
 
+vi.mock("@/hooks/useSandboxHealth", () => ({
+	useSandboxHealth: () => ({
+		isHealthy: null,
+		isLoading: false,
+		refresh: vi.fn(),
+	}),
+}));
+
 describe("ThreadSandboxStatus", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/frontend/src/components/status/ThreadSandboxStatus.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.tsx
@@ -26,23 +26,31 @@ import {
 	getSettings,
 	patchDefaults,
 } from "@/lib/services/userSettingsService";
+import { useSandboxHealth } from "@/hooks/useSandboxHealth";
 
 export default function ThreadSandboxStatus() {
 	const [open, setOpen] = useState(false);
 	const [sandbox, setSandbox] = useState<SandboxType>(DEFAULT_SANDBOX);
 	const [loading, setLoading] = useState(true);
 	const [providerKeys, setProviderKeys] = useState<ProviderKeyStatus[]>([]);
+	const [mcpSandboxUrl, setMcpSandboxUrl] = useState<string | null>(null);
 	const currentOption = getSandboxOption(sandbox);
+	const { isHealthy, refresh } = useSandboxHealth(mcpSandboxUrl);
 
 	const visibleOptions = useMemo(
 		() =>
 			SANDBOX_OPTIONS.filter((opt) => {
-				if (opt.value !== "daytona") return true;
-				return providerKeys.some(
-					(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
-				);
+				if (opt.value === "daytona") {
+					return providerKeys.some(
+						(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
+					);
+				}
+				if (opt.value === "mcp") {
+					return !!mcpSandboxUrl;
+				}
+				return true;
 			}),
-		[providerKeys],
+		[providerKeys, mcpSandboxUrl],
 	);
 
 	useEffect(() => {
@@ -56,6 +64,7 @@ export default function ThreadSandboxStatus() {
 
 				setSandbox(normalizeSandboxValue(res.defaults.sandbox));
 				setProviderKeys(res.provider_keys ?? []);
+				setMcpSandboxUrl(res.defaults.mcp_sandbox_url ?? null);
 			})
 			.catch(() => {
 				if (isActive) {
@@ -100,7 +109,13 @@ export default function ThreadSandboxStatus() {
 			className="flex items-center justify-start"
 			data-tour="sandbox-selector"
 		>
-			<Popover open={open} onOpenChange={setOpen}>
+			<Popover
+				open={open}
+				onOpenChange={(isOpen) => {
+					setOpen(isOpen);
+					if (isOpen) refresh();
+				}}
+			>
 				<PopoverTrigger asChild>
 					<Button
 						variant="ghost"
@@ -152,9 +167,14 @@ export default function ThreadSandboxStatus() {
 											selected ? "opacity-100" : "opacity-0",
 										)}
 									/>
-									<span className="min-w-0">
-										<span className="block text-sm font-medium">
+									<span className="min-w-0 flex-1">
+										<span className="flex items-center gap-2 text-sm font-medium">
 											{option.label}
+											{option.value === "mcp" && isHealthy !== null && (
+												<span
+													className={`h-2 w-2 rounded-full ${isHealthy ? "bg-green-500" : "bg-red-500"}`}
+												/>
+											)}
 										</span>
 										<span className="block text-xs text-muted-foreground">
 											{option.description}

--- a/frontend/src/components/status/ThreadSandboxStatus.tsx
+++ b/frontend/src/components/status/ThreadSandboxStatus.tsx
@@ -45,12 +45,9 @@ export default function ThreadSandboxStatus() {
 						(k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
 					);
 				}
-				if (opt.value === "mcp") {
-					return !!mcpSandboxUrl;
-				}
 				return true;
 			}),
-		[providerKeys, mcpSandboxUrl],
+		[providerKeys],
 	);
 
 	useEffect(() => {

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -657,6 +657,20 @@ export default function useChat(): ChatContextType {
 			return;
 		}
 
+		// Handle MCP sandbox unreachable
+		if (streamMode === "mcp_sandbox_unreachable") {
+			setLoading(false);
+			setController(null);
+			toast.error("MCP sandbox unreachable", {
+				description:
+					typeof payload[1] === "string"
+						? payload[1]
+						: "The MCP sandbox server could not be reached.",
+				duration: Infinity,
+			});
+			return;
+		}
+
 		// Handle aborted events from distributed workers
 		if (streamMode === "aborted") {
 			console.log("Stream aborted by server:", payload[1]?.reason);

--- a/frontend/src/hooks/useSandboxHealth.ts
+++ b/frontend/src/hooks/useSandboxHealth.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SandboxHealthResult {
+	isHealthy: boolean | null;
+	isLoading: boolean;
+	refresh: () => void;
+}
+
+const noop = () => {};
+
+/**
+ * Pings the health endpoint derived from the user's MCP sandbox URL.
+ * Health endpoint: strip trailing /mcp suffix, append /health.
+ */
+function deriveHealthUrl(mcpUrl: string): string {
+	const base = mcpUrl.replace(/\/mcp\/?$/, "");
+	return `${base}/health`;
+}
+
+export function useSandboxHealth(
+	mcpSandboxUrl: string | null,
+): SandboxHealthResult {
+	const [isHealthy, setIsHealthy] = useState<boolean | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const abortRef = useRef<AbortController | null>(null);
+
+	const check = useCallback(() => {
+		if (!mcpSandboxUrl) {
+			setIsHealthy(null);
+			return;
+		}
+
+		// Abort any in-flight request
+		abortRef.current?.abort();
+		const controller = new AbortController();
+		abortRef.current = controller;
+
+		setIsLoading(true);
+		const healthUrl = deriveHealthUrl(mcpSandboxUrl);
+
+		fetch(healthUrl, { signal: controller.signal })
+			.then((res) => {
+				if (!res.ok) throw new Error("not ok");
+				return res.json();
+			})
+			.then(() => {
+				if (!controller.signal.aborted) setIsHealthy(true);
+			})
+			.catch(() => {
+				if (!controller.signal.aborted) setIsHealthy(false);
+			})
+			.finally(() => {
+				if (!controller.signal.aborted) setIsLoading(false);
+			});
+	}, [mcpSandboxUrl]);
+
+	// Check on mount when URL is present
+	useEffect(() => {
+		if (mcpSandboxUrl) {
+			check();
+		} else {
+			setIsHealthy(null);
+		}
+
+		return () => {
+			abortRef.current?.abort();
+		};
+	}, [mcpSandboxUrl, check]);
+
+	if (!mcpSandboxUrl) {
+		return { isHealthy: null, isLoading: false, refresh: noop };
+	}
+
+	return { isHealthy, isLoading, refresh: check };
+}

--- a/frontend/src/hooks/useSandboxHealth.ts
+++ b/frontend/src/hooks/useSandboxHealth.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import apiClient from "@/lib/utils/apiClient";
 
 interface SandboxHealthResult {
 	isHealthy: boolean | null;
@@ -9,14 +10,9 @@ interface SandboxHealthResult {
 const noop = () => {};
 
 /**
- * Pings the health endpoint derived from the user's MCP sandbox URL.
- * Health endpoint: strip trailing /mcp suffix, append /health.
+ * Checks MCP sandbox health via backend proxy endpoint.
+ * The backend makes the actual request to the sandbox (avoids CORS / Docker networking issues).
  */
-function deriveHealthUrl(mcpUrl: string): string {
-	const base = mcpUrl.replace(/\/mcp\/?$/, "");
-	return `${base}/health`;
-}
-
 export function useSandboxHealth(
 	mcpSandboxUrl: string | null,
 ): SandboxHealthResult {
@@ -36,12 +32,10 @@ export function useSandboxHealth(
 		abortRef.current = controller;
 
 		setIsLoading(true);
-		const healthUrl = deriveHealthUrl(mcpSandboxUrl);
 
-		fetch(healthUrl, { signal: controller.signal })
-			.then((res) => {
-				if (!res.ok) throw new Error("not ok");
-				return res.json();
+		apiClient
+			.get("/settings/mcp-sandbox-health", {
+				signal: controller.signal,
 			})
 			.then(() => {
 				if (!controller.signal.aborted) setIsHealthy(true);

--- a/frontend/src/lib/config/sandbox.ts
+++ b/frontend/src/lib/config/sandbox.ts
@@ -22,12 +22,18 @@ export const SANDBOX_OPTIONS: readonly SandboxOption[] = [
 		shortLabel: "Daytona",
 		description: "Run agent code in the Daytona sandbox backend.",
 	},
+	{
+		value: "mcp",
+		label: "MCP Sandbox",
+		shortLabel: "MCP",
+		description: "Run agent code in an isolated MCP sandbox container.",
+	},
 ] as const;
 
 export function normalizeSandboxValue(
 	value: string | null | undefined,
 ): SandboxType {
-	if (value === "daytona") {
+	if (value === "daytona" || value === "mcp") {
 		return value;
 	}
 

--- a/frontend/src/lib/services/userSettingsService.ts
+++ b/frontend/src/lib/services/userSettingsService.ts
@@ -1,6 +1,6 @@
 import apiClient from "@/lib/utils/apiClient";
 
-export type SandboxType = "daytona" | "state";
+export type SandboxType = "daytona" | "state" | "mcp";
 
 export interface ProviderKeyStatus {
 	provider: string;
@@ -25,6 +25,7 @@ export interface DefaultsResponse {
 	deleted_files: string[] | null;
 	onboarding_completed: boolean | null;
 	timezone: string | null;
+	mcp_sandbox_url: string | null;
 }
 
 export interface UserSettingsResponse {
@@ -50,6 +51,7 @@ export const patchDefaults = async (
 		deleted_files: string[] | null;
 		onboarding_completed: boolean | null;
 		timezone: string | null;
+		mcp_sandbox_url: string | null;
 	}>,
 ): Promise<UserSettingsResponse> => {
 	const response = await apiClient.patch("/settings/default", data);

--- a/tasks/prd-mcp-sandbox-backend.md
+++ b/tasks/prd-mcp-sandbox-backend.md
@@ -1,0 +1,313 @@
+# PRD: McpSandboxBackend Core Class (Phase 1 -- Feature #890)
+
+## Ralph Story Mapping
+
+> This PRD covers **Ralph US-001 through US-014** (Phase 1 — McpSandboxBackend core class and unit tests).
+
+## Introduction
+
+Orchestra currently supports two sandbox backends for DeepAgents: `DaytonaSandbox` (cloud-managed via the Daytona API) and `StateBackend` (in-memory, checkpoint-based). Both are wired through `resolve_sandbox_backend()` in `backend/src/agents/__init__.py`.
+
+This PRD introduces a third option -- `McpSandboxBackend` -- that connects to the `ruska-ai/sandboxes` exec_server via the MCP (Model Context Protocol) JSON-RPC 2.0 over Streamable HTTP. The exec_server already exists (`sandboxes/ubuntu/index.js`), exposes a single `exec_command` tool on `POST /mcp`, and runs in Docker on port 3005. Today, it is only accessible through the `shell_exec` LangChain tool or via the frontend MCP configuration. This backend promotes it to a first-class sandbox that DeepAgents can use for all file operations (read, write, edit, grep, glob, ls) and command execution, just like the Daytona backend.
+
+Phase 1 covers only the `McpSandboxBackend` class and its unit tests. It does NOT wire the backend into agent construction, modify `resolve_sandbox_backend()`, or add any frontend/config changes. Those will be handled in Phase 2.
+
+## Goals
+
+- Create `McpSandboxBackend(BaseSandbox)` in `backend/src/agents/mcp_sandbox.py` that implements all 4 abstract methods required by `BaseSandbox`
+- Communicate with the exec_server using MCP JSON-RPC 2.0 over Streamable HTTP (POST to `/mcp` endpoint)
+- Manage MCP session lifecycle: lazy initialization, session ID reuse, and automatic reconnection on session expiry
+- Parse `exit_code` from the exec_server's text response using regex, since the MCP tool returns exit codes embedded in response text (not as structured fields)
+- Implement `upload_files()` and `download_files()` by encoding/decoding file content as base64 and piping through `execute()` shell commands
+- Provide a `health()` async method for checking exec_server availability
+- Achieve full unit test coverage with mocked HTTP calls -- no live exec_server required for tests
+- Follow existing codebase patterns: `httpx.Client` (sync) for HTTP, `src.utils.logger.logger` for logging, and the `DaytonaSandbox` class as the reference implementation
+
+## User Stories
+
+### US-001: McpSandboxBackend Class Skeleton and Constructor
+
+**Description:** As a developer, I need the `McpSandboxBackend` class created with a constructor that accepts the exec_server base URL and optional API key, storing them as instance attributes alongside an `httpx.Client` (sync) and session state.
+
+**Acceptance Criteria:**
+- [ ] File `backend/src/agents/mcp_sandbox.py` is created
+- [ ] Class `McpSandboxBackend` extends `BaseSandbox` (imported from `deepagents.backends.sandbox`)
+- [ ] Constructor signature: `__init__(self, *, base_url: str, api_key: str | None = None)`
+- [ ] `base_url` is stored and has its trailing slash stripped (e.g., `http://localhost:3005/` becomes `http://localhost:3005`)
+- [ ] An `httpx.Client` (sync, matching DaytonaSandbox pattern) is created and stored as `self._client` with a default timeout of 120 seconds
+- [ ] `api_key` is stored as `self._api_key` for use in the `x-api-key` header
+- [ ] Session state attributes initialized: `self._session_id: str | None = None` and `self._request_id: int = 0`
+- [ ] `self._initialized: bool = False` flag to track whether the MCP `initialize` handshake has been completed
+- [ ] `from src.utils.logger import logger` is used for all logging
+- [ ] `make format` passes with no errors on the new file
+
+### US-002: MCP Session Initialization (initialize handshake)
+
+**Description:** As a developer, I need a private method `_ensure_initialized()` that performs the MCP `initialize` handshake if it has not been done yet, obtaining and storing the `Mcp-Session-Id` for subsequent requests.
+
+**Acceptance Criteria:**
+- [ ] Private sync method `_ensure_initialized(self) -> None` is implemented
+- [ ] If `self._initialized` is `True`, the method returns immediately (no-op)
+- [ ] Sends a POST to `{base_url}/mcp` with JSON body:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": {"name": "orchestra", "version": "1.0.0"}
+    }
+  }
+  ```
+- [ ] Request includes headers: `Content-Type: application/json`, `Accept: application/json, text/event-stream`
+- [ ] If `self._api_key` is set, includes `x-api-key: {api_key}` header
+- [ ] On success (HTTP 200), extracts `Mcp-Session-Id` from response headers and stores it in `self._session_id`
+- [ ] Sets `self._initialized = True` and `self._request_id = 1` (since ID 1 was used for init)
+- [ ] After initialization, sends the `notifications/initialized` notification (no `id` field, not a request) to the same endpoint with the `Mcp-Session-Id` header
+- [ ] On HTTP error, raises `McpSandboxError` (a custom exception class defined in the same file) with a descriptive message
+- [ ] Logs the session ID at debug level on success, logs errors at error level on failure
+
+### US-003: MCP Tool Call (execute method)
+
+**Description:** As a developer, I need the `execute()` method to send shell commands to the exec_server via the MCP `tools/call` JSON-RPC method and parse the response into an `ExecuteResponse`.
+
+**Acceptance Criteria:**
+- [ ] `execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse` is implemented
+- [ ] Calls `_ensure_initialized()` before sending the tool call
+- [ ] Increments `self._request_id` and uses it as the JSON-RPC `id`
+- [ ] Sends POST to `{base_url}/mcp` with JSON body:
+  ```json
+  {
+    "jsonrpc": "2.0",
+    "id": <request_id>,
+    "method": "tools/call",
+    "params": {
+      "name": "exec_command",
+      "arguments": {"cmd": "<command>"}
+    }
+  }
+  ```
+- [ ] Includes `Mcp-Session-Id: {session_id}` header on the request
+- [ ] If `self._api_key` is set, includes `x-api-key: {api_key}` header
+- [ ] Extracts the text content from `response["result"]["content"][0]["text"]`
+- [ ] Parses exit code using regex `r'exit_code:\s*(\d+)'` on the response text; defaults to `0` if the pattern is not found (the exec_server only appends `exit_code: N` when there is an error, so absence means success)
+- [ ] Returns `ExecuteResponse(output=text, exit_code=parsed_code, truncated=False)`
+- [ ] If the HTTP request fails with a session-related error (HTTP 400 with "Invalid or missing session ID", or connection error), resets session state (`self._initialized = False`, `self._session_id = None`) and retries once by calling `_ensure_initialized()` and re-sending the tool call
+- [ ] If the retry also fails, raises `McpSandboxError`
+- [ ] If `timeout` is provided, passes it to `httpx` as the request timeout (in seconds)
+- [ ] Logs the command at debug level, errors at error level
+
+### US-004: Sandbox ID Property
+
+**Description:** As a developer, I need the `id` property to return a stable, descriptive identifier for this backend instance.
+
+**Acceptance Criteria:**
+- [ ] `@property` method `id(self) -> str` is implemented
+- [ ] Returns `f"mcp-sandbox:{self._base_url}"` (e.g., `"mcp-sandbox:http://localhost:3005"`)
+- [ ] Does not trigger network calls or session initialization
+
+### US-005: Upload Files via execute()
+
+**Description:** As a developer, I need `upload_files()` to write files to the exec_server filesystem by base64-encoding file content and piping it through shell commands via `execute()`.
+
+**Acceptance Criteria:**
+- [ ] `upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]` is implemented
+- [ ] For each `(path, content)` tuple in the input list:
+  - Base64-encodes the `content` bytes
+  - Constructs a shell command: `mkdir -p "$(dirname '{path}')" && echo '{b64_content}' | base64 -d > '{path}'`
+  - Calls `self.execute(cmd)` to run the command
+  - If `execute()` returns `exit_code == 0`, appends `FileUploadResponse(path=path, error=None)`
+  - If `execute()` returns non-zero exit code, appends `FileUploadResponse(path=path, error="permission_denied")` (best-effort error mapping)
+  - If `execute()` raises an exception, catches it and appends `FileUploadResponse(path=path, error="permission_denied")` with the error logged
+- [ ] Returns a list with one `FileUploadResponse` per input file, in the same order
+- [ ] Partial success is supported -- one file failing does not prevent others from being uploaded
+- [ ] Paths that do not start with `/` get `FileUploadResponse(path=path, error="invalid_path")` without calling execute
+
+### US-006: Download Files via execute()
+
+**Description:** As a developer, I need `download_files()` to read files from the exec_server filesystem by base64-encoding their content through shell commands via `execute()`.
+
+**Acceptance Criteria:**
+- [ ] `download_files(self, paths: list[str]) -> list[FileDownloadResponse]` is implemented
+- [ ] For each path in the input list:
+  - Constructs a shell command: `base64 '{path}'`
+  - Calls `self.execute(cmd)` to run the command
+  - If `execute()` returns `exit_code == 0`, base64-decodes the output and appends `FileDownloadResponse(path=path, content=decoded_bytes, error=None)`
+  - If `execute()` returns non-zero exit code, appends `FileDownloadResponse(path=path, content=None, error="file_not_found")` (best-effort error mapping)
+  - If `execute()` raises an exception, catches it and appends `FileDownloadResponse(path=path, content=None, error="file_not_found")` with the error logged
+- [ ] Returns a list with one `FileDownloadResponse` per input path, in the same order
+- [ ] Partial success is supported -- one file failing does not prevent others from being downloaded
+- [ ] Paths that do not start with `/` get `FileDownloadResponse(path=path, content=None, error="invalid_path")` without calling execute
+- [ ] Strips trailing whitespace from the base64 output before decoding (the exec_server may include trailing newlines in stdout)
+
+### US-007: Health Check
+
+**Description:** As a developer, I need an async `health()` method that checks whether the exec_server is reachable and responding.
+
+**Acceptance Criteria:**
+- [ ] `def health(self) -> bool` is implemented
+- [ ] Sends GET to `{base_url}/health`
+- [ ] If `self._api_key` is set, includes `x-api-key: {api_key}` header
+- [ ] Returns `True` if the response is HTTP 200 and the JSON body contains `"status": "ok"`
+- [ ] Returns `False` on any exception (`httpx.HTTPError`, `httpx.TimeoutException`, `KeyError`, etc.)
+- [ ] Uses a short timeout (5 seconds) separate from the default client timeout
+- [ ] Does not modify session state
+
+### US-008: Custom Exception Class
+
+**Description:** As a developer, I need a custom `McpSandboxError` exception for MCP-specific failures, separate from generic HTTP errors.
+
+**Acceptance Criteria:**
+- [ ] `class McpSandboxError(Exception)` is defined in `backend/src/agents/mcp_sandbox.py`
+- [ ] Accepts a `message: str` parameter
+- [ ] Used by `_ensure_initialized()` and `execute()` when MCP communication fails after retries
+
+### US-009: Client Cleanup
+
+**Description:** As a developer, I need a way to cleanly close the HTTP client and MCP session when the backend is no longer needed.
+
+**Acceptance Criteria:**
+- [ ] `def close(self) -> None` is implemented
+- [ ] If `self._session_id` is set, sends a DELETE to `{base_url}/mcp` with the `Mcp-Session-Id` header to cleanly terminate the MCP session (best-effort, exceptions are caught and logged)
+- [ ] Calls `await self._client.aclose()` to release HTTP connections
+- [ ] Resets `self._session_id = None`, `self._initialized = False`
+- [ ] Safe to call multiple times (idempotent)
+- [ ] Implements `__aenter__` and `__aexit__` for use as an async context manager (`async with McpSandboxBackend(...) as backend:`)
+
+### US-010: Unit Tests -- Constructor and ID
+
+**Description:** As a developer, I need unit tests verifying the constructor stores arguments correctly and the `id` property returns the expected format.
+
+**Acceptance Criteria:**
+- [ ] File `backend/tests/unit/agents/test_mcp_sandbox.py` is created
+- [ ] Test: constructor stores `base_url` with trailing slash stripped
+- [ ] Test: constructor stores `api_key` as `None` when not provided
+- [ ] Test: constructor stores `api_key` when provided
+- [ ] Test: `id` property returns `"mcp-sandbox:http://localhost:3005"` for base_url `"http://localhost:3005"`
+- [ ] Test: initial state has `_initialized == False` and `_session_id is None`
+- [ ] `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v` passes
+
+### US-011: Unit Tests -- MCP Initialize Handshake
+
+**Description:** As a developer, I need unit tests verifying the `_ensure_initialized()` method performs the correct HTTP calls and stores the session ID.
+
+**Acceptance Criteria:**
+- [ ] Test: `_ensure_initialized()` sends correct JSON-RPC initialize payload to `{base_url}/mcp`
+- [ ] Test: `_ensure_initialized()` extracts and stores `Mcp-Session-Id` from response headers
+- [ ] Test: `_ensure_initialized()` sets `_initialized = True` after success
+- [ ] Test: calling `_ensure_initialized()` a second time is a no-op (does not send another HTTP request)
+- [ ] Test: `_ensure_initialized()` sends `notifications/initialized` after successful init
+- [ ] Test: `_ensure_initialized()` raises `McpSandboxError` on HTTP error
+- [ ] Test: `_ensure_initialized()` includes `x-api-key` header when `api_key` is set
+- [ ] All HTTP calls are mocked using `unittest.mock.MagicMock` patching `httpx.Client.post` (sync client)
+- [ ] `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v` passes
+
+### US-012: Unit Tests -- Execute Method
+
+**Description:** As a developer, I need unit tests verifying `execute()` sends correct tool call payloads, parses exit codes from response text, and handles session reconnection.
+
+**Acceptance Criteria:**
+- [ ] Test: `execute("echo hello")` sends correct `tools/call` JSON-RPC payload with `exec_command` tool name
+- [ ] Test: `execute()` includes `Mcp-Session-Id` header in the request
+- [ ] Test: exit code is parsed from response text containing `"exit_code: 1"` -> `ExecuteResponse.exit_code == 1`
+- [ ] Test: exit code defaults to `0` when response text does not contain `exit_code` pattern (success case)
+- [ ] Test: `execute()` returns `ExecuteResponse` with correct `output` field from response text content
+- [ ] Test: when exec_server returns HTTP 400 with session error, `execute()` resets session and retries once
+- [ ] Test: when retry also fails, `execute()` raises `McpSandboxError`
+- [ ] Test: `execute()` passes `timeout` to httpx when provided
+- [ ] All HTTP calls are mocked
+- [ ] `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v` passes
+
+### US-013: Unit Tests -- Upload and Download Files
+
+**Description:** As a developer, I need unit tests verifying `upload_files()` and `download_files()` correctly encode/decode content and handle errors per-file.
+
+**Acceptance Criteria:**
+- [ ] Test: `upload_files()` calls `execute()` with the correct base64-encoding shell command for each file
+- [ ] Test: `upload_files()` returns `FileUploadResponse(error=None)` on success (exit_code 0)
+- [ ] Test: `upload_files()` returns `FileUploadResponse(error="permission_denied")` when execute returns non-zero
+- [ ] Test: `upload_files()` returns `FileUploadResponse(error="invalid_path")` for paths not starting with `/`
+- [ ] Test: `upload_files()` handles partial success (first file succeeds, second fails)
+- [ ] Test: `download_files()` calls `execute()` with `base64 '/path'` command
+- [ ] Test: `download_files()` base64-decodes the output and returns correct `content` bytes
+- [ ] Test: `download_files()` returns `FileDownloadResponse(error="file_not_found")` when execute returns non-zero
+- [ ] Test: `download_files()` returns `FileDownloadResponse(error="invalid_path")` for paths not starting with `/`
+- [ ] Test: `download_files()` strips trailing whitespace before decoding
+- [ ] `execute()` is mocked (these tests should not make real HTTP calls)
+- [ ] `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v` passes
+
+### US-014: Unit Tests -- Health Check and Cleanup
+
+**Description:** As a developer, I need unit tests verifying the `health()` method and `close()` cleanup behavior.
+
+**Acceptance Criteria:**
+- [ ] Test: `health()` returns `True` when GET `/health` returns `{"status": "ok"}`
+- [ ] Test: `health()` returns `False` when the server is unreachable (connection error)
+- [ ] Test: `health()` returns `False` when the response JSON does not contain `"status": "ok"`
+- [ ] Test: `health()` uses a 5-second timeout
+- [ ] Test: `close()` sends DELETE to `/mcp` with session ID header when session is active
+- [ ] Test: `close()` calls `_client.aclose()`
+- [ ] Test: `close()` resets `_session_id` and `_initialized`
+- [ ] Test: `close()` is safe to call when no session exists (no DELETE sent, no error)
+- [ ] Test: async context manager (`__aenter__` / `__aexit__`) calls `close()` on exit
+- [ ] All HTTP calls are mocked
+- [ ] `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v` passes
+
+## Functional Requirements
+
+- FR-1: `McpSandboxBackend` MUST extend `BaseSandbox` from `deepagents.backends.sandbox`, inheriting the 6 file operation methods (`read`, `write`, `edit`, `grep_raw`, `ls_info`, `glob_info`) that delegate to `execute()`.
+- FR-2: `execute()` MUST send JSON-RPC 2.0 `tools/call` requests to the exec_server's `/mcp` endpoint with the `exec_command` tool name and the command as the `cmd` argument.
+- FR-3: `execute()` MUST parse the exit code from the response text using the regex `r'exit_code:\s*(\d+)'`. If the pattern is not found, exit code MUST default to `0`.
+- FR-4: The MCP session MUST be lazily initialized on the first call to `execute()`. The `Mcp-Session-Id` header from the `initialize` response MUST be stored and reused for all subsequent requests.
+- FR-5: If a tool call fails due to an invalid/expired session (HTTP 400), `execute()` MUST reset session state and retry the full sequence (initialize + tool call) exactly once before raising an error.
+- FR-6: `upload_files()` MUST base64-encode file content and write it via shell commands through `execute()`. Each file MUST be handled independently so that one failure does not block others.
+- FR-7: `download_files()` MUST read file content via `base64 <path>` shell commands through `execute()` and base64-decode the output. Each file MUST be handled independently.
+- FR-8: `health()` MUST send GET to `/health` and return `True` only when the response contains `{"status": "ok"}`.
+- FR-9: `close()` MUST send DELETE to `/mcp` with the session ID (best-effort) and close the `httpx.Client`.
+- FR-10: All HTTP requests MUST include the `x-api-key` header when an API key is configured.
+- FR-11: The `id` property MUST return `"mcp-sandbox:{base_url}"` without triggering any network calls.
+- FR-12: All logging MUST use `src.utils.logger.logger` (loguru-based), consistent with the rest of the backend.
+- FR-13: A custom `McpSandboxError(Exception)` MUST be defined for MCP-specific failures and used instead of raw `httpx` exceptions in public methods.
+
+## Non-Goals (Out of Scope)
+
+- **No wiring into `resolve_sandbox_backend()`** -- Phase 2 will add `"mcp"` as a sandbox type option and modify the dispatch logic in `backend/src/agents/__init__.py`.
+- **No constants or environment variable additions** -- The `SHELL_EXEC_SERVER_URL` constant already exists. Phase 2 will decide whether to reuse it or create a new one.
+- **No `SandboxType` enum changes** -- Adding `MCP = "mcp"` to `backend/src/schemas/entities/settings.py` is Phase 2.
+- **No frontend changes** -- The sandbox type selector in the UI is a Phase 2 concern.
+- **No integration tests against a live exec_server** -- Phase 1 uses only mocked HTTP calls.
+- **No SSE/streaming support** -- The exec_server supports Streamable HTTP but the current `tools/call` responses are simple JSON. Streaming will be evaluated in a future phase if needed.
+- **No persistent session management across agent invocations** -- Each `McpSandboxBackend` instance manages its own session. Cross-request session pooling is out of scope.
+
+## Technical Considerations
+
+- **BaseSandbox contract**: `BaseSandbox` (in `deepagents.backends.sandbox`) requires exactly 4 abstract methods: `execute()`, `id` (property), `upload_files()`, `download_files()`. The other 6 methods (`read`, `write`, `edit`, `grep_raw`, `ls_info`, `glob_info`) are inherited and delegate to `execute()` via shell command templates. This means the only HTTP communication needed is through `execute()` -- all file operations are automatically handled.
+- **Sync HTTP client (RESOLVED)**: `BaseSandbox.execute()` is a synchronous method. `DaytonaSandbox` uses sync `httpx.Client`. **McpSandboxBackend must also use `httpx.Client` (sync) for consistency.** All public methods (`execute()`, `upload_files()`, `download_files()`, `health()`, `close()`) and private methods (`_ensure_initialized()`, `_call_tool()`) must be sync `def`, not `async def`. The framework's `aexecute()` wraps sync `execute()` in `asyncio.to_thread()` automatically.
+- **Exit code parsing**: The exec_server (`sandboxes/ubuntu/index.js` line 57) only appends `exit_code: N` when there is an error (`if (error) output.push(...)`). Successful commands have no exit code in the output. The regex must handle both cases: extract the code when present, default to 0 when absent.
+- **MCP session lifecycle**: The exec_server creates a new `StreamableHTTPServerTransport` per session. Sessions are identified by the `Mcp-Session-Id` header. If the server restarts or the session expires, the client gets HTTP 400. The reconnection logic (reset + retry once) handles this transparently.
+- **Auth middleware**: The exec_server checks `x-api-key` header against the `API_KEY` env var. If the env var is not set on the server, auth is disabled. The backend must support both authenticated and unauthenticated modes.
+- **Reference implementations**: `DaytonaSandbox` at `/home/ryaneggz/ruska-ai/orchestra/backend/.venv/lib/python3.12/site-packages/langchain_daytona/sandbox.py` is the closest reference -- same base class, similar method signatures. The `A2AClient` at `backend/src/common/client/client.py` shows the httpx patterns used in this codebase.
+- **File paths**: The exec_server runs commands as user `executor` with home directory `/home/executor`. Commands involving absolute paths will work as expected. The `upload_files()` and `download_files()` implementations should use shell quoting (e.g., `shlex.quote()`) on file paths to prevent injection.
+
+## Success Metrics
+
+- `McpSandboxBackend` passes `isinstance(backend, BaseSandbox)` check -- confirming it correctly extends the base class
+- `execute("echo hello")` returns `ExecuteResponse(output="stdout:\nhello\n", exit_code=0)` when tested against a mocked exec_server response
+- Exit code parsing: `"exit_code: 1"` in response text produces `exit_code=1`; absence of pattern produces `exit_code=0`
+- Session reconnection: a simulated session expiry (HTTP 400) triggers exactly one retry, and the second attempt succeeds
+- `upload_files([("/test.txt", b"hello")])` produces a shell command containing base64-encoded content and returns `FileUploadResponse(error=None)` on success
+- `download_files(["/test.txt"])` decodes base64 output and returns `FileDownloadResponse(content=b"hello")` on success
+- `health()` returns `True` for a healthy server and `False` for an unreachable one
+- All unit tests pass: `uv run pytest backend/tests/unit/agents/test_mcp_sandbox.py -v`
+- Full test suite unaffected: `make test` passes with no regressions
+- Lint passes: `make format` and `make lint` produce no errors
+
+## Open Questions
+
+1. **~~Sync or async `execute()`?~~** RESOLVED: Use sync `httpx.Client` to match `DaytonaSandbox` pattern. `BaseSandbox.execute()` is sync; the framework wraps it in `asyncio.to_thread()` automatically via `aexecute()`.
+2. **Should `close()` be called automatically?** Phase 2 will wire this into `resolve_sandbox_backend()`. Should the cleanup happen in a `finally` block (like Daytona's `sandbox.stop()`) or should we rely on the async context manager pattern?
+3. **Should the default timeout (120s) match the exec_server's timeout (120s)?** The exec_server's `exec()` call has a 120-second timeout. The httpx client timeout should be >= this to avoid premature client-side timeouts while the server is still processing.
+4. **Base64 encoding for large files in `upload_files()`**: The current approach pipes base64-encoded content through a shell command. For very large files, this could hit shell argument limits. The `BaseSandbox.write()` method already handles this via heredoc templates -- should `upload_files()` use a similar heredoc approach, or is the base64 pipe sufficient for expected file sizes?
+5. **~~Should the backend accept `base_url` only, or a full URL with `/mcp` path?~~** RESOLVED: Accept `base_url` only (e.g., `http://localhost:3005`), append `/mcp` internally. This matches the exec_server structure where `/health` and `/mcp` are sibling routes.

--- a/tasks/prd-mcp-sandbox-dispatch.md
+++ b/tasks/prd-mcp-sandbox-dispatch.md
@@ -1,0 +1,236 @@
+# PRD: MCP Sandbox Dispatch Wiring (Phase 2 — Feature #890)
+
+## Ralph Story Mapping
+
+> This PRD covers **Ralph US-015 through US-023** (Phase 2 — Sandbox dispatch wiring).
+
+## Introduction
+
+Wire `McpSandboxBackend` into the existing extensible sandbox dispatch system so that users can run code execution through a remote MCP sandbox server. The MCP sandbox URL is user-configurable via the Settings page (stored in `UserSettings`), not a hardcoded environment variable. This phase updates the fallback chain to: Daytona -> MCP (if URL configured) -> State, and threads the MCP sandbox URL through all three agent execution paths (invoke, stream, worker).
+
+**Dependency:** Phase 1 of Feature #890 must be completed first — it delivers the `McpSandboxBackend` class that this phase wires into the dispatch system.
+
+## Goals
+
+- Add `MCP = "mcp"` to the `SandboxType` enum and register it in the sandbox factory registry
+- Store a user-configurable `mcp_sandbox_url` in `UserSettings`, readable and writable via the existing settings API
+- Update `resolve_sandbox_backend()` to support MCP in the fallback chain: Daytona -> MCP (if URL configured) -> State
+- Thread `mcp_sandbox_url` through all three execution paths: `LLMController` (invoke + stream), `stream_generator`, and `_execute_agent_stream` (worker)
+- Add MCP-specific error handling with `is_mcp_sandbox_error()` helper and `mcp_sandbox_unreachable` SSE error type
+- Maintain full backward compatibility — existing Daytona and State flows must be completely unaffected
+
+## User Stories
+
+### US-001: Add MCP to SandboxType enum and UserSettings schema
+
+**Description:** As a developer, I need the `SandboxType` enum extended with `MCP = "mcp"` and a new `default_mcp_sandbox_url` field on `UserSettings` so the system has typed, validated representation of MCP sandbox configuration.
+
+**Acceptance Criteria:**
+- [ ] `MCP = "mcp"` added to `SandboxType` enum in `backend/src/schemas/entities/settings.py`
+- [ ] `default_mcp_sandbox_url: Optional[str] = Field(default=None, description="User's MCP sandbox server URL")` added to `UserSettings`
+- [ ] Existing `SandboxType.DAYTONA` and `SandboxType.STATE` values are unchanged
+- [ ] `make format` passes
+- [ ] `make lint` passes
+
+### US-002: Add mcp_sandbox_url to API schemas
+
+**Description:** As an API consumer, I need `mcp_sandbox_url` exposed in the settings response and patchable via the defaults endpoint so the frontend (Phase 3+) or API clients can read and write the URL.
+
+**Acceptance Criteria:**
+- [ ] `mcp_sandbox_url: Optional[str] = None` added to `DefaultsResponse` in `backend/src/schemas/entities/settings.py`
+- [ ] `mcp_sandbox_url: Optional[str] = Field(default=None, description="MCP sandbox server URL, or null to clear")` added to `PatchDefaultsRequest`
+- [ ] `mcp_sandbox_url` field is included in `_build_response()` mapping in `backend/src/routes/v0/settings.py` (maps `settings.default_mcp_sandbox_url` to `defaults.mcp_sandbox_url`)
+- [ ] `"mcp_sandbox_url": "default_mcp_sandbox_url"` added to `_DEFAULTS_FIELD_MAP` in `UserSettingsRepo`
+- [ ] `PATCH /settings/default` with `{"mcp_sandbox_url": "http://localhost:3005"}` stores the value and returns it in the response
+- [ ] `PATCH /settings/default` with `{"mcp_sandbox_url": null}` clears the value
+- [ ] `GET /settings` includes `mcp_sandbox_url` in the `defaults` object
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+### US-003: Add MCP sandbox factory and register in _SANDBOX_FACTORIES
+
+**Description:** As a developer, I need a `_create_mcp_backend_checked()` factory function and its registration in the sandbox factory registry so that `resolve_sandbox_backend()` can create MCP-backed `CompositeBackend` instances.
+
+**Acceptance Criteria:**
+- [ ] `_create_mcp_backend_checked(runtime, mcp_sandbox_url)` factory added to `backend/src/agents/__init__.py`
+- [ ] Factory returns `(CompositeBackend, None)` on success, `None` when URL is missing or `McpSandboxBackend` cannot be instantiated
+- [ ] Factory imports `McpSandboxBackend` from the Phase 1 module (conditional import, safe when not installed)
+- [ ] `"mcp"` key added to `_SANDBOX_FACTORIES` dict, pointing to the factory callable
+- [ ] Factory validates that `mcp_sandbox_url` is a non-empty string before attempting instantiation
+- [ ] `make format` passes
+- [ ] `make lint` passes
+
+### US-004: Update resolve_sandbox_backend() with MCP dispatch rules
+
+**Description:** As a developer, I need `resolve_sandbox_backend()` to accept an `mcp_sandbox_url` parameter and implement the updated fallback chain so MCP is tried between Daytona and State when the URL is configured.
+
+**Acceptance Criteria:**
+- [ ] `resolve_sandbox_backend()` signature updated: `resolve_sandbox_backend(runtime, sandbox_type=None, mcp_sandbox_url=None)`
+- [ ] Dispatch rules implemented:
+  - `None` / `"auto"` -> try Daytona, then MCP (if `mcp_sandbox_url` is set), then State
+  - `"state"` -> StateBackend directly (no Daytona, no MCP)
+  - `"daytona"` -> try Daytona, fallback to State (unchanged from current behavior)
+  - `"mcp"` -> try MCP (if `mcp_sandbox_url` is set), fallback to State
+  - Unknown value -> treated as `"auto"`
+- [ ] Return type remains `tuple[CompositeBackend, Any, str]` where third element is `"daytona"`, `"mcp"`, or `"state"`
+- [ ] When `sandbox_type="mcp"` but `mcp_sandbox_url` is `None`/empty, falls back to State (no error)
+- [ ] Existing Daytona and State dispatch paths are completely unmodified for non-MCP sandbox types
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+### US-005: Add MCP error handling helpers
+
+**Description:** As a developer, I need an `is_mcp_sandbox_error()` helper function and an `mcp_sandbox_unreachable` SSE error type so MCP failures are identifiable and can trigger appropriate fallback or user-facing error messages.
+
+**Acceptance Criteria:**
+- [ ] `is_mcp_sandbox_error(exc: Exception) -> bool` added to `backend/src/agents/__init__.py`
+- [ ] Helper checks for connection errors (e.g., `ConnectionError`, `TimeoutError`, `OSError`) when communicating with the MCP sandbox URL
+- [ ] Helper returns `False` when MCP is not involved (safe no-op)
+- [ ] `mcp_sandbox_unreachable` error type defined as a constant string for SSE error events
+- [ ] `make format` passes
+- [ ] `make lint` passes
+
+### US-006: Wire mcp_sandbox_url through LLMController
+
+**Description:** As a user, I want my MCP sandbox URL applied when I invoke or stream an agent, so my configured MCP sandbox is used in all execution paths.
+
+**Acceptance Criteria:**
+- [ ] `_resolve_user_settings()` returns 4-tuple `(model, api_key, default_sandbox, mcp_sandbox_url)` instead of current 3-tuple
+- [ ] `mcp_sandbox_url` read from the already-fetched `settings` object via `settings.default_mcp_sandbox_url`
+- [ ] `mcp_sandbox_url` passed to `resolve_sandbox_backend(runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url)` in `llm_invoke()`
+- [ ] `mcp_sandbox_url` passed through to `stream_generator()` in `llm_stream()`
+- [ ] MCP error handling added to `llm_invoke()` exception handler, mirroring the existing Daytona error pattern:
+  - `sandbox_type="mcp"` -> surface the error
+  - `sandbox_type=None/"auto"` with `effective_type="mcp"` -> fallback to State and retry
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+### US-007: Wire mcp_sandbox_url through stream_generator
+
+**Description:** As a developer, I need `stream_generator()` to accept and forward the MCP sandbox URL so streaming execution uses the correct backend.
+
+**Acceptance Criteria:**
+- [ ] `mcp_sandbox_url: str | None = None` parameter added to `stream_generator()` signature
+- [ ] Parameter passed to `resolve_sandbox_backend(runtime, sandbox_type=sandbox_type, mcp_sandbox_url=mcp_sandbox_url)`
+- [ ] MCP error handling added to the exception handler in `stream_generator()`:
+  - `sandbox_type="mcp"` -> emit `mcp_sandbox_unreachable` SSE error event
+  - `sandbox_type=None/"auto"` with `effective_type="mcp"` -> fallback to State and retry stream
+- [ ] SSE error event format: `("mcp_sandbox_unreachable", "<detail>")` — follows existing `("error", str(e))` tuple pattern but with distinct type for frontend toast handling
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+### US-008: Wire mcp_sandbox_url through worker tasks
+
+**Description:** As a developer, I need `_execute_agent_stream()` in the distributed worker to read and forward the MCP sandbox URL from user settings.
+
+**Acceptance Criteria:**
+- [ ] `settings.default_mcp_sandbox_url` read from the already-fetched settings object in `_execute_agent_stream()`
+- [ ] Value passed to `resolve_sandbox_backend(runtime, sandbox_type=default_sandbox, mcp_sandbox_url=mcp_sandbox_url)`
+- [ ] MCP error handling added to the exception handler, mirroring the existing Daytona error pattern:
+  - `sandbox_type="mcp"` -> write `mcp_sandbox_unreachable` error to Redis stream
+  - `sandbox_type=None/"auto"` with `effective_type="mcp"` -> fallback to State and retry
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+### US-009: Integration validation
+
+**Description:** As a developer, I need to verify that the full MCP sandbox dispatch pipeline works end-to-end via curl commands against the running API.
+
+**Acceptance Criteria:**
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes (all existing tests green, no regressions)
+- [ ] Verify `GET /settings` returns `mcp_sandbox_url: null` for a user with no URL configured
+- [ ] Verify `PATCH /settings/default` with `{"mcp_sandbox_url": "http://localhost:3005"}` stores the URL
+- [ ] Verify `GET /settings` returns the stored `mcp_sandbox_url` value
+- [ ] Verify `PATCH /settings/default` with `{"sandbox": "mcp"}` sets the sandbox type to `"mcp"`
+- [ ] Verify `PATCH /settings/default` with `{"mcp_sandbox_url": null}` clears the URL
+- [ ] Verify that when `sandbox="mcp"` but no URL is configured, agent execution falls back to State without error
+- [ ] Verify that when `sandbox="auto"` (or null), existing Daytona/State behavior is unchanged
+- [ ] Provide curl examples:
+  ```bash
+  # Login
+  curl -X POST http://localhost:8000/api/auth/login \
+    -H "Content-Type: application/json" \
+    -d '{"email": "admin@example.com", "password": "test1234"}'
+
+  # Set MCP sandbox URL
+  curl -X PATCH http://localhost:8000/api/v0/settings/default \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <token>" \
+    -d '{"mcp_sandbox_url": "http://localhost:3005"}'
+
+  # Set sandbox type to mcp
+  curl -X PATCH http://localhost:8000/api/v0/settings/default \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <token>" \
+    -d '{"sandbox": "mcp"}'
+
+  # Read settings
+  curl -X GET http://localhost:8000/api/v0/settings \
+    -H "Authorization: Bearer <token>"
+
+  # Clear MCP sandbox URL
+  curl -X PATCH http://localhost:8000/api/v0/settings/default \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <token>" \
+    -d '{"mcp_sandbox_url": null}'
+  ```
+
+## Functional Requirements
+
+- **FR-1:** The `SandboxType` enum must include `MCP = "mcp"` alongside existing `DAYTONA` and `STATE` values
+- **FR-2:** `UserSettings` must store a `default_mcp_sandbox_url: Optional[str]` field for the user's MCP sandbox server URL
+- **FR-3:** `GET /settings` must include `mcp_sandbox_url` in the `defaults` response object
+- **FR-4:** `PATCH /settings/default` must accept `mcp_sandbox_url` to set or clear the URL
+- **FR-5:** `PATCH /settings/default` must accept `sandbox: "mcp"` as a valid sandbox type
+- **FR-6:** `resolve_sandbox_backend()` must accept an `mcp_sandbox_url` parameter and implement the dispatch rules:
+  - `None`/`"auto"` -> Daytona -> MCP (if URL) -> State
+  - `"state"` -> State only
+  - `"daytona"` -> Daytona -> State
+  - `"mcp"` -> MCP (if URL) -> State
+- **FR-7:** When `sandbox_type="mcp"` but no URL is configured, the system must fall back to State silently (no crash)
+- **FR-8:** `is_mcp_sandbox_error()` must correctly identify MCP sandbox connection failures
+- **FR-9:** MCP errors in SSE streams must use the `mcp_sandbox_unreachable` error type
+- **FR-10:** All three execution paths (invoke, stream, worker) must read `mcp_sandbox_url` from user settings and pass it to the dispatch function
+- **FR-11:** When auto mode selects MCP and it fails at runtime, the system must fall back to State and retry (mirroring Daytona auto-fallback behavior)
+
+## Non-Goals (Out of Scope)
+
+- **No frontend UI for MCP sandbox settings** — frontend components for configuring `mcp_sandbox_url` are deferred to Phase 3+
+- **No native MCP tool integration** — this phase wires the sandbox backend only, not MCP tool discovery or registration
+- **No exec_server changes** — the MCP sandbox server itself is not modified; we only consume its URL
+- **No URL validation or health checks** — the URL is stored as-is; connectivity is tested at dispatch time, not at save time
+- **No per-assistant or per-chat MCP URL overrides** — the URL is per-user only (stored in `UserSettings`)
+- **No migration of existing data** — the new field defaults to `None` which means MCP is not available
+- **No hardcoded `MCP_SANDBOX_URL` environment variable** — the URL comes exclusively from user settings
+
+## Technical Considerations
+
+- **Phase 1 dependency:** `McpSandboxBackend` must exist before this phase can be implemented. The import should be conditional (try/except) to avoid breaking the app when Phase 1 is not yet merged.
+- **Regression safety:** Existing Daytona and State dispatch paths must remain completely untouched for users who do not configure an MCP sandbox URL. The `resolve_sandbox_backend()` changes should be additive — when `mcp_sandbox_url` is `None`, the function behaves identically to its current implementation.
+- **URL source:** The MCP sandbox URL is stored in `UserSettings.default_mcp_sandbox_url` and read through the same `settings_repo._get_or_create()` call that already fetches `default_sandbox`, `default_model`, etc. No additional database queries are needed.
+- **Error handling pattern:** MCP errors follow the same pattern as Daytona errors — a type-checking helper (`is_mcp_sandbox_error()`) and branching logic in each execution path's exception handler. The `mcp_sandbox_unreachable` error type allows the frontend to display a targeted error message (e.g., "Your MCP sandbox server is unreachable").
+- **Factory signature (RESOLVED):** `_create_mcp_backend_checked(runtime, mcp_sandbox_url)` takes 2 params unlike `_create_daytona_backend_checked(runtime)` (1 param) because the URL comes from user settings, not an env var. **The MCP factory should be special-cased in `resolve_sandbox_backend()`** rather than forced into the generic `_SANDBOX_FACTORIES` single-param dispatch. The `_SANDBOX_FACTORIES` dict can include `"mcp"` for type-recognition purposes, but the actual MCP factory call happens directly in the resolver with the extra `mcp_sandbox_url` param.
+- **3 caller sites** must be updated: `LLMController._resolve_user_settings()` + `llm_invoke()` + `llm_stream()`, `stream_generator()`, and `_execute_agent_stream()`. All three already fetch user settings; we read one more field (`default_mcp_sandbox_url`) and pass it through.
+- **Redis cache compatibility:** The new `default_mcp_sandbox_url` field on `UserSettings` is `Optional[str]` with default `None`, so existing cached settings will deserialize correctly via Pydantic's `model_validate()`.
+
+## Success Metrics
+
+- `PATCH /settings/default` with `{"sandbox": "mcp", "mcp_sandbox_url": "http://..."}` succeeds and is reflected in subsequent `GET /settings` responses
+- `resolve_sandbox_backend(runtime, sandbox_type="mcp", mcp_sandbox_url="http://...")` returns an MCP-backed `CompositeBackend` with `effective_type="mcp"`
+- `resolve_sandbox_backend(runtime, sandbox_type="mcp", mcp_sandbox_url=None)` falls back to State gracefully
+- `resolve_sandbox_backend(runtime, sandbox_type=None, mcp_sandbox_url="http://...")` tries Daytona first, then MCP, then State
+- All existing tests pass with zero modifications (no regressions)
+- `make format`, `make lint`, and `make test` all pass at every user story boundary
+
+## Open Questions
+
+- Should `_create_mcp_backend_checked()` perform a lightweight health-check ping to the MCP URL during dispatch (adds latency but catches unreachable servers early), or defer failure to the first tool execution?
+- Should invalid URLs (e.g., missing scheme, non-HTTP) be rejected at `PATCH /settings/default` time with a 400, or stored as-is and validated only at dispatch?
+- ~~If Phase 1 introduces a specific exception type for MCP sandbox errors (e.g., `McpSandboxError`), should `is_mcp_sandbox_error()` check for that type?~~ RESOLVED: Yes, `is_mcp_sandbox_error()` should check for `McpSandboxError` (from Phase 1) in addition to generic connection errors (`ConnectionError`, `TimeoutError`, `OSError`). That is the helper's purpose.

--- a/tasks/prd-mcp-sandbox-exec-server.md
+++ b/tasks/prd-mcp-sandbox-exec-server.md
@@ -1,0 +1,325 @@
+# PRD: exec_server BaseSandbox-Conformant MCP Tools (Phase 4 — Feature #890)
+
+## Ralph Story Mapping
+
+> This PRD covers **Ralph US-024 through US-035** (Phase 4 — exec_server structured tools).
+> **Note**: Phase 4 operates in the `sandboxes/` submodule (`ruska-ai/sandboxes` repo). Ralph cannot commit to the submodule, build Docker images, or start containers. Phase 4 stories should be executed manually or in a separate Ralph run targeting the sandboxes repo.
+
+## Introduction
+
+Enhance `sandboxes/ubuntu/index.js` to expose MCP tools that mirror the full `BaseSandbox` protocol 1:1, making the exec_server a drop-in sandbox backend for DeepAgents. This involves renaming `exec_command` to `execute`, adding 8 new tools (`read`, `write`, `edit`, `grep`, `glob`, `ls`, `upload_file`, `download_file`), adding structured `_meta` with `exit_code` and `sandbox_id` to every tool response, and creating a conformance test suite that validates the entire contract.
+
+Phase 4 is **independent** and can be built in parallel with Phases 1, 2, and 3. All work is scoped to the `sandboxes/` submodule, which lives in the separate `ruska-ai/sandboxes` repository.
+
+**GitHub Feature:** [#890](https://github.com/ruska-ai/orchestra/issues/890)
+
+**4 files touched: 3 modified, 1 created.**
+
+| File | Action |
+|------|--------|
+| `sandboxes/ubuntu/index.js` | MODIFY — rename `exec_command`, add 8 tools, add `_meta`, add `sandbox_id` |
+| `sandboxes/ubuntu/Dockerfile` | MODIFY — install `python3`, create `/workspace` directory structure |
+| `sandboxes/ubuntu/entrypoint.sh` | MODIFY — create `/workspace` OpenClaw layout on container startup |
+| `sandboxes/tests/conformance.sh` | CREATE — full conformance test suite for all 9 tools |
+
+## Goals
+
+- Rename `exec_command` to `execute` as a clean break (no backward-compat alias)
+- Implement 8 new MCP tools (`read`, `write`, `edit`, `grep`, `glob`, `ls`, `upload_file`, `download_file`) that mirror the BaseSandbox protocol
+- Add structured `_meta` (containing `exit_code` as integer and `sandbox_id` as UUID) to every tool response
+- Establish `/workspace` as the default working directory with the OpenClaw layout (`AGENTS.md`, `SOUL.md`, etc.)
+- Ensure `python3` is available inside the container for agent workloads
+- Create a conformance test suite (`tests/conformance.sh`) that validates all 9 tools, exit-code semantics, sandbox identity, and session lifecycle
+- All tool handlers must execute commands as the unprivileged `executor` user
+
+## User Stories
+
+### US-001: Rename `exec_command` to `execute`
+**Description:** As a sandbox consumer, I need the shell execution tool renamed from `exec_command` to `execute` so it aligns with the BaseSandbox protocol naming convention.
+
+**Acceptance Criteria:**
+- [ ] `exec_command` tool registration replaced with `execute` in `registerTools()`, with `exec_command` kept as a backward-compat alias (same handler) to prevent breakage between Phase 4 and Phase 5 deploys
+- [ ] Tool accepts `{cmd: string, timeout?: number}` via Zod schema
+- [ ] `timeout` parameter is optional; defaults to 120s, capped at 120s max
+- [ ] Text-embedded `exit_code: N` preserved in output text for backward compatibility with Phase 1 consumers
+- [ ] Tool handler runs commands as `executor` user (uid/gid)
+- [ ] `tools/list` MCP response shows `execute` (not `exec_command`)
+- [ ] `exec_command` registered as backward-compat alias (same `executeHandler` function) — prevents breakage during Phase 4→5 rollout window
+
+### US-002: Add `_meta` Structure to All Tool Responses
+**Description:** As a sandbox consumer, I need every tool response to include a structured `_meta` object containing `exit_code` (integer) and `sandbox_id` (UUID) so I can programmatically inspect tool outcomes without parsing text output.
+
+**Acceptance Criteria:**
+- [ ] `SANDBOX_ID` constant generated once at module load via `crypto.randomUUID()`
+- [ ] Helper function `makeResult(text, exitCode)` returns `{content: [{type: "text", text}], _meta: {exit_code: exitCode, sandbox_id: SANDBOX_ID}}`
+- [ ] `_meta.exit_code` is always an integer (not a string)
+- [ ] `_meta.sandbox_id` is the same UUID for every response within a server process lifetime
+- [ ] All 9 tool handlers use `makeResult()` for their return value
+- [ ] `execute` tool includes both text-embedded `exit_code: N` in content AND `_meta.exit_code` as structured integer
+
+### US-003: Implement `read` Tool
+**Description:** As a sandbox consumer, I need a `read` tool to retrieve file contents with line numbers (cat -n format), supporting offset and line-limit pagination.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `read` with description "Read file with line numbers"
+- [ ] Params: `{path: z.string(), offset: z.number().optional(), limit: z.number().optional()}`
+- [ ] Returns file content in `cat -n` format: right-justified line numbers + tab + content per line
+- [ ] `offset`: 0-based line offset, defaults to 0
+- [ ] `limit`: maximum lines to return, defaults to 2000
+- [ ] `_meta.exit_code`: 0 on success, 1 if file not found or unreadable
+- [ ] Runs as `executor` user; cannot read files outside executor's permissions
+
+### US-004: Implement `write` Tool
+**Description:** As a sandbox consumer, I need a `write` tool that creates or overwrites files, automatically creating parent directories.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `write` with description "Write content to file"
+- [ ] Params: `{path: z.string(), content: z.string()}`
+- [ ] Creates parent directories with `mkdir -p` before writing
+- [ ] Overwrites file if it already exists
+- [ ] `_meta.exit_code`: 0 on success, 1 on error (permission denied, disk full, etc.)
+- [ ] Runs as `executor` user
+
+### US-005: Implement `edit` Tool
+**Description:** As a sandbox consumer, I need an `edit` tool that performs string replacement in files with exit-code semantics matching the BaseSandbox `_EDIT_COMMAND_TEMPLATE`.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `edit` with description "Replace string in file"
+- [ ] Params: `{path: z.string(), old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional()}`
+- [ ] Exit code 0: replacement made successfully
+- [ ] Exit code 1: `old_string` not found in file
+- [ ] Exit code 2: `old_string` found multiple times and `replace_all` is false (ambiguous match)
+- [ ] Exit code 3: file not found at `path`
+- [ ] When `replace_all` is true, replaces all occurrences (exit code 0, never 2)
+- [ ] Returns occurrence count as text content
+- [ ] Runs as `executor` user
+
+### US-006: Implement `grep` Tool
+**Description:** As a sandbox consumer, I need a `grep` tool that searches files for a fixed-string pattern and returns structured JSON lines output.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `grep` with description "Search for pattern in files"
+- [ ] Params: `{pattern: z.string(), path: z.string().optional(), glob: z.string().optional()}`
+- [ ] Uses fixed-string search (`grep -rHnF` or equivalent)
+- [ ] Default search path: `/workspace`
+- [ ] Returns newline-delimited JSON objects: `{"path": "...", "line": N, "text": "..."}`
+- [ ] `_meta.exit_code`: 0 when matches found, 1 when no matches
+- [ ] `glob` parameter filters files by pattern (e.g., `"*.js"`)
+- [ ] Runs as `executor` user
+
+### US-007: Implement `glob` Tool
+**Description:** As a sandbox consumer, I need a `glob` tool that finds files matching a glob pattern and returns file metadata as structured JSON lines.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `glob` with description "Find files by glob pattern"
+- [ ] Params: `{pattern: z.string(), path: z.string().optional()}`
+- [ ] Default search path: `/workspace`
+- [ ] Returns newline-delimited JSON objects: `{"path": "...", "is_dir": bool, "size": N, "mtime": "ISO"}`
+- [ ] `_meta.exit_code`: 0 on success
+- [ ] Runs as `executor` user
+
+### US-008: Implement `ls` Tool
+**Description:** As a sandbox consumer, I need an `ls` tool that lists directory contents as structured JSON lines.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `ls` with description "List directory contents"
+- [ ] Params: `{path: z.string()}`
+- [ ] Returns newline-delimited JSON objects: `{"path": "...", "is_dir": bool}`
+- [ ] `_meta.exit_code`: 0 on success, 1 if path not found
+- [ ] Runs as `executor` user
+
+### US-009: Implement `upload_file` Tool
+**Description:** As a sandbox consumer, I need an `upload_file` tool that decodes base64-encoded content and writes it as a binary file.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `upload_file` with description "Upload base64 file"
+- [ ] Params: `{path: z.string(), content_base64: z.string()}`
+- [ ] Decodes base64 content and writes binary file
+- [ ] Creates parent directories with `mkdir -p`
+- [ ] Returns text: `"Written N bytes to <path>"`
+- [ ] `_meta.exit_code`: 0 on success, 1 on error (invalid base64, permission denied, etc.)
+- [ ] Runs as `executor` user
+
+### US-010: Implement `download_file` Tool
+**Description:** As a sandbox consumer, I need a `download_file` tool that reads a file and returns its content as base64-encoded text.
+
+**Acceptance Criteria:**
+- [ ] Tool registered as `download_file` with description "Download file as base64"
+- [ ] Params: `{path: z.string()}`
+- [ ] Returns base64-encoded file content as text
+- [ ] `_meta.exit_code`: 0 on success, 1 if file not found
+- [ ] Runs as `executor` user
+
+### US-011: Infrastructure — Sandbox ID, Python3, /workspace
+**Description:** As a sandbox operator, I need the container to have a stable sandbox identity, Python3 runtime, and an OpenClaw-structured `/workspace` directory so agents have a consistent, capable execution environment.
+
+**Acceptance Criteria:**
+- [ ] `SANDBOX_ID` generated via `crypto.randomUUID()` once at server startup
+- [ ] `/health` endpoint returns `{"status": "ok", "sessions": N, "sandbox_id": "<uuid>"}`
+- [ ] `python3` is available in the container (Dockerfile installs `python3` if not already present in `debian:bookworm-slim`)
+- [ ] `/workspace` directory created and owned by `executor` user
+- [ ] OpenClaw layout created on container startup in `entrypoint.sh`:
+  - `/workspace/AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, `MEMORY.md` (empty template files)
+  - `/workspace/memory/`, `/workspace/skills/`, `/workspace/canvas/` (directories)
+- [ ] Default `cwd` in all `exec()` calls changed from `/home/executor` to `/workspace`
+- [ ] `WORKDIR` in Dockerfile updated to `/workspace`
+- [ ] All `/workspace` contents are writable by `executor` user
+
+### US-012: Conformance Test Suite
+**Description:** As a developer, I need a conformance test suite that validates the full MCP tool contract so any sandbox passing the suite is guaranteed to be a drop-in DeepAgents backend.
+
+**Acceptance Criteria:**
+- [ ] `sandboxes/tests/conformance.sh` created
+- [ ] Accepts server URL as first argument: `bash tests/conformance.sh http://localhost:3005`
+- [ ] Tests health check returns `status: ok` and `sandbox_id`
+- [ ] Tests session initialization returns `Mcp-Session-Id` header
+- [ ] Tests `tools/list` returns exactly 9 tools with correct names
+- [ ] Tests `execute` tool: success case (exit_code=0), failure case (non-zero exit_code), text-embedded exit_code present
+- [ ] Tests `read` tool: success (cat -n format, exit_code=0), file not found (exit_code=1)
+- [ ] Tests `write` tool: creates file (exit_code=0), parent dir creation
+- [ ] Tests `edit` tool: all 4 exit codes (0=success, 1=not found, 2=multiple matches, 3=file missing)
+- [ ] Tests `grep` tool: matches found (exit_code=0, JSON lines), no matches (exit_code=1)
+- [ ] Tests `glob` tool: returns JSON lines with metadata
+- [ ] Tests `ls` tool: returns JSON lines, path not found (exit_code=1)
+- [ ] Tests `upload_file` and `download_file`: binary round-trip preserves content
+- [ ] Tests `python3 --version` succeeds via `execute` tool
+- [ ] Tests `pwd` returns `/workspace` via `execute` tool
+- [ ] Tests OpenClaw layout files exist (`AGENTS.md`, `SOUL.md`, etc.)
+- [ ] Tests session reuse: multiple calls on same session succeed
+- [ ] Tests session cleanup: `DELETE /mcp` removes session
+- [ ] Output format: `PASS: <test_name>` or `FAIL: <test_name> - <reason>`
+- [ ] Summary at end: `N/M tests passed`
+- [ ] Exit code 0 if all pass, 1 if any fail
+
+## Functional Requirements
+
+### FR-1: `execute` Tool
+The `execute` tool replaces `exec_command`. It accepts `{cmd: string, timeout?: number}` and runs the command as the `executor` user with cwd `/workspace`. Timeout defaults to 120s, capped at 120s max. Output includes text-embedded `exit_code: N` for backward compatibility and `_meta.exit_code` as a structured integer.
+
+### FR-2: `read` Tool
+Accepts `{path, offset?, limit?}`. Reads the file and returns content in `cat -n` format (right-justified line numbers, tab-separated). Offset is 0-based (default 0), limit defaults to 2000 lines. Returns `_meta.exit_code` 0 on success, 1 if the file does not exist or is unreadable.
+
+### FR-3: `write` Tool
+Accepts `{path, content}`. Creates parent directories (`mkdir -p`), writes content (overwrites existing files). Returns `_meta.exit_code` 0 on success, 1 on any error.
+
+### FR-4: `edit` Tool
+Accepts `{path, old_string, new_string, replace_all?}`. Reads the file, counts occurrences of `old_string`, and applies exit-code semantics:
+- 0: replacement made
+- 1: `old_string` not found in file
+- 2: `old_string` found multiple times and `replace_all` is false
+- 3: file does not exist
+
+When `replace_all` is true, all occurrences are replaced (exit code 0, never 2). Returns occurrence count as text.
+
+### FR-5: `grep` Tool
+Accepts `{pattern, path?, glob?}`. Performs fixed-string recursive search (equivalent to `grep -rHnF`). Default path is `/workspace`. Returns newline-delimited JSON objects `{path, line, text}`. `_meta.exit_code` is 0 when matches are found, 1 when no matches.
+
+### FR-6: `glob` Tool
+Accepts `{pattern, path?}`. Finds files matching the glob pattern under the specified path (default `/workspace`). Returns newline-delimited JSON objects `{path, is_dir, size, mtime}` where `mtime` is ISO 8601. `_meta.exit_code` is 0 on success.
+
+### FR-7: `ls` Tool
+Accepts `{path}`. Lists directory contents. Returns newline-delimited JSON objects `{path, is_dir}`. `_meta.exit_code` is 0 on success, 1 if path does not exist.
+
+### FR-8: `upload_file` Tool
+Accepts `{path, content_base64}`. Decodes base64, creates parent directories, writes binary content. Returns `"Written N bytes to <path>"`. `_meta.exit_code` is 0 on success, 1 on error.
+
+### FR-9: `download_file` Tool
+Accepts `{path}`. Reads file and returns base64-encoded content as text. `_meta.exit_code` is 0 on success, 1 if file not found.
+
+### FR-10: Structured `_meta` in All Responses
+Every tool response includes `_meta: {exit_code: <int>, sandbox_id: "<uuid>"}`. `exit_code` is always an integer. `sandbox_id` is a UUID generated once at server startup and is consistent across all responses for the lifetime of the process.
+
+### FR-11: Sandbox Identity
+A `SANDBOX_ID` is generated via `crypto.randomUUID()` at server startup. It appears in the `/health` endpoint response (`{"status": "ok", "sessions": N, "sandbox_id": "<uuid>"}`) and in every tool response `_meta`.
+
+### FR-12: Python3 Availability
+The Dockerfile installs `python3` (via `apt-get install -y --no-install-recommends python3`). Agents can execute Python scripts via the `execute` tool.
+
+### FR-13: `/workspace` Default Working Directory
+The default cwd changes from `/home/executor` to `/workspace`. The Dockerfile creates `/workspace` and sets ownership to `executor`. The entrypoint creates the OpenClaw layout on startup:
+- Files: `AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, `MEMORY.md`
+- Directories: `memory/`, `skills/`, `canvas/`
+
+### FR-14: Tool Registration
+All 9 tools are registered via `registerTools()` with descriptive names, descriptions, and Zod schemas. `tools/list` MCP response reflects all 9 tools.
+
+### FR-15: Unprivileged Execution
+All tool handlers that interact with the filesystem or execute commands do so as the `executor` user (uid/gid resolved at startup). No tool runs as root.
+
+## Non-Goals (Out of Scope)
+
+- **No backend Python changes.** Phase 4 is entirely contained within the `sandboxes/` submodule. The Python backend (`backend/src/`) is not modified.
+- **No frontend changes.** No UI work is required for this phase.
+- ~~**No backward-compat alias for `exec_command`.**~~ REVISED: `exec_command` is kept as a backward-compat alias to prevent a breakage window between Phase 4 (tool rename) and Phase 5 (dual-name client support). The alias can be removed in a future cleanup once all consumers use `execute`.
+- **No multi-container orchestration.** This phase targets the single `ubuntu` sandbox container.
+- **No persistent storage or volume mounts.** `/workspace` is ephemeral within the container lifecycle.
+- **No authentication changes.** The existing `x-api-key` header auth middleware is unchanged.
+- **No TLS or HTTPS.** The sandbox serves HTTP only; TLS termination is handled upstream.
+
+## Technical Considerations
+
+### Submodule Architecture
+The `sandboxes/` directory is a git submodule pointing to the `ruska-ai/sandboxes` repository. All commits for Phase 4 must be made **inside the `sandboxes/` directory**. The orchestra repo references a specific submodule commit; after Phase 4 is complete, the orchestra repo's submodule pointer must be updated.
+
+### Docker Build
+The Dockerfile (`sandboxes/ubuntu/Dockerfile`) is based on `debian:bookworm-slim`. Changes include:
+- Adding `python3` to the `apt-get install` list
+- Creating `/workspace` with proper ownership (`executor:executor`)
+- Updating `WORKDIR` from `/home/executor` to `/workspace`
+
+### Entrypoint Script
+`entrypoint.sh` must create the OpenClaw workspace layout before starting the Node.js server. Files are created as empty templates. The script must ensure all files/directories under `/workspace` are owned by `executor`.
+
+### Zod Schemas
+Each tool's input parameters are validated via Zod schemas passed to `server.tool()`. Optional parameters use `z.<type>().optional()`. This ensures the MCP SDK validates inputs before the handler is called.
+
+### Session Lifecycle
+The existing session management (session creation via `StreamableHTTPServerTransport`, session map, `DELETE /mcp` for cleanup) is preserved. Each session gets its own `McpServer` instance with all 9 tools registered. The `SANDBOX_ID` is process-global, not per-session.
+
+### Backward Compatibility for `execute` Text Output
+The `execute` tool must keep the text-embedded `exit_code: N` line in its content output. Phase 1 of Feature #890 parses this text to extract exit codes on the Python backend side. The new `_meta.exit_code` is additive and does not replace the text format.
+
+### Tool Handler Pattern
+All tool handlers follow a consistent pattern:
+```javascript
+const SANDBOX_ID = crypto.randomUUID();
+
+function makeResult(text, exitCode) {
+  return {
+    content: [{ type: "text", text }],
+    _meta: { exit_code: exitCode, sandbox_id: SANDBOX_ID },
+  };
+}
+```
+
+Filesystem operations (`read`, `write`, `edit`, `ls`, `glob`, `upload_file`, `download_file`) should use Node.js `fs` APIs (promises or sync) running under the `executor` user's permissions. The `grep` tool can delegate to `child_process.exec` with `grep -rHnF`.
+
+### Conformance Test Suite
+`sandboxes/tests/conformance.sh` is a bash script that uses `curl` and `jq` to exercise the MCP Streamable HTTP endpoint. It must:
+1. Initialize a session (capture `Mcp-Session-Id` header)
+2. Call `tools/list` to verify all 9 tools
+3. Invoke each tool with success and error inputs
+4. Parse `_meta.exit_code` and `_meta.sandbox_id` from JSON-RPC responses
+5. Validate `/health` includes `sandbox_id`
+6. Test session reuse and cleanup
+7. Report `PASS`/`FAIL` per test with summary
+
+The test script depends on `curl` and `jq`, both of which are already available in the container and standard on development machines.
+
+## Success Metrics
+
+1. **Tool completeness**: `tools/list` returns exactly 9 tools (`execute`, `read`, `write`, `edit`, `grep`, `glob`, `ls`, `upload_file`, `download_file`)
+2. **Protocol conformance**: Every tool response includes `_meta.exit_code` (integer) and `_meta.sandbox_id` (UUID)
+3. **Exit-code accuracy**: Each tool returns the correct exit code for both success and error cases, especially `edit` with its 4 exit codes (0-3)
+4. **Conformance test suite**: `bash tests/conformance.sh http://localhost:3005` reports 24/24 tests passed with exit code 0
+5. **Environment readiness**: `python3 --version` succeeds, `pwd` returns `/workspace`, OpenClaw layout files exist
+6. **Security**: All operations execute as unprivileged `executor` user; no root escalation paths
+7. **No regressions**: The `execute` tool's text-embedded `exit_code: N` output is preserved for Phase 1 consumers
+
+## Open Questions
+
+1. **File size limits**: Should `read`, `download_file`, and `upload_file` enforce maximum file size limits to prevent memory exhaustion? If so, what threshold (e.g., 50 MB)?
+2. **Glob implementation**: Should `glob` use Node.js `fs.glob` (Node 22+), a library like `fast-glob`, or shell out to `find`? Node 22 is already installed; `fs.glob` is the simplest approach if stable.
+3. **OpenClaw template content**: Should the workspace template files (`AGENTS.md`, `SOUL.md`, etc.) contain default boilerplate content, or should they be created as empty files?
+4. **Concurrent write safety**: Should `write` and `edit` tools use file locking to prevent race conditions when multiple sessions operate on the same file, or is last-write-wins acceptable for the sandbox use case?
+5. **grep regex support**: The spec calls for fixed-string grep (`grep -F`). Should we also support regex mode via an optional `regex: boolean` parameter, or keep it strictly fixed-string for Phase 4?

--- a/tasks/prd-mcp-sandbox-frontend.md
+++ b/tasks/prd-mcp-sandbox-frontend.md
@@ -1,0 +1,382 @@
+# PRD: Frontend MCP Sandbox Option + Health + Fallback UX (Phase 3 — Feature #890)
+
+## Ralph Story Mapping
+
+> This PRD covers **Ralph US-036 through US-045** (Phase 3 — Frontend MCP sandbox UI).
+
+## Introduction
+
+Add MCP Sandbox as a selectable option in the frontend sandbox selector with a live health indicator (green/red dot) and a user-approved fallback toast when the sandbox is unreachable. This phase is strictly frontend-only: it extends the type system, sandbox configuration UI, health-check UX, and SSE error handling to support the MCP sandbox backend wired in Phase 2. The MCP option is only visible when the user has configured a non-empty `mcp_sandbox_url` in their settings, following the same gating pattern used for Daytona (provider key check).
+
+**Independent:** This phase can be implemented in parallel with Phases 1 (McpSandboxBackend class) and 4 (exec_server structured tools). It depends only on the API schema contract defined in Phase 2 (`mcp_sandbox_url` field on `DefaultsResponse` and `patchDefaults`), which can be stubbed or mocked during frontend development.
+
+## Goals
+
+- Extend `SandboxType`, `DefaultsResponse`, and `patchDefaults` types to include MCP sandbox support
+- Add an MCP entry to `SANDBOX_OPTIONS` and update `normalizeSandboxValue()` to recognize `"mcp"`
+- Provide a text input for configuring `mcp_sandbox_url` in the SandboxSettings component
+- Gate MCP option visibility on the presence of a non-empty `mcp_sandbox_url`
+- Create a `useSandboxHealth` hook that pings the derived health endpoint on mount and on dropdown open
+- Display a green/red health dot in both `SandboxSettings.tsx` and `ThreadSandboxStatus.tsx`
+- Handle the `mcp_sandbox_unreachable` SSE event with a toast that offers a one-time "Use State for this message" retry action, keeping MCP as the user's default
+- Maintain full backward compatibility — existing State and Daytona options must be completely unaffected
+
+## User Stories
+
+### US-001: Extend SandboxType union and normalize function
+
+**Description:** As a developer, I need the `SandboxType` union extended with `"mcp"` and `normalizeSandboxValue()` updated to recognize it, so the type system and value normalization are MCP-aware.
+
+**Acceptance Criteria:**
+- [ ] `SandboxType` in `frontend/src/lib/services/userSettingsService.ts` changed from `"daytona" | "state"` to `"daytona" | "state" | "mcp"`
+- [ ] `normalizeSandboxValue()` in `frontend/src/lib/config/sandbox.ts` returns `"mcp"` when passed `"mcp"`
+- [ ] Existing normalization for `"daytona"`, `"state"`, `null`, `undefined`, and unknown values is unchanged
+- [ ] `npm run test` passes
+
+### US-002: Add mcp_sandbox_url to API type interfaces
+
+**Description:** As a developer, I need `mcp_sandbox_url` on the `DefaultsResponse` interface and the `patchDefaults` data type so the frontend can read and write the MCP sandbox URL through the settings API.
+
+**Acceptance Criteria:**
+- [ ] `mcp_sandbox_url: string | null` added to `DefaultsResponse` in `frontend/src/lib/services/userSettingsService.ts`
+- [ ] `mcp_sandbox_url: string | null` added to the `patchDefaults` data parameter type
+- [ ] No runtime behavior changes — types only
+- [ ] `npm run test` passes
+
+### US-003: Add MCP entry to SANDBOX_OPTIONS
+
+**Description:** As a developer, I need an MCP entry in the `SANDBOX_OPTIONS` array so the sandbox selector dropdown can render an MCP choice.
+
+**Acceptance Criteria:**
+- [ ] MCP entry added to `SANDBOX_OPTIONS` in `frontend/src/lib/config/sandbox.ts` with `value: "mcp"`, `label: "MCP Sandbox"`, `shortLabel: "MCP"`, `description: "Run agent code in an isolated MCP sandbox container."`
+- [ ] `getSandboxOption("mcp")` returns the MCP option
+- [ ] Existing State and Daytona entries are unchanged
+- [ ] `npm run test` passes
+
+### US-004: Add MCP Sandbox URL input field in SandboxSettings
+
+**Description:** As a user, I want a text input field in the Sandbox Settings card where I can enter and persist my MCP sandbox URL, so the system knows where my MCP sandbox server is running.
+
+**Acceptance Criteria:**
+- [ ] A labeled "MCP Sandbox URL" text input is rendered below the sandbox selector dropdown in `SandboxSettings.tsx`
+- [ ] Input has placeholder text `http://localhost:3005/mcp`
+- [ ] On page load, the input displays the current saved URL from `settings.defaults.mcp_sandbox_url`
+- [ ] On blur or Enter key press, the URL is persisted via `patchDefaults({ mcp_sandbox_url: value })`
+- [ ] A success toast "MCP sandbox URL updated" is shown on save; an error toast on failure
+- [ ] An empty input clears the URL by sending `patchDefaults({ mcp_sandbox_url: null })`
+- [ ] Verify in browser using agent-browser skill
+- [ ] `npm run test` passes
+
+### US-005: MCP option visibility gating
+
+**Description:** As a user, I only want to see the MCP Sandbox option in the sandbox dropdown when I have configured a non-empty `mcp_sandbox_url`, so the UI does not present options that cannot work.
+
+**Acceptance Criteria:**
+- [ ] In `SandboxSettings.tsx`, the `visibleOptions` memo filters out the MCP option when `mcp_sandbox_url` is empty or null
+- [ ] In `ThreadSandboxStatus.tsx`, the `visibleOptions` memo applies the same MCP filtering logic
+- [ ] When a user enters and saves a non-empty MCP URL, the MCP option immediately appears in the dropdown without a page reload
+- [ ] When a user clears the MCP URL, the MCP option disappears from the dropdown and the sandbox reverts to State if MCP was selected
+- [ ] Daytona visibility gating (provider key check) continues to work independently and is unaffected
+- [ ] Verify in browser using agent-browser skill
+- [ ] `npm run test` passes
+
+### US-006: Create useSandboxHealth hook
+
+**Description:** As a developer, I need a `useSandboxHealth` hook that pings the health endpoint derived from the user's `mcp_sandbox_url` so both the settings page and the thread status bar can display live reachability status.
+
+**Acceptance Criteria:**
+- [ ] New file `frontend/src/hooks/useSandboxHealth.ts` created
+- [ ] Hook signature: `useSandboxHealth(mcpSandboxUrl: string | null)` returning `{ isHealthy: boolean | null, isLoading: boolean, refresh: () => void }`
+- [ ] Health endpoint derivation: strip trailing `/mcp` suffix from the URL (if present), then append `/health`. Examples:
+  - `http://localhost:3005/mcp` -> `http://localhost:3005/health`
+  - `http://localhost:3005` -> `http://localhost:3005/health`
+  - `http://host:3005/mcp/` -> `http://host:3005/health`
+- [ ] Pings on initial mount when `mcpSandboxUrl` is non-null
+- [ ] `refresh()` triggers a new ping (used when dropdown opens)
+- [ ] `isHealthy` is `null` before first check, `true` when GET returns 2xx, `false` on any error or non-2xx
+- [ ] `isLoading` is `true` during the fetch, `false` otherwise
+- [ ] When `mcpSandboxUrl` is `null` or empty, hook returns `{ isHealthy: null, isLoading: false, refresh: noop }`
+- [ ] No background polling — checks are on-demand only (mount + explicit refresh)
+- [ ] Fetch uses a short timeout (3 seconds) to avoid blocking UI
+- [ ] Aborts in-flight request on unmount or when URL changes (cleanup via `AbortController`)
+- [ ] `npm run test` passes
+
+### US-007: Health dot in SandboxSettings
+
+**Description:** As a user, I want to see a green or red dot next to the MCP Sandbox option in the settings dropdown so I know whether my sandbox server is reachable before selecting it.
+
+**Acceptance Criteria:**
+- [ ] `useSandboxHealth` is called in `SandboxSettings.tsx` with the current `mcp_sandbox_url`
+- [ ] A green dot (`bg-green-500`, `h-2 w-2 rounded-full`) is rendered next to the MCP option label when `isHealthy === true`
+- [ ] A red dot (`bg-red-500`, `h-2 w-2 rounded-full`) is rendered when `isHealthy === false`
+- [ ] No dot is rendered when `isHealthy === null`
+- [ ] Health is refreshed when the sandbox selector dropdown opens
+- [ ] The health dot only appears on the MCP option row — State and Daytona rows are unaffected
+- [ ] Verify in browser using agent-browser skill
+- [ ] `npm run test` passes
+
+### US-008: Health dot in ThreadSandboxStatus
+
+**Description:** As a user, I want to see the same green/red health dot in the thread-level sandbox selector popover so I have reachability info without navigating to Settings.
+
+**Acceptance Criteria:**
+- [ ] `useSandboxHealth` is called in `ThreadSandboxStatus.tsx` with the current `mcp_sandbox_url`
+- [ ] `mcp_sandbox_url` is read from the `getSettings()` response (already fetched on mount)
+- [ ] Green/red dot displayed next to the MCP option row in the popover, using the same visual pattern as US-007
+- [ ] `refresh()` is called when the popover opens (`onOpenChange` handler)
+- [ ] The health dot only appears on the MCP option row
+- [ ] Verify in browser using agent-browser skill
+- [ ] `npm run test` passes
+
+### US-009: Handle mcp_sandbox_unreachable SSE event with fallback toast
+
+**Description:** As a user, when my MCP sandbox is unreachable during a message I want to see a clear toast notification with the option to retry using the State backend for just that one message, without changing my default sandbox preference.
+
+**Acceptance Criteria:**
+- [ ] The `mcp_sandbox_unreachable` event type is recognized in the stream event handler (both `convertEventToLegacy` in the unified handler and `handleMessages` in the legacy handler)
+- [ ] When the event fires, a toast is displayed with:
+  - Message: "MCP sandbox unreachable"
+  - Description: The error detail from the SSE payload (e.g., "Connection refused")
+  - Action button labeled: "Use State for this message"
+  - Duration: persistent until dismissed or action taken (no auto-dismiss)
+- [ ] Clicking "Use State for this message" retries the same user message by calling `handleSubmit()` with a one-time `sandbox_type=state` override. The override is NOT persisted to settings — only applied for that single retry.
+- [ ] After the retry, MCP remains the user's selected default sandbox (no `patchDefaults` call for the override)
+- [ ] The loading state is cleared when the `mcp_sandbox_unreachable` event is received (before the toast is shown), so the UI is not stuck in a loading spinner
+- [ ] The last user message is preserved in the input field or message queue for the retry
+- [ ] `npm run test` passes
+
+### US-010: Integration validation with agent-browser
+
+**Description:** As a developer, I need to verify the full frontend MCP sandbox UX end-to-end in a browser to confirm settings, visibility gating, health indicators, and the fallback toast all work together.
+
+**Acceptance Criteria:**
+- [ ] `npm run test` passes (all existing tests green, no regressions)
+- [ ] `npm run lint` passes
+- [ ] `npm run format` produces no changes
+- [ ] Verify in browser using agent-browser skill with these steps:
+  1. Navigate to Settings page
+  2. Scroll to Default Sandbox card
+  3. Verify MCP option is NOT visible in dropdown (no URL configured)
+  4. Enter `http://localhost:3005/mcp` in MCP Sandbox URL input, press Enter
+  5. Verify toast confirms save
+  6. Open sandbox dropdown — verify "MCP Sandbox" now appears
+  7. Verify health dot color (green if exec_server running, red if not)
+  8. Select "MCP Sandbox" — verify selection persists after dropdown closes
+  9. Refresh page — verify both URL and MCP selection persist
+  10. Navigate to Chat page
+  11. Click sandbox selector in the utility row
+  12. Verify "MCP Sandbox" option with health dot in popover
+  13. Select MCP — verify button updates to show "MCP" short label
+  14. Clear the MCP URL in Settings — verify MCP option disappears from both dropdowns and sandbox reverts to State
+
+## Functional Requirements
+
+- **FR-1:** `SandboxType` must be `"daytona" | "state" | "mcp"` in `userSettingsService.ts`
+- **FR-2:** `DefaultsResponse` must include `mcp_sandbox_url: string | null`
+- **FR-3:** `patchDefaults` must accept `mcp_sandbox_url: string | null` in its data parameter
+- **FR-4:** `SANDBOX_OPTIONS` must include an MCP entry with value `"mcp"`, label `"MCP Sandbox"`, shortLabel `"MCP"`, and description `"Run agent code in an isolated MCP sandbox container."`
+- **FR-5:** `normalizeSandboxValue("mcp")` must return `"mcp"`
+- **FR-6:** The SandboxSettings component must render an "MCP Sandbox URL" text input below the sandbox dropdown, persisting on blur/Enter via `patchDefaults({ mcp_sandbox_url: value })`
+- **FR-7:** The MCP option must only be visible in both `SandboxSettings` and `ThreadSandboxStatus` dropdowns when `mcp_sandbox_url` is a non-empty string
+- **FR-8:** `useSandboxHealth` must derive the health endpoint by stripping `/mcp` (and trailing slash) from the URL and appending `/health`
+- **FR-9:** `useSandboxHealth` must ping on mount and on explicit `refresh()` calls — no background polling
+- **FR-10:** A green dot (`bg-green-500`) must display next to the MCP option when healthy; a red dot (`bg-red-500`) when unhealthy; no dot when health is unknown (`null`)
+- **FR-11:** The `mcp_sandbox_unreachable` SSE event must trigger a persistent toast with "Use State for this message" action button
+- **FR-12:** The toast retry must re-send the same message with a one-time `sandbox_type=state` override without changing the user's default sandbox setting
+- **FR-13:** After using the State fallback button, MCP must remain the user's selected default sandbox for future messages
+- **FR-14:** Existing State and Daytona sandbox options must be completely unaffected by all changes
+
+## Non-Goals (Out of Scope)
+
+- **No backend changes** — this phase is frontend-only; the API contract (`mcp_sandbox_url` on DefaultsResponse and PatchDefaults) is delivered by Phase 2
+- **No exec_server changes** — the MCP sandbox server itself is not modified
+- **No MCP protocol work** — no MCP tool discovery, registration, or JSON-RPC implementation in the frontend
+- **No per-agent or per-thread MCP URL overrides** — the URL is a global user setting only
+- **No URL validation** — the input accepts any string; connectivity is tested by the health check and at execution time
+- **No background health polling** — health checks are on-demand (mount + dropdown open) to avoid unnecessary network traffic
+- **No automatic fallback** — the user must explicitly click "Use State for this message" to retry; the system does not silently switch backends
+- **No migration of existing user data** — the `mcp_sandbox_url` field defaults to `null` which hides the MCP option
+
+## Design Considerations
+
+### Settings Page Layout
+
+The Default Sandbox card in `SandboxSettings.tsx` gains a new input field below the existing dropdown:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Default Sandbox                                             │
+│ Choose the sandbox backend for agent code execution.        │
+│                                                             │
+│ ┌─────────────────────────────────────────────────┐         │
+│ │ MCP Sandbox                                  ▼  │         │
+│ └─────────────────────────────────────────────────┘         │
+│                                                             │
+│ MCP Sandbox URL                                             │
+│ ┌─────────────────────────────────────────────────┐         │
+│ │ http://localhost:3005/mcp                        │         │
+│ └─────────────────────────────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The URL input is always visible (not gated), since entering a URL is how the user enables the MCP option. The input label should be a subtle `text-sm text-muted-foreground` label.
+
+### Dropdown with Health Dots
+
+Both `SandboxSettings` and `ThreadSandboxStatus` dropdown/popover menus render a small health dot inline with the MCP option label:
+
+```
+┌─────────────────────────────────────────┐
+│ ✓ State (Default)                       │
+│   Run agent code with the state sandbox │
+│                                         │
+│   Daytona                               │
+│   Run agent code in the Daytona sandbox │
+│                                         │
+│   MCP Sandbox  ●                        │
+│   Run agent code in an isolated MCP     │
+│   sandbox container.                    │
+└─────────────────────────────────────────┘
+```
+
+The dot is a `span` with `h-2 w-2 rounded-full inline-block ml-1.5` and `bg-green-500` or `bg-red-500`. It appears only on the MCP row.
+
+### Fallback Toast
+
+The toast uses sonner's `toast.error()` with an `action` configuration:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ ✕  MCP sandbox unreachable                          │
+│    Connection refused to http://localhost:3005/mcp   │
+│                                                     │
+│                    [ Use State for this message ]    │
+└─────────────────────────────────────────────────────┘
+```
+
+The toast is persistent (no auto-dismiss timeout) so the user has time to decide. Clicking the action button dismisses the toast and retries.
+
+## Technical Considerations
+
+### Health Endpoint Derivation
+
+The `useSandboxHealth` hook derives the health URL from `mcp_sandbox_url` using this algorithm:
+
+1. Remove trailing slashes from the URL
+2. If the URL ends with `/mcp`, strip the `/mcp` suffix
+3. Append `/health`
+
+Examples:
+- `http://localhost:3005/mcp` -> `http://localhost:3005/health`
+- `http://localhost:3005/mcp/` -> `http://localhost:3005/health`
+- `http://localhost:3005` -> `http://localhost:3005/health`
+- `https://sandbox.example.com/mcp` -> `https://sandbox.example.com/health`
+
+Implementation:
+```typescript
+function deriveHealthUrl(mcpUrl: string): string {
+  let base = mcpUrl.replace(/\/+$/, "");    // strip trailing slashes
+  base = base.replace(/\/mcp$/, "");         // strip /mcp suffix
+  return `${base}/health`;
+}
+```
+
+The health check is a simple `fetch(healthUrl, { signal, method: "GET" })` with a 3-second timeout via `AbortController.timeout()`. CORS may block the request from the browser — if so, the hook catches the error and sets `isHealthy = false`. A future improvement could proxy the health check through the backend API, but for Phase 3 the direct fetch is sufficient.
+
+### SSE Event Handling Pattern
+
+The backend (Phase 2) emits `mcp_sandbox_unreachable` events in the SSE stream as:
+
+```
+data: ["mcp_sandbox_unreachable", "Connection refused"]
+```
+
+**Note**: This follows the existing `("error", str(e))` tuple pattern — the first element is the event type string, the second is a plain error message string (not a nested object).
+
+This is parsed by `FetchStreamReader.parseEvent()` and `ResponseBodyReader.parseEvent()` in the stream readers. A new case must be added to:
+
+1. **`parseEvent()` in both readers** (`fetchStreamReader.ts`): recognize `"mcp_sandbox_unreachable"` as a valid event type and return a typed event
+2. **`SSEEvent` type** (`stream.ts`): add `McpSandboxUnreachableEvent` to the union
+3. **`convertEventToLegacy()`** in `useChat.ts`: map the event to legacy format
+4. **`handleMessages()`** in `useChat.ts`: handle the `"mcp_sandbox_unreachable"` stream mode by showing the toast and stopping the loading state
+
+For the legacy SSE handler (`handleSSE`), the `sseHandler` -> `handleMessages` path already processes all parsed JSON payloads, so adding a case for `"mcp_sandbox_unreachable"` in `handleMessages` covers both code paths.
+
+### Toast Retry Mechanism
+
+When the user clicks "Use State for this message":
+
+1. The toast is dismissed
+2. The last user message is re-sent via `handleSubmit()` (the message content is still available in the messages array)
+3. A one-time override is applied so this specific request uses `sandbox_type=state` instead of the user's default `"mcp"`
+4. The override is NOT persisted — `patchDefaults` is NOT called
+5. After the retry completes, future messages continue to use MCP as the default
+
+Implementation approach: The `handleSubmit` function (or a new retry-specific function) can accept an optional `sandboxOverride` parameter. When present, this override is included in the stream request payload (e.g., as a metadata field `sandbox_type_override: "state"`). The backend dispatch layer (Phase 2) should respect this override for the single request.
+
+Alternatively, if the backend does not support per-request overrides, the frontend can:
+1. Temporarily patch the sandbox to `"state"` via `patchDefaults`
+2. Send the message
+3. Immediately restore `"mcp"` via another `patchDefaults` call
+
+The first approach (per-request override in payload) is cleaner and avoids race conditions. Coordinate with Phase 2 to ensure the backend accepts a `sandbox_type` field in the stream request body or metadata.
+
+### Visibility Gating Approach
+
+The MCP option uses URL-based gating, distinct from Daytona's provider-key gating:
+
+```typescript
+const visibleOptions = useMemo(
+  () =>
+    SANDBOX_OPTIONS.filter((opt) => {
+      if (opt.value === "daytona") {
+        return providerKeys.some(
+          (k) => k.provider === "DAYTONA_API_KEY" && k.is_set,
+        );
+      }
+      if (opt.value === "mcp") {
+        return !!mcpSandboxUrl;
+      }
+      return true;
+    }),
+  [providerKeys, mcpSandboxUrl],
+);
+```
+
+Both `SandboxSettings.tsx` and `ThreadSandboxStatus.tsx` must maintain `mcpSandboxUrl` state derived from the `getSettings()` response. In `SandboxSettings`, the URL input on-save handler should update this state immediately (optimistic update) so the dropdown reflects the new visibility without requiring a page reload.
+
+### Files Changed
+
+| File | Action | Changes |
+|------|--------|---------|
+| `frontend/src/lib/services/userSettingsService.ts` | MODIFY | Extend `SandboxType` union, add `mcp_sandbox_url` to `DefaultsResponse` and `patchDefaults` |
+| `frontend/src/lib/config/sandbox.ts` | MODIFY | Add MCP to `SANDBOX_OPTIONS`, update `normalizeSandboxValue()` |
+| `frontend/src/hooks/useSandboxHealth.ts` | CREATE | New health-check hook |
+| `frontend/src/components/settings/SandboxSettings.tsx` | MODIFY | Add MCP URL input, visibility gating, health dot |
+| `frontend/src/components/status/ThreadSandboxStatus.tsx` | MODIFY | Add visibility gating, health dot, refresh on popover open |
+| `frontend/src/lib/entities/stream.ts` | MODIFY | Add `McpSandboxUnreachableEvent` to `SSEEvent` union |
+| `frontend/src/lib/utils/fetchStreamReader.ts` | MODIFY | Add `mcp_sandbox_unreachable` case to `parseEvent()` in both `FetchStreamReader` and `ResponseBodyReader` |
+| `frontend/src/hooks/useChat.ts` | MODIFY | Handle `mcp_sandbox_unreachable` in `convertEventToLegacy()` and `handleMessages()`, implement toast retry |
+
+## Success Metrics
+
+- `SandboxType` includes `"mcp"` and `normalizeSandboxValue("mcp")` returns `"mcp"`
+- MCP option appears in dropdown only when `mcp_sandbox_url` is non-empty
+- MCP option disappears when URL is cleared
+- MCP Sandbox URL input persists values via `patchDefaults` and loads saved values on page mount
+- Health dot is green when exec_server is reachable, red when unreachable, absent when unchecked
+- Health refreshes on dropdown/popover open
+- `mcp_sandbox_unreachable` SSE event triggers a persistent toast with the action button
+- Clicking "Use State for this message" retries the message with the State backend
+- After retry, MCP remains the user's default sandbox
+- All existing frontend tests pass (`npm run test`) with no regressions
+- `npm run lint` and `npm run format` produce no changes
+- State and Daytona sandbox flows are completely unaffected
+
+## Open Questions
+
+- Should the MCP Sandbox URL input be visible at all times, or only when MCP is the currently selected sandbox? (Current design: always visible, since entering a URL is the prerequisite for enabling MCP.)
+- Should the health check be proxied through the backend API (`GET /api/v0/sandbox/health?url=...`) to avoid CORS issues with direct browser-to-exec_server requests? If CORS is blocked, the health dot will always show red even when the server is reachable.
+- How should the per-request `sandbox_type=state` override be communicated to the backend for the toast retry? Options: (a) metadata field in stream request payload, (b) query parameter on the stream URL, (c) temporary patchDefaults round-trip. Option (a) is preferred — confirm with Phase 2 implementation.
+- Should the health dot animate (pulse) while the health check is in-flight, or remain hidden until the result is known? (Current design: no dot when `isHealthy === null`, which covers both unchecked and in-flight states.)
+- If the user has `sandbox=mcp` selected but then clears the `mcp_sandbox_url`, should the frontend automatically switch the sandbox back to `"state"` via `patchDefaults`, or just hide the MCP option and let the backend fallback handle it?

--- a/tasks/prd-mcp-sandbox-v2-native.md
+++ b/tasks/prd-mcp-sandbox-v2-native.md
@@ -1,0 +1,333 @@
+# PRD: McpSandboxBackend v2 — Native MCP Tools (Phase 5 — Feature #890)
+
+## Ralph Story Mapping
+
+> This PRD covers **Ralph US-046 through US-059** (Phase 5 — McpSandboxBackend v2 native MCP tools).
+
+## Introduction
+
+Phase 1 of Feature #890 introduced `McpSandboxBackend(BaseSandbox)` with `execute()` as the sole MCP tool call. All other `BaseSandbox` operations (`read`, `write`, `edit`, `grep_raw`, `glob_info`, `ls_info`, `upload_files`, `download_files`) work via inherited shell-delegation — they construct python3 heredoc commands or shell pipelines and route them through `execute()`. This works but is inefficient: every file read spawns a python3 process, every grep forks a subprocess chain, and error semantics are inferred from shell exit codes embedded in text output.
+
+Phase 5 upgrades `McpSandboxBackend` to call native MCP tools directly for all 9 `BaseSandbox` operations when the exec_server supports them (Phase 4 delivers those tools). When a native tool is available, the override calls it directly via `_call_tool()`. When it is not available (older exec_server), the override falls back to the inherited shell-delegation implementation — zero regression. This native-first, fallback-second pattern ensures `McpSandboxBackend` works seamlessly with both old and new exec_servers.
+
+**Dependencies:** Phase 2 (dispatch wiring into `resolve_sandbox_backend()`) and Phase 4 (exec_server structured MCP tools with `_meta` responses).
+
+**Spec:** `.claude/specs/feat-890-mcp-sandbox/005-mcp-sandbox-v2.md`
+
+## Goals
+
+- Discover available MCP tools during session initialization and cache them for the lifetime of the session
+- Override all 9 `BaseSandbox` methods with native MCP tool calls when the exec_server advertises those tools
+- Extract structured metadata (`_meta.exit_code`, `_meta.sandbox_id`) from tool responses, with fallback to text-regex parsing for older servers
+- Maintain exact return type parity — every native override returns the identical type as its inherited counterpart
+- Guarantee graceful degradation: an exec_server with only `exec_command` (no native tools, no `_meta`) must produce identical behavior to Phase 1
+
+## User Stories
+
+### US-001: Tool Discovery on Session Init
+
+**Description:** As the system, I need `McpSandboxBackend` to discover which MCP tools the connected exec_server supports so that each method can decide whether to use a native tool or fall back to the inherited shell delegation.
+
+**Acceptance Criteria:**
+- [ ] `_ensure_initialized()` calls `tools/list` JSON-RPC method after the `initialize` handshake
+- [ ] Response tools are cached in `self._available_tools: set[str]` (set of tool name strings)
+- [ ] Helper `_has_tool(name: str) -> bool` checks the cached set
+- [ ] When `tools/list` returns an empty list or fails, `_available_tools` is an empty set (fallback-safe)
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-002: Dual-Mode Exit Code Extraction
+
+**Description:** As the system, I need to extract `exit_code` from MCP tool responses using the structured `_meta.exit_code` field when present, falling back to text-regex parsing (`r'exit_code:\s*(\d+)'`) for older exec_servers that embed the exit code in the text output.
+
+**Acceptance Criteria:**
+- [ ] Helper `_parse_meta(result: dict) -> tuple[int | None, str | None]` extracts `exit_code` and `sandbox_id` from `result.get("_meta", {})`
+- [ ] When `_meta.exit_code` is present (integer), it is used directly — no text parsing needed
+- [ ] When `_meta.exit_code` is absent, the text content is searched with `EXIT_CODE_RE` regex and the last match is used
+- [ ] When neither `_meta` nor regex match is found, exit code defaults to `0`
+- [ ] Unit tests cover: `_meta` present, `_meta` absent with text fallback, both absent (default 0)
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-003: Sandbox ID from _meta
+
+**Description:** As the system, I need the `McpSandboxBackend.id` property to use `_meta.sandbox_id` from the exec_server when available, falling back to the locally generated identifier from Phase 1.
+
+**Acceptance Criteria:**
+- [ ] On the first tool call response that contains `_meta.sandbox_id`, the value is cached in `self._sandbox_id`
+- [ ] The `id` property returns `_meta.sandbox_id` if cached, otherwise the Phase 1 fallback value (URL-based or UUID)
+- [ ] `_parse_meta()` updates the cached `_sandbox_id` when it encounters a new `sandbox_id` value
+- [ ] Unit test: `id` returns fallback before any tool calls, returns `_meta.sandbox_id` after a tool call
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-004: Override execute() — Dual Tool Name Support
+
+**Description:** As the system, I need `execute()` to call the `execute` MCP tool on new exec_servers and fall back to the `exec_command` tool on old exec_servers, using the dual-mode exit code extraction for both.
+
+**Acceptance Criteria:**
+- [ ] `execute()` checks `_has_tool("execute")` first; if present, calls `execute` tool with `{"cmd": command}`
+- [ ] If `"execute"` is not available, checks `_has_tool("exec_command")` and calls `exec_command` with `{"cmd": command}`
+- [ ] If neither is available, raises a clear error (should never happen — at least one must exist)
+- [ ] Exit code extracted via `_parse_meta()` (prefers `_meta.exit_code`, falls back to text regex)
+- [ ] `timeout` parameter forwarded to the tool call
+- [ ] Returns `ExecuteResponse(output=text, exit_code=int, truncated=False)`
+- [ ] Unit tests: new server (`execute` tool), old server (`exec_command` tool), `_meta.exit_code` preferred over text regex
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-005: Override read()
+
+**Description:** As the system, I need `read()` to call the native `read` MCP tool when available, returning cat -n formatted text content, with fallback to the inherited python3 heredoc implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("read")` is true: calls `read` MCP tool with `{"path": file_path, "offset": offset, "limit": limit}`
+- [ ] Extracts text content from the response (already in cat -n format from the server)
+- [ ] When `_has_tool("read")` is false: calls `super().read(file_path, offset, limit)` (inherited shell delegation)
+- [ ] Return type is `str` (cat -n formatted text), matching inherited implementation
+- [ ] Unit tests: native path returns text, fallback path calls super
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-006: Override write()
+
+**Description:** As the system, I need `write()` to call the native `write` MCP tool when available, returning a `WriteResult`, with fallback to the inherited python3 heredoc implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("write")` is true: calls `write` MCP tool with `{"path": file_path, "content": content}`
+- [ ] Parses `_meta.exit_code` — 0 means success, non-zero means error
+- [ ] Returns `WriteResult(error=None, path=file_path)` on success
+- [ ] Returns `WriteResult(error="<text>", path=file_path)` on error (exit_code != 0)
+- [ ] When `_has_tool("write")` is false: calls `super().write(file_path, content)`
+- [ ] Return type is `WriteResult`, matching inherited implementation
+- [ ] Unit tests: native success, native error, fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-007: Override edit()
+
+**Description:** As the system, I need `edit()` to call the native `edit` MCP tool when available, parsing the 4-level exit code semantics (0=ok, 1=not found, 2=multiple matches, 3=file missing), with fallback to the inherited implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("edit")` is true: calls `edit` MCP tool with `{"path": file_path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all}`
+- [ ] Parses `_meta.exit_code` with semantics: 0=success, 1=old_string not found, 2=multiple matches (replace_all=false), 3=file not found
+- [ ] On exit_code 0: returns `EditResult(error=None, path=file_path, occurrences=N)` with occurrence count parsed from text content
+- [ ] On exit_code 1-3: returns `EditResult(error="<descriptive message>", path=file_path, occurrences=None)`
+- [ ] When `_has_tool("edit")` is false: calls `super().edit(file_path, old_string, new_string, replace_all)`
+- [ ] Return type is `EditResult`, matching inherited implementation
+- [ ] Unit tests: exit codes 0, 1, 2, 3, fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-008: Override grep_raw()
+
+**Description:** As the system, I need `grep_raw()` to call the native `grep` MCP tool when available, parsing JSON lines into `GrepMatch` objects, with fallback to the inherited grep command.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("grep")` is true: calls `grep` MCP tool with `{"pattern": pattern, "path": path, "glob": glob_pattern}`
+- [ ] Parses newline-delimited JSON response: each line is `{"path": "...", "line": N, "text": "..."}`
+- [ ] Helper `_parse_json_lines(text: str) -> list[dict]` added for parsing
+- [ ] Returns `list[GrepMatch]` with each match converted from the JSON objects
+- [ ] When `_meta.exit_code` is 1 (no matches), returns empty list
+- [ ] When `_has_tool("grep")` is false: calls `super().grep_raw(pattern, path, glob_pattern)`
+- [ ] Return type is `list[GrepMatch]`, matching inherited implementation
+- [ ] Unit tests: matches found (multiple JSON lines), no matches (exit_code 1), fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-009: Override glob_info()
+
+**Description:** As the system, I need `glob_info()` to call the native `glob` MCP tool when available, parsing JSON lines into `FileInfo` objects, with fallback to the inherited implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("glob")` is true: calls `glob` MCP tool with `{"pattern": pattern, "path": path}`
+- [ ] Parses newline-delimited JSON response: each line is `{"path": "...", "is_dir": bool, "size": N, "mtime": "ISO"}`
+- [ ] Returns `list[FileInfo]` with each entry converted from JSON objects
+- [ ] When `_has_tool("glob")` is false: calls `super().glob_info(pattern, path)`
+- [ ] Return type is `list[FileInfo]`, matching inherited implementation
+- [ ] Unit tests: results found, empty results, fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-010: Override ls_info()
+
+**Description:** As the system, I need `ls_info()` to call the native `ls` MCP tool when available, parsing JSON lines into `FileInfo` objects, with fallback to the inherited implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("ls")` is true: calls `ls` MCP tool with `{"path": path}`
+- [ ] Parses newline-delimited JSON response: each line is `{"path": "...", "is_dir": bool}`
+- [ ] Returns `list[FileInfo]` with `size=None` and `mtime=None` (ls does not provide these)
+- [ ] When `_meta.exit_code` is 1 (path not found), returns empty list
+- [ ] When `_has_tool("ls")` is false: calls `super().ls_info(path)`
+- [ ] Return type is `list[FileInfo]`, matching inherited implementation
+- [ ] Unit tests: results found, path not found (exit_code 1), fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-011: Override upload_files()
+
+**Description:** As the system, I need `upload_files()` to call the native `upload_file` MCP tool per file when available, with fallback to the inherited shell-based base64 implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("upload_file")` is true: for each `(path, content_bytes)` tuple, calls `upload_file` MCP tool with `{"path": path, "content_base64": base64.b64encode(content).decode()}`
+- [ ] Parses `_meta.exit_code` — 0 means success, non-zero means error
+- [ ] Returns `FileUploadResponse(path=path, error=None)` on success per file
+- [ ] Returns `FileUploadResponse(path=path, error="<text>")` on error per file
+- [ ] Individual file errors do not abort the batch — all files are attempted
+- [ ] When `_has_tool("upload_file")` is false: calls `super().upload_files(files)` (inherited base64 shell implementation)
+- [ ] Return type is `list[FileUploadResponse]`, matching inherited implementation
+- [ ] Unit tests: all succeed, partial failure, fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-012: Override download_files()
+
+**Description:** As the system, I need `download_files()` to call the native `download_file` MCP tool per file when available, with fallback to the inherited shell-based base64 implementation.
+
+**Acceptance Criteria:**
+- [ ] When `_has_tool("download_file")` is true: for each path, calls `download_file` MCP tool with `{"path": path}`
+- [ ] Decodes base64 text content to bytes on success (`_meta.exit_code` == 0)
+- [ ] Returns `FileDownloadResponse(path=path, content=decoded_bytes, error=None)` on success per file
+- [ ] Returns `FileDownloadResponse(path=path, content=None, error="file_not_found")` when `_meta.exit_code` == 1
+- [ ] Individual file errors do not abort the batch — all files are attempted
+- [ ] When `_has_tool("download_file")` is false: calls `super().download_files(paths)` (inherited base64 shell implementation)
+- [ ] Return type is `list[FileDownloadResponse]`, matching inherited implementation
+- [ ] Unit tests: all succeed, file not found, fallback path
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-013: Graceful Degradation — Old exec_server Compatibility
+
+**Description:** As the system, I need `McpSandboxBackend` to work identically to Phase 1 behavior when connected to an old exec_server that only exposes `exec_command` (no native tools, no `_meta` in responses). This is the critical regression-safety guarantee.
+
+**Acceptance Criteria:**
+- [ ] When `tools/list` returns only `exec_command`: `_available_tools` is `{"exec_command"}`
+- [ ] `execute()` correctly uses `exec_command` tool with text-regex exit code parsing
+- [ ] `read()`, `write()`, `edit()`, `grep_raw()`, `glob_info()`, `ls_info()` all fall back to `super()` (inherited shell delegation through `execute()`)
+- [ ] `upload_files()` and `download_files()` fall back to `super()` (inherited base64 shell implementation)
+- [ ] `id` property returns the Phase 1 fallback value (no `_meta.sandbox_id` available)
+- [ ] No exceptions raised, no behavioral differences from Phase 1
+- [ ] Unit test: mock old exec_server (only `exec_command` in tools list), verify all 9 methods produce correct results via fallback
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes
+- [ ] `make format` passes
+
+### US-014: Integration Validation — New and Old exec_servers
+
+**Description:** As a developer, I need to verify that `McpSandboxBackend` works correctly against both new (Phase 4) and old (pre-Phase 4) exec_servers, with all tests passing and code clean.
+
+**Acceptance Criteria:**
+- [ ] `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes with all new and existing tests green
+- [ ] `make format` passes
+- [ ] `make lint` passes
+- [ ] `make test` passes (no regressions in any test suite)
+- [ ] Unit tests cover: native tool paths (9 methods), fallback paths (9 methods), mixed availability (some tools native, others fallback), `_meta` parsing (exit_code + sandbox_id), JSON lines parsing (grep, glob, ls), dual tool name for execute (execute vs exec_command)
+- [ ] Test count: minimum 25 new test cases covering the matrix of methods x paths x edge cases
+
+## Functional Requirements
+
+- **FR-1:** `_ensure_initialized()` must call `tools/list` after `initialize` and cache the set of available tool names in `self._available_tools: set[str]`
+- **FR-2:** Every method override must check `_has_tool(name)` before deciding between native and fallback paths — this is the native-first, fallback-second pattern
+- **FR-3:** `_parse_meta(result: dict) -> tuple[int | None, str | None]` must extract `exit_code` (int) and `sandbox_id` (str) from `result.get("_meta", {})` when present, returning `(None, None)` when `_meta` is absent. Both return values are Optional since `_meta` may not exist on older exec_servers.
+- **FR-4:** Exit code resolution order: `_meta.exit_code` (structured int) -> text regex match -> default 0
+- **FR-5:** `execute()` must support both `execute` (Phase 4 tool name) and `exec_command` (Phase 1 tool name) based on `_available_tools`
+- **FR-6:** Native overrides for `read`, `write`, `edit`, `grep_raw`, `glob_info`, `ls_info`, `upload_files`, and `download_files` must call the corresponding MCP tool when available
+- **FR-7:** All native overrides must return the exact same types as their inherited counterparts:
+  - `execute()` -> `ExecuteResponse(output: str, exit_code: int, truncated: bool)`
+  - `read()` -> `str`
+  - `write()` -> `WriteResult(error: str | None, path: str | None)`
+  - `edit()` -> `EditResult(error: str | None, path: str | None, occurrences: int | None)`
+  - `grep_raw()` -> `list[GrepMatch]`
+  - `glob_info()` -> `list[FileInfo]`
+  - `ls_info()` -> `list[FileInfo]`
+  - `upload_files()` -> `list[FileUploadResponse]`
+  - `download_files()` -> `list[FileDownloadResponse]`
+- **FR-8:** When a tool is not in `_available_tools`, the override must call `super().method()` to use the inherited shell-delegation path through `execute()`
+- **FR-9:** The `id` property must return `_meta.sandbox_id` when available, otherwise the Phase 1 fallback value
+- **FR-10:** JSON lines parsing (`_parse_json_lines`) must handle empty text, single-line, and multi-line responses gracefully, skipping malformed lines
+- **FR-11:** `edit()` exit code semantics: 0=success, 1=old_string not found, 2=multiple matches (replace_all=false), 3=file not found
+- **FR-12:** File upload/download operations must handle per-file errors individually without aborting the batch
+- **FR-13:** An exec_server exposing only `exec_command` (no native tools, no `_meta`) must produce identical behavior to Phase 1 — zero regression
+
+## Non-Goals (Out of Scope)
+
+- **No exec_server changes** — Phase 4 delivers the server-side tools; this phase only consumes them from the client side
+- **No new MCP tools** — we override existing `BaseSandbox` methods to use existing MCP tools, not invent new operations
+- **No frontend changes** — this is a backend-only upgrade; the frontend is unaware of native vs. shell-delegation paths
+- **No dispatch wiring changes** — Phase 2 already wires `McpSandboxBackend` into `resolve_sandbox_backend()`; this phase modifies only the sandbox class itself
+- **No new dependencies** — all imports (`httpx`, `base64`, `json`, `re`) are already available
+- **No schema/migration changes** — no database or API schema modifications
+- **No changes to `BaseSandbox` or `deepagents`** — we only override methods, never modify the base class
+
+## Technical Considerations
+
+### Dependency Chain
+
+Phase 5 depends on two prior phases:
+- **Phase 2 (dispatch wiring):** `McpSandboxBackend` must be registered in `_SANDBOX_FACTORIES` and wired through `resolve_sandbox_backend()` so it can be instantiated during agent execution. Phase 2 delivers this via `_create_mcp_backend_checked()`.
+- **Phase 4 (exec_server structured tools):** The exec_server must expose the 9 native MCP tools (`execute`, `read`, `write`, `edit`, `grep`, `glob`, `ls`, `upload_file`, `download_file`) with `_meta` responses. Phase 4 delivers this server-side. However, Phase 5 is designed to work even when Phase 4 is not deployed — graceful degradation ensures old servers still function.
+
+### Return Type Parity
+
+This is non-negotiable. The `CompositeBackend` and agent framework depend on exact return types from `BaseSandbox` methods. Native overrides must construct the exact same Pydantic models or dataclasses that the inherited implementations return. Any type mismatch will cause runtime errors downstream in the agent loop.
+
+### Native-First, Fallback-Second Pattern
+
+Every override follows an identical structure:
+
+```python
+async def method(self, *args, **kwargs) -> ReturnType:
+    if self._has_tool("tool_name"):
+        result = await self._call_tool("tool_name", {args_dict})
+        # Parse result and construct ReturnType
+        return ReturnType(...)
+    return await super().method(*args, **kwargs)
+```
+
+This pattern guarantees that:
+1. New exec_servers get efficient native tool calls
+2. Old exec_servers get inherited shell-delegation (unchanged from Phase 1)
+3. Mixed-capability servers (some tools native, others not) work correctly on a per-method basis
+
+### Backwards Compatibility with Old exec_servers
+
+Old exec_servers expose only `exec_command` (no `execute`, no native tools, no `_meta`). The upgrade path is:
+- `execute()` falls back from `execute` to `exec_command` tool name
+- Exit code falls back from `_meta.exit_code` to text regex
+- `id` falls back from `_meta.sandbox_id` to local UUID
+- All other methods fall back to `super()` (inherited shell delegation)
+
+No code path raises an exception due to missing tools or `_meta`.
+
+### JSON Lines Parsing
+
+The `grep`, `glob`, and `ls` tools return newline-delimited JSON objects. The parser must:
+- Split on newlines
+- Skip empty lines
+- Parse each line as JSON independently
+- Skip malformed lines (log warning, do not raise)
+- Return a list of parsed dictionaries
+
+### Files Modified
+
+| File | Action | What Changes |
+|------|--------|-------------|
+| `backend/src/agents/mcp_sandbox.py` | MODIFY | Add `_available_tools`, `_has_tool()`, `_parse_meta()`, `_parse_json_lines()`, override all 9 methods |
+| `backend/tests/unit/agents/test_mcp_sandbox.py` | MODIFY | Add tests for native tool paths, fallback paths, `_meta` parsing, JSON lines parsing, mixed availability, old server compat |
+
+## Success Metrics
+
+- All 9 `BaseSandbox` method overrides implemented with native-first, fallback-second pattern
+- Return type parity verified — native overrides return identical types to inherited implementations
+- Graceful degradation verified — old exec_server (only `exec_command`) produces Phase 1-identical behavior
+- Minimum 25 new unit test cases covering the full method x path x edge-case matrix
+- `cd backend && uv run pytest tests/unit/agents/test_mcp_sandbox.py -v` passes with all tests green
+- `make format` passes
+- `make lint` passes
+- `make test` passes with zero regressions
+
+## Open Questions
+
+- Should `_parse_json_lines()` silently skip malformed lines, or should it collect parsing errors and include them in a warning log? (Recommended: skip with warning log)
+- Should tool discovery (`tools/list`) be retried on transient failure, or should a single failure result in an empty `_available_tools` set? (Recommended: single attempt, empty set on failure — safe fallback)
+- For `execute()`, if both `execute` and `exec_command` appear in `_available_tools` (unlikely but possible), should `execute` always take priority? (Recommended: yes, prefer `execute` as the canonical name)
+- Should `upload_files()` and `download_files()` batch their native tool calls concurrently (e.g., `asyncio.gather`), or execute them sequentially? (Recommended: sequential for simplicity in Phase 5, optimize in a follow-up if needed)


### PR DESCRIPTION
## Summary

End-to-end MCP Sandbox integration for Orchestra (#890):

- **Phase 1 (P1)**: `McpSandboxBackend` class with MCP JSON-RPC session management, execute/upload/download/health/close, 38 unit tests
- **Phase 2 (P2)**: `MCP` added to `SandboxType` enum, settings schema, API routes, sandbox factory, dispatch rules with auto-fallback chain (Daytona → MCP → State), error helpers, wired through LLMController/stream_generator/worker tasks
- **Phase 3 (P3)**: Frontend UX — MCP Sandbox URL input, visibility gating, `useSandboxHealth` hook, green/red health dots in both sandbox selectors, `mcp_sandbox_unreachable` SSE toast handler
- **Phase 4 (P4)**: exec_server structured tools — 9 native MCP tools (execute, read, write, edit, grep, glob, ls, upload_file, download_file), `_meta` structure, `/workspace` OpenClaw layout, python3, conformance test suite (**separate PR needed in ruska-ai/sandboxes**)
- **Phase 5 (P5)**: Native tool overrides with graceful degradation — tools/list discovery, `_parse_meta` dual-mode exit codes, native paths for all 9 methods with super() fallback for old exec_servers, 75 unit tests

> **Note**: Phase 4 changes (US-024–US-035) live in the `sandboxes/` submodule and have been pushed to `ruska-ai/sandboxes` master. A separate PR is needed there. This PR covers P1, P2, P3, and P5.

## Test plan

- [ ] `make test` passes (backend: 595+ unit tests, 75 MCP sandbox tests)
- [ ] `npm run test` passes (frontend: 341 tests)
- [ ] `make format` and `make lint` clean
- [ ] `npx tsc --noEmit` clean (frontend)
- [ ] Manual: configure MCP URL in Settings → verify health dot, select MCP → verify agent execution
- [ ] Manual: clear MCP URL → verify MCP option disappears, sandbox reverts to State
- [ ] Manual: with MCP selected and server down → verify `mcp_sandbox_unreachable` toast
- [ ] Manual: `bash sandboxes/tests/conformance.sh http://localhost:3005` (requires running exec_server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP Sandbox as a new execution environment option alongside existing backends
  * Integrated health status indicator to show MCP sandbox availability
  * Added MCP sandbox URL configuration in user settings
  * Implemented automatic fallback to State backend when MCP is unreachable
  * Added error toast with retry option when MCP sandbox becomes unavailable during execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->