### PR TITLE
feat: Planner agent frontend components

### DIFF
--- a/frontend/src/components/chat/PlanPanel.tsx
+++ b/frontend/src/components/chat/PlanPanel.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, FileText, Check, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+interface PlanPanelProps {
+	plan: string;
+	status: "planning" | "awaiting_approval" | "approved" | "generating";
+	onApprove?: () => void;
+	onReject?: () => void;
+}
+
+export function PlanPanel({
+	plan,
+	status,
+	onApprove,
+	onReject,
+}: PlanPanelProps) {
+	const [isOpen, setIsOpen] = useState(status === "awaiting_approval");
+
+	const statusColors = {
+		planning: "bg-yellow-500/10 text-yellow-600 border-yellow-500/30",
+		awaiting_approval: "bg-blue-500/10 text-blue-600 border-blue-500/30",
+		approved: "bg-green-500/10 text-green-600 border-green-500/30",
+		generating: "bg-purple-500/10 text-purple-600 border-purple-500/30",
+	};
+
+	const statusLabels = {
+		planning: "Planning...",
+		awaiting_approval: "Awaiting Approval",
+		approved: "Approved",
+		generating: "Generating...",
+	};
+
+	return (
+		<div className="my-2 rounded-lg border border-border bg-card">
+			<Collapsible open={isOpen} onOpenChange={setIsOpen}>
+				<CollapsibleTrigger asChild>
+					<button className="flex w-full items-center gap-2 px-4 py-3 text-sm hover:bg-accent/50 transition-colors rounded-t-lg">
+						{isOpen ? (
+							<ChevronDown className="h-4 w-4 text-muted-foreground" />
+						) : (
+							<ChevronRight className="h-4 w-4 text-muted-foreground" />
+						)}
+						<FileText className="h-4 w-4 text-muted-foreground" />
+						<span className="font-medium">Product Plan</span>
+						<Badge
+							variant="outline"
+							className={`ml-auto text-xs ${statusColors[status]}`}
+						>
+							{statusLabels[status]}
+						</Badge>
+					</button>
+				</CollapsibleTrigger>
+				<CollapsibleContent>
+					<div className="border-t border-border px-4 py-3">
+						<div className="prose prose-sm dark:prose-invert max-w-none">
+							<div dangerouslySetInnerHTML={{ __html: plan }} />
+						</div>
+						{status === "awaiting_approval" && (
+							<div className="mt-4 flex gap-2 border-t border-border pt-3">
+								<Button
+									size="sm"
+									variant="default"
+									onClick={onApprove}
+									className="gap-1.5"
+								>
+									<Check className="h-3.5 w-3.5" />
+									Approve Plan
+								</Button>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={onReject}
+									className="gap-1.5"
+								>
+									<X className="h-3.5 w-3.5" />
+									Reject
+								</Button>
+							</div>
+						)}
+					</div>
+				</CollapsibleContent>
+			</Collapsible>
+		</div>
+	);
+}

--- a/frontend/src/components/chat/PlanPanel.tsx
+++ b/frontend/src/components/chat/PlanPanel.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ChevronDown, ChevronRight, FileText, Check, X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -15,6 +16,20 @@ interface PlanPanelProps {
 	onReject?: () => void;
 }
 
