### PR TITLE
chore: Phase 0 — shared foundation for harness design features

### DIFF
--- a/backend/src/constants/__init__.py
+++ b/backend/src/constants/__init__.py
@@ -135,3 +135,6 @@ DISTRIBUTED_WORKERS = os.getenv("DISTRIBUTED_WORKERS", "false").lower() == "true
 # Thread Search
 # Number of recent messages to store per thread snapshot for semantic search
 THREAD_SNAPSHOT_MESSAGE_COUNT = 20
+
+# Phase enum
+from src.constants.phases import AgentPhase  # noqa: E402, F401

--- a/backend/src/constants/llm.py
+++ b/backend/src/constants/llm.py
@@ -196,3 +196,48 @@ ANTHROPIC_PROMPT_CACHE_TTL = os.getenv("ANTHROPIC_PROMPT_CACHE_TTL", "5m")
 DEFAULT_COMPACTION_TOKEN_THRESHOLD = _safe_int_env("COMPACTION_TOKEN_THRESHOLD", 170000)
 DEFAULT_COMPACTION_RECENT_MESSAGES = _safe_int_env("COMPACTION_RECENT_MESSAGES", 6)
 DEFAULT_COMPACTION_MODEL = DEFAULT_CHAT_MODEL_BASIC or DEFAULT_CHAT_MODEL
+
+# Model context window sizes (tokens) — used by context reset middleware
+MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    # OpenAI
+    "openai:o3": 200_000,
+    "openai:o4-mini": 200_000,
+    "openai:gpt-4.1-nano": 1_000_000,
+    "openai:gpt-4.1-mini": 1_000_000,
+    "openai:gpt-5-nano": 1_000_000,
+    "openai:gpt-5-mini": 1_000_000,
+    "openai:gpt-5": 1_000_000,
+    "openai:gpt-5.1": 1_000_000,
+    "openai:gpt-5.2": 1_000_000,
+    "openai:gpt-5.2-chat-latest": 1_000_000,
+    "openai:gpt-5.2-pro": 1_000_000,
+    # Anthropic
+    "anthropic:claude-3-7-sonnet-latest": 200_000,
+    "anthropic:claude-sonnet-4": 200_000,
+    "anthropic:claude-opus-4-1": 200_000,
+    "anthropic:claude-haiku-4-5": 200_000,
+    "anthropic:claude-sonnet-4-5": 200_000,
+    # xAI
+    "xai:grok-4-1-fast": 1_000_000,
+    "xai:grok-4-1-fast-non-reasoning": 1_000_000,
+    "xai:grok-4": 256_000,
+    "xai:grok-4-fast": 256_000,
+    "xai:grok-4-fast-non-reasoning": 256_000,
+    "xai:grok-code-fast-1": 256_000,
+    # Google
+    "google_genai:gemini-2.5-flash-lite": 1_000_000,
+    "google_genai:gemini-2.5-flash": 1_000_000,
+    "google_genai:gemini-2.5-pro": 1_000_000,
+    "google_genai:gemini-flash-lite-latest": 1_000_000,
+    "google_genai:gemini-3-flash-preview": 1_000_000,
+    # Groq
+    "groq:openai/gpt-oss-120b": 128_000,
+    "groq:llama-3.3-70b-versatile": 128_000,
+}
+
+DEFAULT_CONTEXT_WINDOW = 200_000  # Fallback for unknown models
+
+
+def get_context_window(model: str) -> int:
+    """Get context window size for a model, with fallback."""
+    return MODEL_CONTEXT_WINDOWS.get(model, DEFAULT_CONTEXT_WINDOW)

--- a/backend/src/constants/llm.py
+++ b/backend/src/constants/llm.py
@@ -233,6 +233,16 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     # Groq
     "groq:openai/gpt-oss-120b": 128_000,
     "groq:llama-3.3-70b-versatile": 128_000,
