### PR TITLE
feat: Agent phase observability — structured traces with frontend timeline

### DIFF
--- a/.claude/plans/agent-observability.md
+++ b/.claude/plans/agent-observability.md
@@ -1,0 +1,150 @@
+# Plan: Agent Phase Observability & Trace Visualization
+
+## Overview
+
+Add structured observability to Orchestra's agent execution pipeline. Each agent phase (planner, generator, evaluator, handoff, tool_call, retrieval) emits a span with timing, token usage, model, cost, and error information. Spans are persisted to PostgreSQL, exposed via REST API, rendered in a frontend swimlane timeline, and optionally exported via OpenTelemetry OTLP.
+
+Full spec: [`.claude/specs/agent-observability.md`](../specs/agent-observability.md)
+
+## User Stories
+
+1. **As a developer**, I want to see a visual timeline of every phase my agent went through when processing a request, so I can identify bottlenecks and understand execution flow.
+
+2. **As an operator**, I want per-phase token counts and cost breakdowns for each thread turn, so I can monitor spending and optimize prompt sizes.
+
+3. **As a developer debugging an error**, I want to click on a failed phase span and see the error message, metadata, and timing context, so I can quickly root-cause issues.
+
+4. **As a platform engineer**, I want to export agent spans to our existing Datadog/Jaeger infrastructure via OTLP, so agent telemetry integrates with our broader observability stack.
+
+5. **As a team lead**, I want to compare trace timelines across different agent configurations, so I can evaluate which setups produce faster, cheaper, or more reliable results.
+
+## Implementation Phases
+
+### Phase 1: Backend Schema & Storage
+
+**Goal:** Define the data model, create the database table, and implement span CRUD.
+
+**Tasks:**
+- [ ] Create `backend/src/schemas/entities/trace.py` with `AgentSpan`, `SpanPhase` enum, `SpanStatus` enum Pydantic models
+- [ ] Create SQLAlchemy model in `backend/src/models/` (or extend existing models module) for `agent_spans` table
+- [ ] Create Alembic migration `0002_add_agent_spans.py` with columns matching the schema, indexes on `trace_id`, `thread_id`, `started_at`
+- [ ] Create `backend/src/repos/trace_repo.py` with `create_span`, `update_span`, `get_spans_by_trace`, `get_spans_by_thread`, `get_span_by_id`
+
+**Acceptance Criteria:**
+- Migration runs cleanly on fresh and existing databases
+- Repo methods pass unit tests for CRUD operations
+- Schema validates all field types and constraints
+
+### Phase 2: Span Lifecycle & Instrumentation Utilities
+
+**Goal:** Provide ergonomic utilities for emitting spans from agent code.
+
+**Tasks:**
+- [ ] Create `backend/src/utils/tracing.py` with:
+  - `start_span(trace_id, phase, thread_id, **kwargs) -> AgentSpan`
+  - `end_span(span_id, status, output_tokens, cost_usd, error, **kwargs)`
+  - `@trace_phase(phase)` async context manager / decorator
+  - `TraceContext` using `contextvars` for propagating `trace_id` and `parent_span_id`
+- [ ] Integrate `@trace_phase` into existing agent pipeline phases (planner, generator, evaluator, handoff points)
+- [ ] Wire token count and cost data from LLM callbacks into span finalization
+
+**Acceptance Criteria:**
+- Context manager correctly creates and finalizes spans with accurate timing
+- Nested spans (e.g., tool_call inside generator) have correct `parent_span_id`
+- Token counts and cost flow through from LLM callbacks
+- Unit tests cover normal completion, error, and nested span scenarios
+
+### Phase 3: REST API Endpoints
+
+**Goal:** Expose trace data for frontend consumption and external integrations.
+
+**Tasks:**
+- [ ] Create `backend/src/routes/v0/trace.py` with endpoints:
+  - `GET /api/v0/threads/{thread_id}/traces` — paginated list of trace groups
+  - `GET /api/v0/threads/{thread_id}/traces/{trace_id}` — all spans for a trace
+  - `GET /api/v0/traces/{trace_id}/spans/{span_id}` — single span detail
+- [ ] Add response schemas in `backend/src/schemas/entities/trace.py` (list/detail response wrappers)
+- [ ] Register routes in the v0 router
+- [ ] Add authentication/authorization checks (same as thread access)
+
+**Acceptance Criteria:**
+- Endpoints return correct data shapes per OpenAPI spec
+- Thread-level auth prevents cross-user trace access
+- Pagination works for threads with many traces
+- Integration tests cover happy path and 404/403 scenarios
+
+### Phase 4: Frontend Timeline Component
+
+**Goal:** Visual swimlane timeline in the thread view showing agent phases.
+
+**Tasks:**
+- [ ] Create `frontend/src/components/timeline/TraceTimeline.tsx` — main container component
+- [ ] Create `frontend/src/components/timeline/SpanBlock.tsx` — individual phase block with color coding
+- [ ] Create `frontend/src/components/timeline/SpanDetail.tsx` — drill-down panel for a selected span
+- [ ] Add React Query hook `frontend/src/hooks/useTraceData.ts` for fetching trace API data
+- [ ] Integrate timeline into the thread/chat view (collapsible panel)
+- [ ] Phase color mapping: planner=blue, generator=green, evaluator=amber, handoff=purple, tool_call=slate, retrieval=cyan
+- [ ] Dark mode support via Tailwind classes
+- [ ] Hover tooltip showing duration, tokens, cost
+
+**Acceptance Criteria:**
+- Timeline renders correctly for traces with 1-20+ spans
+- Span blocks are proportionally sized by duration
+- Hover shows tooltip; click opens detail panel
+- Responsive on desktop and tablet viewports
+- Vitest component tests for rendering and interaction
+
+### Phase 5: OpenTelemetry OTLP Export
+
+**Goal:** Optional export of spans to external observability platforms.
+
+**Tasks:**
+- [ ] Add `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc` to `backend/pyproject.toml` as optional dependencies
+- [ ] Create `backend/src/utils/otel_exporter.py` with:
+  - OTel `TracerProvider` setup (conditional on `OTEL_EXPORTER_OTLP_ENDPOINT` env var)
+  - `export_span(agent_span: AgentSpan)` mapping function
+  - Attribute mapping: phase, model, tokens, cost, thread_id, error
+- [ ] Call `export_span` from `end_span` when OTLP is configured
+- [ ] Add `.env.example` entries for OTLP configuration
+
+**Acceptance Criteria:**
+- When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, no OTel code is loaded (zero overhead)
+- When configured, spans appear in Jaeger/collector with correct attributes
+- Unit tests mock the exporter and verify attribute mapping
+
+## Dependencies & Risks
+
+| Dependency | Risk | Mitigation |
+|-----------|------|------------|
+| Agent pipeline phase hooks | Medium — planner/evaluator may not have clean entry/exit points today | Phase 2 may require refactoring phase boundaries; start with generator which is well-defined |
+| LLM callback token counts | Low — LangChain callbacks already provide this | Wire existing callback data into span finalization |
+| PostgreSQL migration | Low — additive table, no schema changes to existing tables | Standard Alembic migration; reversible |
+| OpenTelemetry deps | Low — optional extras, not required at runtime | Conditional imports; feature-flagged via env var |
+| Frontend bundle size | Low — timeline is a small component | Lazy-load the timeline panel |
+
+## Testing Strategy
+
+### Unit Tests
+- `backend/tests/unit/test_tracing.py` — span lifecycle, context propagation, timing accuracy
+- `backend/tests/unit/test_trace_repo.py` — CRUD operations with mocked DB
+- `backend/tests/unit/test_otel_exporter.py` — attribute mapping, conditional loading
+- `frontend/src/tests/TraceTimeline.test.tsx` — rendering, interaction, empty states
+
+### Integration Tests
+- `backend/tests/integration/test_trace_routes.py` — full API roundtrip (create spans via tracing utils, fetch via API)
+- Database migration up/down test
+
+### Manual Testing
+- Run agent with tracing enabled, verify timeline appears in frontend
+- Configure OTLP endpoint, verify spans in Jaeger UI
+
+## Estimated Effort
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1: Schema & Storage | 1-2 days |
+| Phase 2: Lifecycle & Instrumentation | 2-3 days |
+| Phase 3: REST API | 1 day |
+| Phase 4: Frontend Timeline | 2-3 days |
+| Phase 5: OTLP Export | 1-2 days |
+| **Total** | **7-11 days** |