+const statusColors = {
+	planning: "bg-yellow-500/10 text-yellow-600 border-yellow-500/30",
+	awaiting_approval: "bg-blue-500/10 text-blue-600 border-blue-500/30",
+	approved: "bg-green-500/10 text-green-600 border-green-500/30",
+	generating: "bg-purple-500/10 text-purple-600 border-purple-500/30",
+};
+
+const statusLabels = {
+	planning: "Planning...",
+	awaiting_approval: "Awaiting Approval",
+	approved: "Approved",
+	generating: "Generating...",
+};
+
 export function PlanPanel({
 	plan,
 	status,
@@ -23,19 +38,11 @@ export function PlanPanel({
 }: PlanPanelProps) {
 	const [isOpen, setIsOpen] = useState(status === "awaiting_approval");
 
-	const statusColors = {
-		planning: "bg-yellow-500/10 text-yellow-600 border-yellow-500/30",
-		awaiting_approval: "bg-blue-500/10 text-blue-600 border-blue-500/30",
-		approved: "bg-green-500/10 text-green-600 border-green-500/30",
-		generating: "bg-purple-500/10 text-purple-600 border-purple-500/30",
-	};
-
-	const statusLabels = {
-		planning: "Planning...",
-		awaiting_approval: "Awaiting Approval",
-		approved: "Approved",
-		generating: "Generating...",
-	};
+	useEffect(() => {
+		if (status === "awaiting_approval") {
+			setIsOpen(true);
+		}
+	}, [status]);
 
 	return (
 		<div className="my-2 rounded-lg border border-border bg-card">
@@ -59,15 +66,15 @@ export function PlanPanel({
 				</CollapsibleTrigger>
 				<CollapsibleContent>
 					<div className="border-t border-border px-4 py-3">
-						<div className="prose prose-sm dark:prose-invert max-w-none">
-							<div dangerouslySetInnerHTML={{ __html: plan }} />
-						</div>
+						<ReactMarkdown className="prose prose-sm dark:prose-invert max-w-none">
+							{plan}
+						</ReactMarkdown>
 						{status === "awaiting_approval" && (
 							<div className="mt-4 flex gap-2 border-t border-border pt-3">
 								<Button
 									size="sm"
 									variant="default"
-									onClick={onApprove}
+									onClick={() => onApprove?.()}
 									className="gap-1.5"
 								>
 									<Check className="h-3.5 w-3.5" />
@@ -76,7 +83,7 @@ export function PlanPanel({
 								<Button
 									size="sm"
 									variant="outline"
-									onClick={onReject}
+									onClick={() => onReject?.()}
 									className="gap-1.5"
 								>
 									<X className="h-3.5 w-3.5" />

--- a/frontend/src/hooks/usePlannerStatus.ts
+++ b/frontend/src/hooks/usePlannerStatus.ts
@@ -1,0 +1,43 @@
+import { useState, useCallback } from "react";
+
+interface PlannerState {
+	status: "idle" | "planning" | "awaiting_approval" | "approved" | "generating";
+	plan: string | null;
+}
+
+export function usePlannerStatus() {
+	const [plannerState, setPlannerState] = useState<PlannerState>({
+		status: "idle",
+		plan: null,
+	});
+
+	const handlePlanStatus = useCallback(
+		(data: { status: string; plan?: string }) => {
+			setPlannerState({
+				status: data.status as PlannerState["status"],
+				plan: data.plan || null,
+			});
+		},
+		[],
+	);
+
+	const approvePlan = useCallback(() => {
+		setPlannerState((prev) => ({ ...prev, status: "approved" }));
+	}, []);
+
+	const rejectPlan = useCallback(() => {
+		setPlannerState({ status: "idle", plan: null });
+	}, []);
+
+	const resetPlanner = useCallback(() => {
+		setPlannerState({ status: "idle", plan: null });
+	}, []);
+
+	return {
+		...plannerState,
+		handlePlanStatus,
+		approvePlan,
+		rejectPlan,
+		resetPlanner,
+	};
+}

--- a/frontend/src/hooks/usePlannerStatus.ts
+++ b/frontend/src/hooks/usePlannerStatus.ts
@@ -1,7 +1,16 @@
 import { useState, useCallback } from "react";
 
+const VALID_STATUSES = [
+	"idle",
+	"planning",
+	"awaiting_approval",
+	"approved",
+	"generating",
+] as const;
+type PlannerStatus = (typeof VALID_STATUSES)[number];
+
 interface PlannerState {
-	status: "idle" | "planning" | "awaiting_approval" | "approved" | "generating";
+	status: PlannerStatus;
 	plan: string | null;
 }
 
@@ -13,8 +22,11 @@ export function usePlannerStatus() {
 
 	const handlePlanStatus = useCallback(
 		(data: { status: string; plan?: string }) => {
+			const status = VALID_STATUSES.includes(data.status as PlannerStatus)
+				? (data.status as PlannerStatus)
+				: "idle";
 			setPlannerState({
-				status: data.status as PlannerState["status"],
+				status,
 				plan: data.plan || null,
 			});
 		},

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -73,15 +73,9 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
-export interface CustomEvent {
+export interface CustomSSEEvent {
 	type: "custom";
 	data: Record<string, unknown>;
-}
-
-export interface PlanStatusEvent {
-	type: "plan_status";
-	status: "planning" | "awaiting_approval" | "approved" | "generating";
-	plan?: string; // Markdown plan content (when status is "awaiting_approval")
 }
 
 export type SSEEvent =
@@ -90,7 +84,7 @@ export type SSEEvent =
 	| ValuesEvent
 	| ErrorEvent
 	| AbortedEvent
-	| CustomEvent;
+	| CustomSSEEvent;
 
 export interface DoneSignal {
 	type: "done";

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -36,7 +36,8 @@ export type SSEEventType =
 	| "messages"
 	| "values"
 	| "error"
-	| "aborted";
+	| "aborted"
+	| "custom";
 
 export interface MetadataEvent {
 	type: "metadata";
@@ -72,12 +73,24 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
+export interface CustomEvent {
+	type: "custom";
+	data: Record<string, unknown>;
+}
+
+export interface PlanStatusEvent {
+	type: "plan_status";
+	status: "planning" | "awaiting_approval" | "approved" | "generating";
+	plan?: string; // Markdown plan content (when status is "awaiting_approval")
+}
+
 export type SSEEvent =
 	| MetadataEvent
 	| MessagesEvent
 	| ValuesEvent
 	| ErrorEvent
-	| AbortedEvent;
+	| AbortedEvent
+	| CustomEvent;
 
 export interface DoneSignal {
 	type: "done";


### PR DESCRIPTION
## Summary

Closes #898

Frontend components for the Planner Agent — PlanPanel collapsible display, usePlannerStatus state hook, and plan SSE type definitions.

## Files Changed

- `frontend/src/lib/entities/stream.ts` — modified: added `CustomSSEEvent`, `"custom"` SSE type
- `frontend/src/components/chat/PlanPanel.tsx` — new: collapsible panel with status badges and approve/reject buttons
- `frontend/src/hooks/usePlannerStatus.ts` — new: planner state machine hook

## Human Review Checklist

- [ ] **CRITICAL**: Verify NO `dangerouslySetInnerHTML` — plan content must render via `ReactMarkdown` (XSS prevention)
- [ ] Verify `CustomSSEEvent` is used (not `CustomEvent` which shadows DOM global)
- [ ] Verify `PlanStatusEvent` interface was removed (disconnected, not in SSEEvent union)
- [ ] Verify `PlanPanel` auto-opens via `useEffect` when status transitions to `"awaiting_approval"` (not just on mount)
- [ ] Verify `statusColors`/`statusLabels` are defined outside the component (not recreated per render)
- [ ] Verify approve/reject buttons use null-safe calls: `onClick={() => onApprove?.()}` (not `onClick={onApprove}`)
- [ ] Verify `usePlannerStatus` has runtime type guard with `VALID_STATUSES` array — falls back to `"idle"` for unknown values
- [ ] Note: approve/reject buttons update local state only — backend HITL API wiring is a follow-up task
- [ ] Run `cd frontend && npm run lint && npm run test` — should pass

## Test Plan

- [ ] `PlanPanel` renders correctly for each status: `planning`, `awaiting_approval`, `approved`, `generating`
- [ ] `PlanPanel` auto-expands when status changes to `awaiting_approval`
- [ ] Approve/reject buttons only visible in `awaiting_approval` state
- [ ] Plan markdown renders safely (no raw HTML injection)
- [ ] `usePlannerStatus` transitions: `idle` → `planning` → `awaiting_approval` → `approved` → `generating`
- [ ] Unknown status strings fall back to `"idle"` (runtime guard)
- [ ] `resetPlanner()` returns to `idle` with `null` plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)