+    # Bedrock
+    "bedrock_converse:us.anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
+    "bedrock_converse:us.anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
+    "bedrock_converse:us.anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
+    "bedrock_converse:us.moonshot.kimi-k2-thinking": 131_072,
+    "bedrock_converse:us.anthropic.claude-3-5-sonnet-20241022-v2:0": 200_000,
+    "bedrock_converse:us.anthropic.claude-3-5-haiku-20241022-v1:0": 200_000,
+    "bedrock_converse:amazon.titan-text-premier-v1:0": 32_768,
+    "bedrock_converse:us.meta.llama3-2-90b-instruct-v1:0": 128_000,
+    "bedrock_converse:us.mistral.mistral-large-2407-v1:0": 128_000,
 }
 
 DEFAULT_CONTEXT_WINDOW = 200_000  # Fallback for unknown models
@@ -240,4 +250,8 @@ DEFAULT_CONTEXT_WINDOW = 200_000  # Fallback for unknown models
 
 def get_context_window(model: str) -> int:
     """Get context window size for a model, with fallback."""
-    return MODEL_CONTEXT_WINDOWS.get(model, DEFAULT_CONTEXT_WINDOW)
+    size = MODEL_CONTEXT_WINDOWS.get(model)
+    if size is None:
+        logger.debug(f"context_window_fallback model={model} using default={DEFAULT_CONTEXT_WINDOW}")
+        return DEFAULT_CONTEXT_WINDOW
+    return size

--- a/backend/src/constants/phases.py
+++ b/backend/src/constants/phases.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class AgentPhase(str, Enum):
+    """Unified phase names used across cost tracking, observability, and harness features."""
+
+    PLANNER = "planner"
+    GENERATOR = "generator"
+    EVALUATOR = "evaluator"
+    HANDOFF = "handoff"
+    NEGOTIATION = "negotiation"
+    SOLO = "solo"

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -213,6 +213,8 @@ export default function useChat(): ChatContextType {
 				return ["error", event.data.error];
 			case "aborted":
 				return ["aborted", event.data];
+			case "custom":
+				return ["custom", event.data];
 			case "done":
 				return null; // Handled separately
 			default:
@@ -721,6 +723,13 @@ export default function useChat(): ChatContextType {
 				setTodos(valuesData.todos);
 			}
 
+			return;
+		}
+
+		if (streamMode === "custom") {
+			// Custom events dispatched by feature-specific handlers
+			// Sub-types: cost_update, plan_status, eval_progress, context_reset, span
+			console.debug("[custom event]", payload[1]);
 			return;
 		}
 

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -727,9 +727,11 @@ export default function useChat(): ChatContextType {
 		}
 
 		if (streamMode === "custom") {
-			// Custom events dispatched by feature-specific handlers
+			// Custom events dispatched by Phase 1+ feature handlers
 			// Sub-types: cost_update, plan_status, eval_progress, context_reset, span
-			console.debug("[custom event]", payload[1]);
+			if (import.meta.env.DEV) {
+				console.debug("[custom event]", payload[1]);
+			}
 			return;
 		}
 

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -30,14 +30,6 @@ export function isDistributedResponse(
 	);
 }
 
