### PR TITLE
feat: white-label branding via YAML config

### DIFF
--- a/backend/config/whitelabel.yaml
+++ b/backend/config/whitelabel.yaml
@@ -1,0 +1,30 @@
+# White-label branding configuration.
+#
+# PUBLIC, brandable values only — secrets stay in environment variables.
+# Loaded at startup by src/config/branding.py and served (non-secret) at
+# GET /api/config/public. Individual values can still be overridden by
+# environment variables where wired (e.g. APP_TITLE, DOCS_BASE_URL).
+#
+# To white-label a deployment: edit this file, or point the WHITELABEL_CONFIG
+# environment variable at an alternate YAML.
+
+brand:
+  name: "Mifune"
+  title: "Mifune - Orchestra 🪶"
+  short_name: "Mifune"
+  copyright_holder: "Mifune"
+  logo_url: ""            # optional; frontend uses a default logo when empty
+
+urls:
+  console: "https://console.mifune.dev"
+  api_base: "https://console.mifune.dev/api"
+  docs: "https://docs.mifune.dev"
+  website: "https://mifune.dev"
+  blog: "https://mifune.dev/blog"
+  socials: "https://mifune.dev/socials"
+  github: "https://github.com/mifunedev"
+  slack_invite: ""        # optional; UI hides the link when empty
+
+contact:
+  name: "Ryan Eggleston"
+  email: "reggleston@mifune.dev"

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from src.constants import (
     APP_ENV,
     APP_TITLE,
 )
+from src.config.branding import BRANDING
 from src.utils.migrations import run_migrations
 from src.utils.rate_limit import limiter
 from src.services.schedule import schedule_service
@@ -113,9 +114,9 @@ app = FastAPI(
         "This is a simple API for building chatbots with LangGraph. "
         "It allows you to create new threads, query existing threads, "
         "and get the history of a thread.\n Check out the repo on "
-        "<a href='https://github.com/ruska-ai/orchestra'>Github</a>"
+        f"<a href='{BRANDING.urls.github}/orchestra'>Github</a>"
     ),
-    contact={"name": "Ryan Eggleston", "email": "reggleston@ruska.ai"},
+    contact={"name": BRANDING.contact.name, "email": BRANDING.contact.email},
     debug=True,
     docs_url="/api",
     lifespan=lifespan,