--- a/.claude/specs/agent-observability.md
+++ b/.claude/specs/agent-observability.md
@@ -1,0 +1,79 @@
+# Agent Phase Observability & Trace Visualization
+
+## Summary
+
+Structured spans per agent phase (planner, generator, evaluator, handoff) with timing, token counts, model, cost, and error info. Frontend timeline component showing phases as visual blocks with drill-down. OpenTelemetry export for external tools (Jaeger, Honeycomb, Datadog).
+
+## Motivation
+
+Today, when an agent processes a request it passes through multiple internal phases — planning, generation, evaluation, tool calls, handoffs — but there is no structured visibility into what happened, how long each phase took, how many tokens were consumed, or where errors occurred. Operators and developers debugging agent behavior must rely on raw logs. This spec introduces first-class observability spans that capture per-phase telemetry and expose it through both an API and a visual frontend timeline.
+
+## Key Components
+
+### 1. AgentSpan Schema (`backend/src/schemas/entities/trace.py`)
+
+A Pydantic model representing a single phase span:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `uuid` | Unique span identifier |
+| `trace_id` | `uuid` | Groups spans belonging to the same thread turn |
+| `parent_span_id` | `uuid \| None` | For nested spans (e.g., tool call inside generator) |
+| `thread_id` | `str` | Thread this span belongs to |
+| `phase` | `enum` | One of: `planner`, `generator`, `evaluator`, `handoff`, `tool_call`, `retrieval` |
+| `model` | `str \| None` | LLM model used (if applicable) |
+| `started_at` | `datetime` | Phase start timestamp |
+| `ended_at` | `datetime \| None` | Phase end timestamp |
+| `duration_ms` | `int \| None` | Computed duration in milliseconds |
+| `input_tokens` | `int \| None` | Prompt/input token count |
+| `output_tokens` | `int \| None` | Completion/output token count |
+| `cost_usd` | `float \| None` | Estimated cost in USD |
+| `status` | `enum` | `running`, `completed`, `errored` |
+| `error` | `str \| None` | Error message if status is errored |
+| `metadata` | `dict \| None` | Arbitrary key-value metadata |
+
+### 2. Span Lifecycle Management (`backend/src/utils/tracing.py`)
+
+- `start_span(trace_id, phase, **kwargs) -> AgentSpan` — create and persist a new span
+- `end_span(span_id, status, **kwargs)` — finalize timing and token counts
+- `@trace_phase(phase)` — decorator / async context manager for automatic span lifecycle
+- Thread-local or context-var based trace context propagation
+
+### 3. Storage — PostgreSQL `agent_spans` Table
+
+New Alembic migration adding `agent_spans` table with indexes on `trace_id`, `thread_id`, and `started_at`. Supports efficient retrieval of all spans for a thread turn.
+
+### 4. API Endpoints
+
+- `GET /api/v0/threads/{thread_id}/traces` — list all trace groups for a thread
+- `GET /api/v0/threads/{thread_id}/traces/{trace_id}` — get all spans for a specific trace
+- `GET /api/v0/traces/{trace_id}/spans/{span_id}` — get a single span with full metadata
+
+### 5. Frontend Timeline Component
+
+- Horizontal swimlane timeline showing phases as colored blocks
+- Color coding per phase type (planner = blue, generator = green, evaluator = amber, etc.)
+- Hover tooltip with timing, token counts, cost
+- Click drill-down to see full span details (metadata, error info, nested spans)
+- Responsive layout, dark-mode compatible
+
+### 6. OpenTelemetry OTLP Exporter
+
+- Optional OTLP gRPC/HTTP exporter for shipping spans to Jaeger, Honeycomb, Datadog, etc.
+- Configured via environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`)
+- Maps `AgentSpan` fields to OTel span attributes
+- Disabled by default; zero overhead when off
+
+## Dependencies
+
+- Works standalone; most valuable when planner + evaluator phases are active
+- Integrates with existing cost-tracking infrastructure for `cost_usd` field
+- No external service dependencies required (OTLP export is optional)
+
+## Labels
+
+`enhancement`, `observability`, `frontend`, `harness-design`
+
+## Milestone
+
+v0.10.0 — Harness Design v2


### PR DESCRIPTION
## Summary

- Adds spec and implementation plan for Agent Phase Observability & Trace Visualization
- Structured spans per agent phase (planner, generator, evaluator, handoff, tool_call, retrieval) with timing, token counts, model, cost, and error info
- Frontend swimlane timeline component for visual phase drill-down
- Optional OpenTelemetry OTLP export for external observability tools

Closes #904

## Implementation Plan

Five phases outlined in [`.claude/plans/agent-observability.md`](https://github.com/ruska-ai/orchestra/blob/feat/agent-observability/.claude/plans/agent-observability.md):

1. **Schema & Storage** — Pydantic models, SQLAlchemy model, Alembic migration, repo layer
2. **Span Lifecycle & Instrumentation** — `tracing.py` utilities, `@trace_phase` decorator, context propagation
3. **REST API** — Thread trace endpoints with auth and pagination
4. **Frontend Timeline** — Swimlane visualization with colored phase blocks, hover tooltips, click drill-down
5. **OpenTelemetry Export** — Optional OTLP exporter, zero overhead when disabled

## Test plan

- [ ] Unit tests for span lifecycle, context propagation, timing accuracy
- [ ] Unit tests for trace repo CRUD operations
- [ ] Integration tests for API endpoints (roundtrip create + fetch)
- [ ] Vitest component tests for timeline rendering and interaction
- [ ] Manual verification of timeline in thread view
- [ ] OTLP export verification with Jaeger (when configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)