-// SSE Event types
-export type SSEEventType =
-	| "metadata"
-	| "messages"
-	| "values"
-	| "error"
-	| "aborted";
-
 export interface MetadataEvent {
 	type: "metadata";
 	data: {
@@ -72,12 +64,29 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
+export interface CustomEvent {
+	type: "custom";
+	data: {
+		type: string; // Sub-type: "cost_update", "plan_status", "eval_progress", etc.
+		[key: string]: unknown;
+	};
+}
+
+export type SSEEventType =
+	| "metadata"
+	| "messages"
+	| "values"
+	| "error"
+	| "aborted"
+	| "custom";
+
 export type SSEEvent =
 	| MetadataEvent
 	| MessagesEvent
 	| ValuesEvent
 	| ErrorEvent
-	| AbortedEvent;
+	| AbortedEvent
+	| CustomEvent;
 
 export interface DoneSignal {
 	type: "done";

--- a/frontend/src/lib/entities/stream.ts
+++ b/frontend/src/lib/entities/stream.ts
@@ -64,7 +64,7 @@ export interface AbortedEvent {
 	data: { reason: string };
 }
 
-export interface CustomEvent {
+export interface CustomSSEEvent {
 	type: "custom";
 	data: {
 		type: string; // Sub-type: "cost_update", "plan_status", "eval_progress", etc.
@@ -86,7 +86,7 @@ export type SSEEvent =
 	| ValuesEvent
 	| ErrorEvent
 	| AbortedEvent
-	| CustomEvent;
+	| CustomSSEEvent;
 
 export interface DoneSignal {
 	type: "done";

--- a/frontend/src/lib/utils/fetchStreamReader.ts
+++ b/frontend/src/lib/utils/fetchStreamReader.ts
@@ -183,6 +183,8 @@ export class FetchStreamReader {
 				};
 			case "aborted":
 				return { type: "aborted", data: payload };
+			case "custom":
+				return { type: "custom", data: payload };
 			default:
 				return null;
 		}
@@ -329,6 +331,8 @@ export class ResponseBodyReader {
 				};
 			case "aborted":
 				return { type: "aborted", data: payload };
+			case "custom":
+				return { type: "custom", data: payload };
 			default:
 				return null;
 		}


### PR DESCRIPTION
## Summary

Closes #914

- Add `AgentPhase` enum (`backend/src/constants/phases.py`) — unified phase names (`planner`, `generator`, `evaluator`, `handoff`, `negotiation`, `solo`) used across cost tracking, observability, and harness features
- Add `MODEL_CONTEXT_WINDOWS` mapping and `get_context_window()` helper to `backend/src/constants/llm.py` — context window sizes for all supported models, used by context reset middleware
- Add `CustomSSEEvent` type and `"custom"` SSE event plumbing across frontend (`stream.ts`, `fetchStreamReader.ts`, `useChat.ts`) — enables feature branches to send custom SSE events without modifying shared infrastructure
- Re-export `AgentPhase` from `backend/src/constants/__init__.py`

## Files Changed

- `backend/src/constants/phases.py` — new: `AgentPhase` enum
- `backend/src/constants/llm.py` — modified: added `MODEL_CONTEXT_WINDOWS`, `get_context_window()`
- `backend/src/constants/__init__.py` — modified: re-export `AgentPhase`
- `frontend/src/lib/entities/stream.ts` — modified: added `CustomSSEEvent`, `"custom"` SSE type
- `frontend/src/lib/utils/fetchStreamReader.ts` — modified: handle `"custom"` in `parseEvent()`
- `frontend/src/hooks/useChat.ts` — modified: handle `"custom"` events in `handleMessages()`

## Human Review Checklist

- [ ] Verify `AgentPhase` enum values cover all planned harness phases (planner, generator, evaluator, handoff, negotiation, solo)
- [ ] Verify `MODEL_CONTEXT_WINDOWS` values are accurate for each provider (OpenAI, Anthropic, xAI, Google, Groq, Bedrock)
- [ ] Confirm Bedrock entries include Titan (32K) and Kimi K2 (131K) with correct sizes
- [ ] Verify `get_context_window()` logs a debug warning on fallback — not silent
- [ ] Verify `CustomSSEEvent` (not `CustomEvent`) is used everywhere — no DOM global shadowing
- [ ] Verify `parseEvent()` in `fetchStreamReader.ts` returns the event for `"custom"` case (not `null`)
- [ ] Verify `useChat.ts` custom handler is gated behind `import.meta.env.DEV` (no console.debug in production)
- [ ] Run `cd backend && make format && make lint` — should pass
- [ ] Run `cd frontend && npm run lint && npm run test` — should pass

## Test Plan

- [ ] `from src.constants.phases import AgentPhase` works
- [ ] `from src.constants import AgentPhase` works (re-export)
- [ ] `get_context_window("openai:gpt-5")` returns `1_000_000`
- [ ] `get_context_window("bedrock_converse:amazon.titan-text-premier-v1:0")` returns `32_768`
- [ ] `get_context_window("unknown:model")` returns `200_000` (default) and logs debug
- [ ] Frontend: custom SSE events parsed and logged in dev mode only

🤖 Generated with [Claude Code](https://claude.com/claude-code)