--- a/backend/src/config/branding.py
+++ b/backend/src/config/branding.py
@@ -1,0 +1,75 @@
+"""White-label branding configuration.
+
+Loads brand + public-URL config from a YAML file and exposes a validated
+``BRANDING`` singleton. Secrets never live here — only public, white-labelable
+values (brand name, logos, docs/console links, contact). Individual values can
+still be overridden by environment variables where wired (see ``src/constants``),
+preserving backward compatibility.
+
+Resolution order for the YAML path:
+  1. explicit ``path`` argument
+  2. ``WHITELABEL_CONFIG`` environment variable
+  3. ``<backend>/config/whitelabel.yaml``
+
+A missing, empty, or invalid file falls back to the built-in defaults so the
+app never fails to boot on branding config.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+# src/config/branding.py -> config -> src -> backend
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_CONFIG_PATH = _BACKEND_ROOT / "config" / "whitelabel.yaml"
+
+
+class Brand(BaseModel):
+    name: str = "Mifune"
+    title: str = "Mifune - Orchestra 🪶"
+    short_name: str = "Mifune"
+    copyright_holder: str = "Mifune"
+    logo_url: str = ""
+
+
+class Urls(BaseModel):
+    console: str = "https://console.mifune.dev"
+    api_base: str = "https://console.mifune.dev/api"
+    docs: str = "https://docs.mifune.dev"
+    website: str = "https://mifune.dev"
+    blog: str = "https://mifune.dev/blog"
+    socials: str = "https://mifune.dev/socials"
+    github: str = "https://github.com/mifunedev"
+    slack_invite: str = ""
+
+
+class Contact(BaseModel):
+    name: str = "Ryan Eggleston"
+    email: str = "reggleston@mifune.dev"
+
+
+class Branding(BaseModel):
+    brand: Brand = Field(default_factory=Brand)
+    urls: Urls = Field(default_factory=Urls)
+    contact: Contact = Field(default_factory=Contact)
+
+
+def load_branding(path: str | os.PathLike | None = None) -> Branding:
+    """Load white-label branding from YAML, falling back to built-in defaults."""
+    cfg_path = Path(path or os.getenv("WHITELABEL_CONFIG") or _DEFAULT_CONFIG_PATH)
+    if not cfg_path.is_file():
+        return Branding()
+    try:
+        data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return Branding()
+    if not isinstance(data, dict):
+        return Branding()
+    return Branding.model_validate(data)
+
+
+BRANDING = load_branding()

--- a/backend/src/constants/__init__.py
+++ b/backend/src/constants/__init__.py
@@ -2,6 +2,8 @@ import os
 
 from enum import Enum
 
+from src.config.branding import BRANDING
+
 # Server
 HOST = str(os.getenv("HOST", "0.0.0.0"))
 PORT = int(os.getenv("PORT", 8000))
@@ -18,12 +20,12 @@ JWT_ALGORITHM = "HS256"
 JWT_TOKEN_EXPIRE_MINUTES = 60 * 24
 
 # App
-APP_TITLE = os.getenv("APP_TITLE", "Ruska AI - Orchestra 🪶")
+APP_TITLE = os.getenv("APP_TITLE", BRANDING.brand.title)
 APP_ENV = os.getenv("APP_ENV", "development")
 APP_VERSION = os.getenv("APP_VERSION", "0.1.0")
 APP_SECRET_KEY = os.getenv("APP_SECRET_KEY", "this-is-a-secret-key")
 APP_LOG_LEVEL = os.getenv("APP_LOG_LEVEL", "INFO").upper()
-DOCS_BASE_URL = os.getenv("DOCS_BASE_URL", "https://docs.ruska.ai")
+DOCS_BASE_URL = os.getenv("DOCS_BASE_URL", BRANDING.urls.docs)
 
 
 # Database

--- a/backend/src/repos/tool_repo.py
+++ b/backend/src/repos/tool_repo.py
@@ -12,6 +12,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from pydantic import BaseModel, Field
 from datetime import datetime
 
+from src.config.branding import BRANDING
 from src.schemas.entities.a2a import A2AServers
 from src.services.db import get_store_in_memory
 from src.utils.logger import logger
@@ -40,7 +41,7 @@ class ToolExamples:
             description="Use this to get the health of the server and app version.",
             config={
                 "api_tool": {
-                    "base_url": "https://chat.ruska.ai/api",
+                    "base_url": BRANDING.urls.api_base,
                     "method": "GET",
                     "endpoint": "/info/health",
                 }

--- a/backend/src/routes/v0/__init__.py
+++ b/backend/src/routes/v0/__init__.py
@@ -18,6 +18,7 @@ from .api_tokens import router as api_tokens
 from .share import router as share
 from .settings import router as settings
 from .memory import router as memory
+from .config import router as config
 
 
 def create_api_router(app: FastAPI, prefix: str = "/api"):
@@ -39,6 +40,7 @@ def create_api_router(app: FastAPI, prefix: str = "/api"):
     app.include_router(share, prefix=prefix)
     app.include_router(settings, prefix=prefix)
     app.include_router(memory, prefix=prefix)
+    app.include_router(config, prefix=prefix)
     return app
 
 

--- a/backend/src/routes/v0/config/__init__.py
+++ b/backend/src/routes/v0/config/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from src.config.branding import BRANDING, Branding
+
+router = APIRouter(prefix="/config")
+
+
+@router.get("/public", name="Public Branding Config", response_model=Branding)
+async def get_public_config() -> Branding:
+    """Public white-label branding + links (no secrets).
+
+    Consumed by the frontend at boot to render the brand name, logo, and
+    docs/console/contact links. All fields are non-sensitive and safe to
+    expose unauthenticated.
+    """
+    return BRANDING

--- a/backend/src/tools/api.py
+++ b/backend/src/tools/api.py
@@ -112,7 +112,7 @@ async def create_tool(
         await create_tool(
             name="get_server_health",
             description="Use this to get the health of the server and app version.",
-            base_url="https://chat.ruska.ai/api",
+            base_url="https://console.mifune.dev/api",
             method="GET",
             endpoint="/info/health",
         )
@@ -220,7 +220,7 @@ async def edit_tool(
         await create_tool(
             name="get_server_health",
             description="Use this to get the health of the server and app version.",
-            base_url="https://chat.ruska.ai/api",
+            base_url="https://console.mifune.dev/api",
             method="GET",
             endpoint="/info/health",
         )

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
 		<link rel="mask-icon" href="/icons/icon-192.png" color="#000000" />
 		<meta name="theme-color" content="#000000" />
 		<link rel="manifest" href="/manifest.webmanifest" />
-		<title>Ruska AI - Orchestra 🪶</title>
+		<title>Mifune - Orchestra 🪶</title>
 	</head>
 
 	<body>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-	"name": "Ruska AI - Orchestra 🪶",
-	"short_name": "Ruska",
+	"name": "Mifune - Orchestra 🪶",
+	"short_name": "Mifune",
 	"description": "Steerable Harnesses for DeepAgents",
 	"theme_color": "#000000",
 	"background_color": "#000000",

--- a/frontend/src/components/icons/HelpfulIcons.tsx
+++ b/frontend/src/components/icons/HelpfulIcons.tsx
@@ -1,8 +1,11 @@
+import { useBranding } from "@/context/BrandingContext";
+
 export default function HelpfulIcons() {
+	const branding = useBranding();
 	return (
 		<div className="text-center flex justify-center gap-2 my-3">
 			<a
-				href="https://docs.ruska.ai"
+				href={branding.urls.docs}
 				target="_blank"
 				className="hover:opacity-80 transition-opacity"
 				rel="noreferrer"
@@ -13,7 +16,7 @@ export default function HelpfulIcons() {
 				/>
 			</a>
 			<a
-				href="https://github.com/ruska-ai/cloud"
+				href={`${branding.urls.github}/cloud`}
 				target="_blank"
 				className="hover:opacity-80 transition-opacity"
 				rel="noreferrer"

--- a/frontend/src/components/icons/HomeIcon.tsx
+++ b/frontend/src/components/icons/HomeIcon.tsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
+import { useBranding } from "@/context/BrandingContext";
 
 function HomeIcon({ onClick }: { onClick?: () => void }) {
+	const branding = useBranding();
 	return (
 		<Link
 			to={onClick ? "/" : ""}
@@ -12,7 +14,9 @@ function HomeIcon({ onClick }: { onClick?: () => void }) {
 				alt="Logo"
 				className="w-8 h-8 rounded-full"
 			/>
-			<h1 className="text-2xl font-bold text-foreground">RUSKA</h1>
+			<h1 className="text-2xl font-bold text-foreground">
+				{branding.brand.short_name}
+			</h1>
 		</Link>
 	);
 }

--- a/frontend/src/components/modals/ToolSelectionModal/McpServerPanel.tsx
+++ b/frontend/src/components/modals/ToolSelectionModal/McpServerPanel.tsx
@@ -34,10 +34,10 @@ const MCP_TEMPLATES = {
 		url: "",
 		headers: {},
 	},
-	ruska: {
-		name: "Ruska MCP",
+	mifune: {
+		name: "Mifune MCP",
 		transport: "sse" as const,
-		url: "https://chat.ruska.ai/mcp",
+		url: "https://console.mifune.dev/mcp",
 		headers: { "x-api-key": "" },
 	},
 	github: {

--- a/frontend/src/components/popovers/SettingsPopover.tsx
+++ b/frontend/src/components/popovers/SettingsPopover.tsx
@@ -10,11 +10,13 @@ import { SiGithub } from "react-icons/si";
 import { useNavigate } from "react-router-dom";
 import { useChatContext } from "@/context/ChatContext";
 import { useAuth } from "@/hooks/useAuth";
+import { useBranding } from "@/context/BrandingContext";
 
 export function SettingsPopover() {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const { clearMessages } = useChatContext();
+	const branding = useBranding();
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
@@ -58,11 +60,7 @@ export function SettingsPopover() {
 						variant="ghost"
 						className="w-full justify-start gap-2 text-sm font-normal"
 						onClick={() =>
-							window.open(
-								"https://docs.ruska.ai",
-								"_blank",
-								"noopener,noreferrer",
-							)
+							window.open(branding.urls.docs, "_blank", "noopener,noreferrer")
 						}
 					>
 						<Book className="h-4 w-4" />
@@ -71,7 +69,7 @@ export function SettingsPopover() {
 					<Button
 						variant="ghost"
 						className="w-full justify-start gap-2 text-sm font-normal"
-						onClick={() => window.open("https://enso.sh", "_blank")}
+						onClick={() => window.open(branding.urls.website, "_blank")}
 					>
 						<Globe className="h-4 w-4" />
 						Website
@@ -79,7 +77,7 @@ export function SettingsPopover() {
 					<Button
 						variant="ghost"
 						className="w-full justify-start gap-2 text-sm font-normal"
-						onClick={() => window.open("https://github.com/ruska-ai", "_blank")}
+						onClick={() => window.open(branding.urls.github, "_blank")}
 					>
 						<SiGithub className="h-4 w-4" />
 						Github

--- a/frontend/src/components/sections/agent-section.tsx
+++ b/frontend/src/components/sections/agent-section.tsx
@@ -2,6 +2,7 @@ import ChatInput from "@/components/inputs/ChatInput";
 import ChatUtilityRow from "@/components/chat/ChatUtilityRow";
 import { Agent } from "@/lib/services/agentService";
 import { Button } from "@/components/ui/button";
+import { useBranding } from "@/context/BrandingContext";
 import {
 	BookOpen,
 	Newspaper,
@@ -26,6 +27,7 @@ export function AgentSection({
 	onRemix,
 	isForking = false,
 }: AgentSectionProps) {
+	const branding = useBranding();
 	return (
 		<>
 			<img
@@ -70,7 +72,7 @@ export function AgentSection({
 					asChild
 				>
 					<a
-						href="https://docs.ruska.ai"
+						href={branding.urls.docs}
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -85,7 +87,7 @@ export function AgentSection({
 					asChild
 				>
 					<a
-						href="https://ruska.ai/blog"
+						href={branding.urls.blog}
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -100,7 +102,7 @@ export function AgentSection({
 					asChild
 				>
 					<a
-						href="https://ruska.ai/socials"
+						href={branding.urls.socials}
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -108,21 +110,23 @@ export function AgentSection({
 						Social
 					</a>
 				</Button>
-				<Button
-					variant="ghost"
-					size="sm"
-					className="text-muted-foreground hover:text-foreground h-8"
-					asChild
-				>
-					<a
-						href="https://join.slack.com/t/ruska-ai/shared_invite/zt-3l2lnevo6-hOe5ZeoAz~xj7CFAJk2bzg"
-						target="_blank"
-						rel="noopener noreferrer"
+				{branding.urls.slack_invite && (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="text-muted-foreground hover:text-foreground h-8"
+						asChild
 					>
-						<MessageCircle className="w-4 h-4 mr-1" />
-						Slack
-					</a>
-				</Button>
+						<a
+							href={branding.urls.slack_invite}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<MessageCircle className="w-4 h-4 mr-1" />
+							Slack
+						</a>
+					</Button>
+				)}
 			</div>
 		</>
 	);

--- a/frontend/src/components/sections/chat-section.tsx
+++ b/frontend/src/components/sections/chat-section.tsx
@@ -1,6 +1,8 @@
 import ChatInput from "@/components/inputs/ChatInput";
+import { useBranding } from "@/context/BrandingContext";
 
 export function ChatSection() {
+	const branding = useBranding();
 	return (
 		<>
 			<img
@@ -8,11 +10,13 @@ export function ChatSection() {
 				alt="Logo"
 				className="w-32 h-32 mx-auto rounded-full"
 			/>
-			<h1 className="text-4xl font-bold mt-2">Ensō Orchestra</h1>
+			<h1 className="text-4xl font-bold mt-2">
+				{branding.brand.name} Orchestra
+			</h1>
 			<p className="text-lg mb-2">
 				AI Orchestrator powered by{" "}
 				<a
-					href="https://github.com/ruska-ai/mcp-sse"
+					href={`${branding.urls.github}/mcp-sse`}
 					target="_blank"
 					rel="noopener noreferrer"
 					className="text-primary hover:underline"
@@ -21,7 +25,7 @@ export function ChatSection() {
 				</a>{" "}
 				&{" "}
 				<a
-					href="https://github.com/ruska-ai/a2a-langgraph"
+					href={`${branding.urls.github}/a2a-langgraph`}
 					target="_blank"
 					rel="noopener noreferrer"
 					className="text-primary hover:underline"
@@ -36,10 +40,10 @@ export function ChatSection() {
 				<a href="https://discord.com/invite/QRfjg4YNzU">
 					<img src="https://img.shields.io/badge/Join-Discord-purple" />
 				</a>
-				<a href="https://enso.sh/socials">
+				<a href={branding.urls.socials}>
 					<img src="https://img.shields.io/badge/Follow-Social-black" />
 				</a>
-				<a href="https://docs.ruska.ai">
+				<a href={branding.urls.docs}>
 					<img src="https://img.shields.io/badge/View-Docs-blue" />
 				</a>
 			</div>

--- a/frontend/src/context/BrandingContext.tsx
+++ b/frontend/src/context/BrandingContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { Branding, DEFAULT_BRANDING } from "@/lib/config/branding";
+import { getPublicConfig } from "@/lib/services/configService";
+
+const BrandingContext = createContext<Branding>(DEFAULT_BRANDING);
+
+/**
+ * Provides white-label branding (name, links, contact) to the app.
+ * Starts from the baked-in defaults and overlays the runtime config fetched
+ * from GET /api/config/public; keeps defaults if the endpoint is unavailable.
+ */
+export default function BrandingProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [branding, setBranding] = useState<Branding>(DEFAULT_BRANDING);
+
+	useEffect(() => {
+		let cancelled = false;
+		getPublicConfig()
+			.then((data) => {
+				if (!cancelled && data) setBranding(data);
+			})
+			.catch(() => {
+				/* keep defaults when the config endpoint is unavailable */
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return (
+		<BrandingContext.Provider value={branding}>
+			{children}
+		</BrandingContext.Provider>
+	);
+}
+
+export function useBranding(): Branding {
+	return useContext(BrandingContext);
+}

--- a/frontend/src/hooks/useDocumentTitle.test.ts
+++ b/frontend/src/hooks/useDocumentTitle.test.ts
@@ -9,9 +9,9 @@ vi.mock("@/context/AppContext", () => ({
 }));
 
 describe("useDocumentTitle", () => {
-	const DEFAULT_TITLE = "Ruska AI - Orchestra";
-	const STREAMING_TITLE = "[Streaming...] Ruska AI";
-	const DONE_TITLE = "[Done] Ruska AI";
+	const DEFAULT_TITLE = "Mifune - Orchestra 🪶";
+	const STREAMING_TITLE = "[Streaming...] Mifune";
+	const DONE_TITLE = "[Done] Mifune";
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,30 +1,37 @@
 import { useEffect, useRef } from "react";
 import { useAppContext } from "@/context/AppContext";
+import { useBranding } from "@/context/BrandingContext";
 
 export type TitleStatus = "idle" | "streaming" | "done";
 
-const DEFAULT_TITLE = "Ruska AI - Orchestra";
 const DONE_TIMEOUT_MS = 3000;
-
-const TITLE_MAP: Record<TitleStatus, string> = {
-	idle: DEFAULT_TITLE,
-	streaming: `[Streaming...] Ruska AI`,
-	done: `[Done] Ruska AI`,
-};
 
 /**
  * Hook that updates the browser tab title based on streaming status.
- * Derives status from AppContext loading state.
+ * Derives status from AppContext loading state and the brand from BrandingContext.
  *
  * @returns Object containing the current title status
  */
 export function useDocumentTitle(): { status: TitleStatus } {
 	const { loading } = useAppContext();
+	const branding = useBranding();
 	const prevLoadingRef = useRef<boolean | undefined>(undefined);
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const statusRef = useRef<TitleStatus>("idle");
 
+	const defaultTitle = branding.brand.title;
+	const brandName = branding.brand.name;
+	// Keep the latest idle title for the unmount reset without re-subscribing.
+	const idleTitleRef = useRef(defaultTitle);
+	idleTitleRef.current = defaultTitle;
+
 	useEffect(() => {
+		const titleMap: Record<TitleStatus, string> = {
+			idle: defaultTitle,
+			streaming: `[Streaming...] ${brandName}`,
+			done: `[Done] ${brandName}`,
+		};
+
 		const isLoading = loading === true;
 		const wasLoading = prevLoadingRef.current === true;
 
@@ -46,7 +53,7 @@ export function useDocumentTitle(): { status: TitleStatus } {
 
 			timeoutRef.current = setTimeout(() => {
 				statusRef.current = "idle";
-				document.title = TITLE_MAP.idle;
+				document.title = titleMap.idle;
 				timeoutRef.current = null;
 			}, DONE_TIMEOUT_MS);
 		} else {
@@ -58,7 +65,7 @@ export function useDocumentTitle(): { status: TitleStatus } {
 			prevLoadingRef.current === undefined
 		) {
 			statusRef.current = newStatus;
-			document.title = TITLE_MAP[newStatus];
+			document.title = titleMap[newStatus];
 		}
 
 		prevLoadingRef.current = isLoading;
@@ -66,11 +73,11 @@ export function useDocumentTitle(): { status: TitleStatus } {
 		return () => {
 			clearDoneTimeout();
 		};
-	}, [loading]);
+	}, [loading, defaultTitle, brandName]);
 
 	useEffect(() => {
 		return () => {
-			document.title = TITLE_MAP.idle;
+			document.title = idleTitleRef.current;
 			if (timeoutRef.current !== null) {
 				clearTimeout(timeoutRef.current);
 			}

--- a/frontend/src/layouts/NoAuthLayout.tsx
+++ b/frontend/src/layouts/NoAuthLayout.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { ColorModeButton } from "@/components/buttons/ColorModeButton";
 import { useAppContext } from "@/context/AppContext";
+import { useBranding } from "@/context/BrandingContext";
 
 export default function NoAuthLayout({
 	children,
@@ -8,6 +9,7 @@ export default function NoAuthLayout({
 	children: React.ReactNode;
 }) {
 	const { appVersion } = useAppContext();
+	const branding = useBranding();
 	const location = useLocation();
 
 	return (
@@ -34,7 +36,8 @@ export default function NoAuthLayout({
 			<footer className="mt-auto bg-card border-t border-border">
 				<div className="px-4 sm:px-6 lg:px-8 py-4">
 					<p className="text-center text-muted-foreground text-xs">
-						&copy; 2025 Ruska Labs. All rights reserved. v{appVersion}
+						&copy; 2025 {branding.brand.copyright_holder}. All rights reserved.
+						v{appVersion}
 					</p>
 				</div>
 			</footer>

--- a/frontend/src/lib/config/branding.ts
+++ b/frontend/src/lib/config/branding.ts
@@ -1,0 +1,54 @@
+// White-label branding shape + defaults.
+//
+// Mirrors the backend `Branding` model served at GET /api/config/public.
+// DEFAULT_BRANDING is the baked-in fallback used before the runtime config
+// is fetched (and if the endpoint is unavailable), so the UI never renders
+// an empty brand.
+
+export interface Branding {
+	brand: {
+		name: string;
+		title: string;
+		short_name: string;
+		copyright_holder: string;
+		logo_url: string;
+	};
+	urls: {
+		console: string;
+		api_base: string;
+		docs: string;
+		website: string;
+		blog: string;
+		socials: string;
+		github: string;
+		slack_invite: string;
+	};
+	contact: {
+		name: string;
+		email: string;
+	};
+}
+
+export const DEFAULT_BRANDING: Branding = {
+	brand: {
+		name: "Mifune",
+		title: "Mifune - Orchestra 🪶",
+		short_name: "Mifune",
+		copyright_holder: "Mifune",
+		logo_url: "",
+	},
+	urls: {
+		console: "https://console.mifune.dev",
+		api_base: "https://console.mifune.dev/api",
+		docs: "https://docs.mifune.dev",
+		website: "https://mifune.dev",
+		blog: "https://mifune.dev/blog",
+		socials: "https://mifune.dev/socials",
+		github: "https://github.com/mifunedev",
+		slack_invite: "",
+	},
+	contact: {
+		name: "Ryan Eggleston",
+		email: "reggleston@mifune.dev",
+	},
+};

--- a/frontend/src/lib/config/instruction.ts
+++ b/frontend/src/lib/config/instruction.ts
@@ -1,5 +1,5 @@
 const DEFAULT_SYSTEM_PROMPT = `<persona>
-You are Orchestra, an AI assistant that can help with a wide range of tasks, built by Ruska AI. You are powered by MCP (Model Context Protocol) and A2A (Agent to Agent Protocol).
+You are Orchestra, an AI assistant that can help with a wide range of tasks, built by Mifune. You are powered by MCP (Model Context Protocol) and A2A (Agent to Agent Protocol).
 </persona>
 
 <tool_calling>

--- a/frontend/src/lib/services/configService.ts
+++ b/frontend/src/lib/services/configService.ts
@@ -1,0 +1,8 @@
+import apiClient from "@/lib/utils/apiClient";
+import type { Branding } from "@/lib/config/branding";
+
+/** Fetch public white-label branding/links (no secrets). */
+export const getPublicConfig = async (): Promise<Branding> => {
+	const response = await apiClient.get("/config/public");
+	return response.data;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import AgentProvider from "./context/AgentContext";
 import ProjectProvider from "./context/ProjectContext";
 import ThemeProvider from "./context/ThemeContext";
 import AppProvider from "./context/AppContext";
+import BrandingProvider from "./context/BrandingContext";
 import { PromptProvider } from "./context/PromptContext";
 import { OnboardingProvider } from "./context/OnboardingContext";
 import { NuqsAdapter } from "nuqs/adapters/react";
@@ -32,19 +33,21 @@ createRoot(document.getElementById("root")!).render(
 		<ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
 			<QueryProvider>
 				<NuqsAdapter>
-					<AppProvider>
-						<AgentProvider>
-							<ProjectProvider>
-								<PromptProvider>
-									<ChatProvider>
-										<OnboardingProvider>
-											<AppRoutes />
-										</OnboardingProvider>
-									</ChatProvider>
-								</PromptProvider>
-							</ProjectProvider>
-						</AgentProvider>
-					</AppProvider>
+					<BrandingProvider>
+						<AppProvider>
+							<AgentProvider>
+								<ProjectProvider>
+									<PromptProvider>
+										<ChatProvider>
+											<OnboardingProvider>
+												<AppRoutes />
+											</OnboardingProvider>
+										</ChatProvider>
+									</PromptProvider>
+								</ProjectProvider>
+							</AgentProvider>
+						</AppProvider>
+					</BrandingProvider>
 				</NuqsAdapter>
 			</QueryProvider>
 		</ThemeProvider>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,9 +33,9 @@ const MANIFEST: Partial<VitePWAOptions> = {
 		],
 	},
 	manifest: {
-		name: "Ruska AI",
-		short_name: "Ruska AI",
-		description: "Ruska AI",
+		name: "Mifune",
+		short_name: "Mifune",
+		description: "Mifune",
 		theme_color: "#000000",
 		background_color: "#000000",
 		display: "standalone",


### PR DESCRIPTION
Makes the app **white-labelable**: brand name + public URLs come from a YAML config file (secrets stay in env vars), instead of hardcoded `Ruska`/`ruska.ai`/`enso.sh` values scattered across the codebase. Default values are the new **Mifune** brand.

## How it works
YAML on disk → backend loads + validates it at startup → public values served at `GET /api/config/public` → frontend fetches once into a `BrandingContext`. White-label a deployment by editing `backend/config/whitelabel.yaml` or pointing `WHITELABEL_CONFIG` at an alternate file. Env vars still override where wired (`APP_TITLE`, `DOCS_BASE_URL`).

## Backend
- `backend/config/whitelabel.yaml` — committed default (Mifune); public, brandable values only.
- `src/config/branding.py` — Pydantic `Branding` model + loader (env-overridable path, safe built-in defaults so the app always boots).
- `GET /api/config/public` (`src/routes/v0/config/`) — serves the branding (no secrets).
- `APP_TITLE` / `DOCS_BASE_URL`, the OpenAPI contact, and the tool example `base_url` now source from branding.

## Frontend
- `BrandingContext` / `useBranding()` fetch `/api/config/public` at boot with a baked-in Mifune fallback.
- Brand name, document title, copyright, and the docs/console/website/blog/socials/github/slack links + the MCP template now read from branding.
- Static `index.html` `<title>` and `manifest.json` defaults updated to Mifune.

## Scope (v1)
Branding + public links. **Out of scope (left as-is, follow-ups):** functional service endpoints (`mcp.enso.sh`/`a2a.enso.sh`), dev `allowedHosts`, runtime identifiers (`ruska-default` LangSmith prompt name, `ruska.active_streams` localStorage key, `ruska-dev` user-agent), logo image propagation across all surfaces, GHCR/`github.com/ruska-ai` CI namespace, and README/decks prose.

## Verification
- `backend`: `branding.py` loads the YAML + falls back cleanly; `/api/config/public` returns the Mifune branding; `ruff check` clean.
- `frontend`: `tsc -b && vite build` passes; full vitest suite green (367 passed); `useDocumentTitle` test updated to the new brand.

> Note: a few concrete values in the YAML are placeholders pending confirmation — `brand.logo_url`, `urls.slack_invite` (both empty → UI falls back/hides), `brand.copyright_holder`, and `contact.email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)