### PR TITLE
feat: Sprint contracts — agents negotiate scope and pass/fail criteria before execution

### DIFF
--- a/.claude/plans/sprint-contracts.md
+++ b/.claude/plans/sprint-contracts.md
@@ -1,0 +1,130 @@
+# Plan: Sprint Contracts — Negotiated Acceptance Criteria Between Agents
+
+## Overview
+
+Implement a contract negotiation protocol between generator and evaluator agents. Before each sprint (work chunk), the generator proposes a `SprintContract` containing features to build and testable criteria. The evaluator reviews and can counter-propose. Once agreed, the contract is persisted and used as the grading rubric. This mirrors Anthropic's harness pattern where Sprint 3 of their retro game maker had 27 testable criteria for the level editor alone.
+
+Currently, Orchestra's subagent system supports delegation but has no pre-execution agreement on acceptance criteria. Sprint contracts bridge the gap between high-level product specs and testable implementation.
+
+## User Stories
+
+1. **As a generator agent**, I want to propose a sprint contract with specific features and test criteria before starting work, so that expectations are clear and measurable.
+
+2. **As an evaluator agent**, I want to review proposed contracts and counter-propose changes to criteria or scope, so that I can ensure the contract is realistic and testable.
+
+3. **As a user watching an agent thread**, I want to see the negotiated contract and per-criterion pass/fail results in the frontend, so I understand what the agents agreed to and how they performed.
+
+4. **As an orchestration developer**, I want contracts persisted as structured markdown in the StateBackend, so both agents can read/write them as a communication channel.
+
+5. **As a system operator**, I want the negotiation loop bounded by a configurable max-rounds limit, so agents cannot endlessly negotiate and block progress.
+
+## Implementation Phases
+
+### Phase 1: Schema and Data Model
+
+**Goal:** Define the `SprintContract` and `TestCriterion` Pydantic schemas.
+
+**Files:**
+- `backend/src/schemas/entities/sprint_contract.py` (new)
+
+**Acceptance Criteria:**
+- [ ] `TestCriterion` model with `description: str` and `verification_method: str`
+- [ ] `SprintContract` model with `sprint_number`, `title`, `features`, `test_criteria`, `status` (Literal enum), `generator_notes`, `evaluator_notes`, `negotiation_rounds`
+- [ ] Status supports: `proposed`, `negotiating`, `agreed`, `in_progress`, `completed`, `failed`
+- [ ] Schema exports registered in `backend/src/schemas/entities/__init__.py`
+- [ ] Unit tests for schema validation and status transitions
+
+### Phase 2: Contract Negotiation Flow
+
+**Goal:** Add contract negotiation orchestration to the LLM controller for the Full Harness template.
+
+**Files:**
+- `backend/src/controllers/llm.py` (modify)
+
+**Acceptance Criteria:**
+- [ ] Generator proposes contract before each feature chunk when using Full Harness template
+- [ ] Contract is passed to evaluator for review
+- [ ] Evaluator can approve, request changes (with specific feedback), or reject scope
+- [ ] If changes requested, generator revises (max N rounds, configurable, default 3)
+- [ ] Once agreed, contract status transitions to `agreed` and is persisted
+- [ ] Negotiation terminates gracefully if max rounds exceeded (falls back to last proposal)
+
+### Phase 3: File-Based Communication via StateBackend
+
+**Goal:** Persist contracts as structured markdown files so both agents can read/write them.
+
+**Files:**
+- `backend/src/controllers/llm.py` (modify)
+- Potentially a utility module for contract serialization
+
+**Acceptance Criteria:**
+- [ ] Contracts stored at `/contracts/sprint-{N}.md` in StateBackend
+- [ ] Evaluation results stored at `/contracts/sprint-{N}-evaluation.md`
+- [ ] Both generator and evaluator can load/save contracts via StateBackend
+- [ ] Markdown format is human-readable and machine-parseable
+
+### Phase 4: Contract-Aware Evaluation
+
+**Goal:** Modify evaluator orchestration to grade against agreed contract criteria individually.
+
+**Files:**
+- `backend/src/controllers/llm.py` (modify)
+
+**Acceptance Criteria:**
+- [ ] Evaluator loads the agreed sprint contract for the current sprint
+- [ ] Each `TestCriterion` is graded individually (pass/fail + notes)
+- [ ] Contract compliance is included in overall evaluation score
+- [ ] Results reported in "17/27 criteria passed" style
+- [ ] Evaluation results persisted back to StateBackend
+
+### Phase 5: Frontend — Contract Panel and Criteria Checklist
+
+**Goal:** Display contracts, negotiation history, and per-criterion results in the chat UI.
+
+**Files:**
+- `frontend/src/components/panels/ContractPanel.tsx` (new)
+- `frontend/src/components/lists/CriteriaChecklist.tsx` (new)
+
+**Acceptance Criteria:**
+- [ ] Contract panel shows current sprint's agreed criteria
+- [ ] Checklist view displays each criterion with pass/fail indicator after evaluation
+- [ ] Negotiation history visible (collapsed by default)
+- [ ] Sprint progress indicator across the full thread
+- [ ] Responsive layout consistent with existing Orchestra UI patterns
+
+### Phase 6: Tests
+
+**Goal:** Comprehensive unit and integration test coverage.
+
+**Files:**
+- `backend/tests/unit/test_sprint_contract.py` (new)
+- `backend/tests/integration/test_sprint_contract_flow.py` (new)
+
+**Acceptance Criteria:**
+- [ ] Unit test: contract schema validation, field constraints
+- [ ] Unit test: status transitions are valid (e.g., cannot go from `proposed` to `completed`)
+- [ ] Unit test: negotiation terminates after max rounds
+- [ ] Integration test: generator proposes, evaluator counter-proposes, agreement reached
+- [ ] Integration test: evaluator grades against specific contract criteria
+- [ ] All tests pass in CI
+
+## Dependencies and Risks
+
+### Dependencies
+- **Evaluator Agent** (`evaluator-agent.md` spec): Sprint contracts require an evaluator agent to review proposals and grade results. This is a hard dependency for Phases 2-4.
+- **Planner Agent** (`planner-agent.md` spec): Best used with a planner agent that generates high-level specs which contracts break down into sprints. This is a soft dependency (contracts can work without it).
+- **StateBackend**: File-based communication requires a working StateBackend implementation. This already exists in Orchestra.
+- **Full Harness Template**: Contract negotiation integrates into the Full Harness orchestration template.
+
+### Risks
+- **Negotiation loops**: Agents could produce low-quality counter-proposals that waste rounds without convergence. Mitigated by max-rounds limit and fallback to last proposal.
+- **Schema evolution**: Contract schema may need to evolve as we learn what criteria agents produce. Keep schema flexible with optional fields.
+- **LLM reliability**: Agents may not reliably produce well-structured contracts. May need structured output enforcement or retry logic.
+- **Evaluator dependency**: If the evaluator-agent spec is not yet implemented, Phases 2-4 cannot be fully realized. Phase 1 (schema) and Phase 5 (frontend) can proceed independently.
+
+## Testing Strategy
+
+- **Unit tests** validate schema construction, serialization, and status transition rules in isolation.
+- **Integration tests** use mocked LLM responses to simulate the full negotiation flow: proposal, counter-proposal, agreement, and grading.
+- **Frontend tests** (Vitest + Testing Library) verify the ContractPanel and CriteriaChecklist render correctly for various contract states.
+- Run via `make test` (backend) and `npm run test` (frontend).

