### PR TITLE
feat: Cost tracking frontend components

### DIFF
--- a/frontend/src/components/chat/CostBadge.tsx
+++ b/frontend/src/components/chat/CostBadge.tsx
@@ -1,0 +1,67 @@
+import { DollarSign } from "lucide-react";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface CostBadgeProps {
+	totalCost: number;
+	turnCount: number;
+	costByPhase?: Record<string, number>;
+}
+
+export function CostBadge({
+	totalCost,
+	turnCount,
+	costByPhase,
+}: CostBadgeProps) {
+	if (totalCost === 0) return null;
+
+	const formatCost = (cost: number) => {
+		if (cost < 0.01) return `$${cost.toFixed(4)}`;
+		if (cost < 1) return `$${cost.toFixed(3)}`;
+		return `$${cost.toFixed(2)}`;
+	};
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button className="flex h-8 items-center gap-1.5 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors">
+					<DollarSign className="h-3.5 w-3.5" />
+					<span>{formatCost(totalCost)}</span>
+					<span className="text-muted-foreground/60">&middot;</span>
+					<span>{turnCount} calls</span>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-64 p-3" align="start">
+				<div className="space-y-2">
+					<div className="text-sm font-medium">Cost Breakdown</div>
+					<div className="flex justify-between text-xs">
+						<span className="text-muted-foreground">Total</span>
+						<span className="font-mono">{formatCost(totalCost)}</span>
+					</div>
+					<div className="flex justify-between text-xs">
+						<span className="text-muted-foreground">LLM Calls</span>
+						<span className="font-mono">{turnCount}</span>
+					</div>
+					{costByPhase && Object.keys(costByPhase).length > 0 && (
+						<>
+							<div className="border-t border-border pt-2 text-xs font-medium">
+								By Phase
+							</div>
+							{Object.entries(costByPhase).map(([phase, cost]) => (
+								<div key={phase} className="flex justify-between text-xs">
+									<span className="text-muted-foreground capitalize">
+										{phase}
+									</span>
+									<span className="font-mono">{formatCost(cost)}</span>
+								</div>
+							))}
+						</>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/frontend/src/components/chat/CostBadge.tsx
+++ b/frontend/src/components/chat/CostBadge.tsx
@@ -5,10 +5,16 @@ import {
 	PopoverTrigger,
 } from "@/components/ui/popover";
 
+function formatCost(cost: number): string {
+	if (cost < 0.01) return `$${cost.toFixed(4)}`;
+	if (cost < 1) return `$${cost.toFixed(3)}`;
+	return `$${cost.toFixed(2)}`;
+}
+
 interface CostBadgeProps {
 	totalCost: number;
 	turnCount: number;
-	costByPhase?: Record<string, number>;
+	costByPhase: Record<string, number>;
 }
 
 export function CostBadge({
@@ -18,16 +24,13 @@ export function CostBadge({
 }: CostBadgeProps) {
 	if (totalCost === 0) return null;
 
-	const formatCost = (cost: number) => {
-		if (cost < 0.01) return `$${cost.toFixed(4)}`;
-		if (cost < 1) return `$${cost.toFixed(3)}`;
-		return `$${cost.toFixed(2)}`;
-	};
-
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<button className="flex h-8 items-center gap-1.5 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors">
+				<button
+					aria-label={`Cost: ${formatCost(totalCost)}, ${turnCount} API calls`}
+					className="flex h-8 items-center gap-1.5 rounded-full border border-border/60 px-3 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+				>
 					<DollarSign className="h-3.5 w-3.5" />
 					<span>{formatCost(totalCost)}</span>
 					<span className="text-muted-foreground/60">&middot;</span>
@@ -45,7 +48,7 @@ export function CostBadge({
 						<span className="text-muted-foreground">LLM Calls</span>
 						<span className="font-mono">{turnCount}</span>
 					</div>
-					{costByPhase && Object.keys(costByPhase).length > 0 && (
+					{Object.keys(costByPhase).length > 0 && (
 						<>
 							<div className="border-t border-border pt-2 text-xs font-medium">
 								By Phase

--- a/frontend/src/hooks/useCostTracking.ts
+++ b/frontend/src/hooks/useCostTracking.ts
@@ -1,5 +1,11 @@
 import { useState, useCallback } from "react";
 
+/**
+ * Internal state for cost tracking.
+ *
+ * `totalInputTokens` and `totalOutputTokens` are tracked here and returned
+ * from the hook for use by the cost breakdown panel in a future iteration.
+ */
 interface CostState {
 	totalCost: number;
 	turnCount: number;

--- a/frontend/src/hooks/useCostTracking.ts
+++ b/frontend/src/hooks/useCostTracking.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+
+interface CostState {
+	totalCost: number;
+	turnCount: number;
+	costByPhase: Record<string, number>;
+	totalInputTokens: number;
+	totalOutputTokens: number;
+}
+
+export function useCostTracking() {
+	const [costState, setCostState] = useState<CostState>({
+		totalCost: 0,
+		turnCount: 0,
+		costByPhase: {},
+		totalInputTokens: 0,
+		totalOutputTokens: 0,
+	});
+
+	const handleCostUpdate = useCallback(
+		(data: {
+			cost_usd: number;
+			input_tokens: number;
+			output_tokens: number;
+			phase: string;
+		}) => {
+			setCostState((prev) => ({
+				totalCost: prev.totalCost + data.cost_usd,
+				turnCount: prev.turnCount + 1,
+				costByPhase: {
+					...prev.costByPhase,
+					[data.phase]: (prev.costByPhase[data.phase] || 0) + data.cost_usd,
+				},
+				totalInputTokens: prev.totalInputTokens + data.input_tokens,
+				totalOutputTokens: prev.totalOutputTokens + data.output_tokens,
+			}));
+		},
+		[],
+	);
+
+	const resetCost = useCallback(() => {
+		setCostState({
+			totalCost: 0,
+			turnCount: 0,
+			costByPhase: {},
+			totalInputTokens: 0,
+			totalOutputTokens: 0,
+		});
+	}, []);
+
+	return { ...costState, handleCostUpdate, resetCost };
+}

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -73,7 +73,7 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
-export interface CustomEvent {
+export interface CustomSSEEvent {
 	type: "custom";
 	data: {
 		type: string;
@@ -98,7 +98,7 @@ export type SSEEvent =
 	| ValuesEvent
 	| ErrorEvent
 	| AbortedEvent
-	| CustomEvent;
+	| CustomSSEEvent;
 
 export interface DoneSignal {
 	type: "done";

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -36,7 +36,8 @@ export type SSEEventType =
 	| "messages"
 	| "values"
 	| "error"
-	| "aborted";
+	| "aborted"
+	| "custom";
 
 export interface MetadataEvent {
 	type: "metadata";
@@ -72,12 +73,32 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
+export interface CustomEvent {
+	type: "custom";
+	data: {
+		type: string;
+		[key: string]: unknown;
+	};
+}
+
+export interface CostUpdateEvent {
+	type: "cost_update";
+	model: string;
+	input_tokens: number;
+	output_tokens: number;
+	cost_usd: number;
+	duration_seconds: number;
+	running_total_usd: number;
+	phase: string;
+}
+
 export type SSEEvent =
 	| MetadataEvent
 	| MessagesEvent
 	| ValuesEvent
 	| ErrorEvent
-	| AbortedEvent;
+	| AbortedEvent
+	| CustomEvent;
 
 export interface DoneSignal {
 	type: "done";


### PR DESCRIPTION
## Summary

Closes #905

Frontend components for cost tracking — CostBadge display component, useCostTracking accumulation hook, and custom SSE type definitions.

## Files Changed

- `frontend/src/lib/entities/stream.ts` — modified: added `CustomSSEEvent`, `CostUpdateEvent`, `"custom"` SSE type
- `frontend/src/components/chat/CostBadge.tsx` — new: pill badge with popover cost breakdown
- `frontend/src/hooks/useCostTracking.ts` — new: hook to accumulate cost data from SSE events

## Human Review Checklist

- [ ] Verify `CustomSSEEvent` is used (not `CustomEvent` which shadows the DOM global)
- [ ] Verify `CostBadge` returns `null` when `totalCost === 0` (no empty badge)
- [ ] Verify `CostBadge` has `aria-label` on the popover trigger button for accessibility
- [ ] Verify `formatCost()` is defined at module level (not inside component — avoids re-creation per render)
- [ ] Verify `costByPhase` prop is required (not optional) in `CostBadgeProps`
- [ ] Verify `useCostTracking` uses functional updater pattern (`setCostState(prev => ...)`) to avoid stale closures
- [ ] Verify no `dangerouslySetInnerHTML` — cost values rendered as text content only
- [ ] Verify `CostBadge` styling matches existing pill patterns in `ChatUtilityRow` (`h-8 rounded-full border border-border/60 px-3 text-xs`)
- [ ] Note: `CostBadge` is not yet wired into any parent component — this is intentional for independent review. Wiring happens when this merges with the backend branch.
- [ ] Run `cd frontend && npm run lint && npm run test` — should pass

## Test Plan

- [ ] `CostBadge` renders nothing when `totalCost === 0`
- [ ] `CostBadge` displays formatted cost (`$0.0034`, `$0.123`, `$12.34` at different scales)
- [ ] Popover opens on click showing phase breakdown
- [ ] `useCostTracking.handleCostUpdate()` accumulates totals correctly across multiple calls
- [ ] `useCostTracking.resetCost()` clears all state to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)