--- a/.claude/specs/sprint-contracts.md
+++ b/.claude/specs/sprint-contracts.md
@@ -1,0 +1,102 @@
+# Plan: Sprint Contracts — Negotiated Acceptance Criteria Between Agents
+
+## Context
+
+Anthropic's harness uses sprint contracts where the generator and evaluator negotiate what "done" looks like before code is written. Sprint 3 of their retro game maker had 27 testable criteria for the level editor alone, and the evaluator graded against those specific criteria. This bridges the gap between high-level product specs and testable implementation.
+
+Orchestra's subagent system supports delegation but has no contract negotiation protocol. Subagents execute instructions without pre-agreeing on acceptance criteria.
+
+## Requirements
+
+- `SprintContract` schema with features, test criteria, and status
+- Generator proposes contract before each work chunk
+- Evaluator reviews and can counter-propose
+- Negotiation loop with configurable max rounds
+- Agreed contracts persisted and used for grading
+- Frontend displays contracts with status
+
+## Implementation Steps
+
+### Step 1: Schema
+
+```python
+# sprint_contract.py
+class TestCriterion(BaseModel):
+    description: str              # What to test
+    verification_method: str      # How to verify (manual, Playwright, API call, etc.)
+
+class SprintContract(BaseModel):
+    sprint_number: int
+    title: str
+    features: list[str]           # What will be built
+    test_criteria: list[TestCriterion]
+    status: Literal["proposed", "negotiating", "agreed", "in_progress", "completed", "failed"]
+    generator_notes: Optional[str] = None
+    evaluator_notes: Optional[str] = None
+    negotiation_rounds: int = 0
+```
+
+### Step 2: Contract negotiation flow
+
+Add to orchestration in `backend/src/controllers/llm.py`:
+
+1. When using Full Harness template, generator proposes contract before each feature chunk
+2. Contract is passed to evaluator for review
+3. Evaluator can: approve, request changes (with specific feedback), or reject scope
+4. If changes requested, generator revises (max 3 rounds)
+5. Once agreed, contract is persisted to `/contracts/sprint-{N}.md`
+6. Generator builds against the contract
+7. Evaluator grades against the contract's specific `test_criteria`
+
+### Step 3: Contract-aware evaluation
+
+Modify evaluator orchestration to:
+
+- Load the agreed sprint contract for the current sprint
+- Grade each `TestCriterion` individually (pass/fail + notes)
+- Include contract compliance in overall evaluation score
+- Report: "17/27 criteria passed" style results
+
+### Step 4: File-based communication
+
+Contracts stored as structured markdown in StateBackend:
+
+```
+/contracts/sprint-1.md
+/contracts/sprint-2.md
+/contracts/sprint-1-evaluation.md
+```
+
+Both generator and evaluator read/write these files as their communication channel.
+
+### Step 5: Frontend
+
+- Contract panel showing current sprint's agreed criteria
+- Checklist view: each criterion with pass/fail indicator after evaluation
+- Negotiation history (collapsed by default)
+- Sprint progress indicator across the full thread
+
+### Step 6: Tests
+
+- Unit test: contract schema validation, status transitions
+- Unit test: negotiation terminates after max rounds
+- Integration test: generator proposes, evaluator counter-proposes, agreement reached
+- Integration test: evaluator grades against specific contract criteria
+
+## File Changes
+
+- `backend/src/schemas/entities/sprint_contract.py` — new
+- `backend/src/controllers/llm.py` — contract negotiation flow
+- `frontend/src/components/panels/ContractPanel.tsx` — new
+- `frontend/src/components/lists/CriteriaChecklist.tsx` — new
+
+## Dependencies
+
+- Requires evaluator agent (plan: `evaluator-agent.md`)
+- Best used with planner agent (plan: `planner-agent.md`) to generate the high-level spec that contracts break down
+
+## GitHub Issue
+
+**Title:** `feat: Sprint contracts — agents negotiate scope and pass/fail criteria before execution`
+**Labels:** `enhancement`, `agents`, `harness-design`
+**Milestone:** v0.10.0 — Harness Design v2


### PR DESCRIPTION
## Summary

- Add `SprintContract` and `TestCriterion` Pydantic schemas for negotiated acceptance criteria between generator and evaluator agents
- Define contract negotiation flow with configurable max rounds, file-based persistence via StateBackend, and contract-aware evaluation grading
- Include implementation plan with 6 phases: schema, negotiation flow, StateBackend communication, contract-aware evaluation, frontend panels, and tests

Closes #910

## Spec & Plan

- Spec: [`.claude/specs/sprint-contracts.md`](https://github.com/ruska-ai/orchestra/blob/feat/sprint-contracts/.claude/specs/sprint-contracts.md)
- Plan: [`.claude/plans/sprint-contracts.md`](https://github.com/ruska-ai/orchestra/blob/feat/sprint-contracts/.claude/plans/sprint-contracts.md)

## Dependencies

- Requires evaluator-agent (hard dependency for Phases 2-4)
- Best used with planner-agent (soft dependency)

## Test plan

- [ ] Unit tests for `SprintContract` and `TestCriterion` schema validation
- [ ] Unit tests for status transition rules and negotiation round limits
- [ ] Integration test: full negotiation loop (propose, counter-propose, agree)
- [ ] Integration test: evaluator grades against contract criteria
- [ ] Frontend tests for ContractPanel and CriteriaChecklist components


🤖 Generated with [Claude Code](https://claude.com/claude-code)