### PR TITLE
FROM fix/onboarding-tour-persist-on-close TO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,9 @@ Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day
 ### Changed
   - feat/infra-consolidation — consolidate all Docker/build artifacts into a single `infra/` directory (one `docker-compose.yml` + thin `docker-compose.test.yml`); move `backend/Dockerfile` to `infra/backend.Dockerfile`; drop the dev/storage/services/debug overlays and the `dozzle` service; update Makefile, CI (`build.yml`/`test.yml`), and docs.
 
+### Fixed
+  - fix/onboarding-tour-persist-on-close — persist onboarding completion when the welcome tour is dismissed via the X button or overlay click (`ACTIONS.CLOSE`), so it no longer re-fires on every login. Previously only Skip/Done persisted; closing hid the tour for the session but left `onboarding_completed` unset.
+
 ## 2026.3.6-2
 
 ### Changed

--- a/frontend/src/context/OnboardingContext.tsx
+++ b/frontend/src/context/OnboardingContext.tsx
@@ -102,7 +102,15 @@ export function OnboardingProvider({
 		(data: CallBackProps) => {
 			const { action, index, status, type } = data;
 
-			if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+			// Any terminal dismissal — finished, skipped, or closed via the X
+			// button / overlay click (ACTIONS.CLOSE) — must persist completion so
+			// the tour does not re-fire on the next login. Closing previously only
+			// hid the tour for the session, leaving onboarding_completed unset.
+			if (
+				status === STATUS.FINISHED ||
+				status === STATUS.SKIPPED ||
+				action === ACTIONS.CLOSE
+			) {
 				setRun(false);
 				setStepIndex(0);
 				markComplete();


### PR DESCRIPTION
## Problem

The first-login welcome tour (react-joyride) becomes a recurring nuisance: it does not stay dismissed after the initial login. Reproduced against `console.mifune.dev` (1920×1080) with `admin@example.com`:

1. Log in → tour fires at step **1 / 15**.
2. Click the **X** (or the overlay) to dismiss → tour hides for the session.
3. Reload / log in again → tour returns at **1 / 15**.

## Root cause

`OnboardingContext.handleJoyrideCallback` only persisted `onboarding_completed` on `STATUS.FINISHED` or `STATUS.SKIPPED`. The X button and overlay click fire `ACTIONS.CLOSE` (with `type: step:after`), which fell through to the step-advance branch and **never called `markComplete()`** — so the server flag stayed `null` and the tour re-fired on the next mount.

Verified empirically: after **Skip**, `GET /api/settings` → `onboarding_completed: true` and the tour stays gone; after **X-close**, the flag remained `null` and the tour returned on reload.

## Fix

Treat `ACTIONS.CLOSE` as a terminal dismissal alongside `FINISHED`/`SKIPPED` — stop the tour and persist completion. This covers both the X button and overlay-click dismissals (`disableOverlayClose={false}`). Next/Back/Done/Skip behavior is unchanged.

## Validation

- `tsc --noEmit` ✅ · `eslint` ✅
- Browser repro of the bug (X-close → reload → tour returns) and confirmation that the Skip path persists — the fix routes close through that same proven `markComplete()` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onboarding completion to persist when the welcome tour is dismissed via the close button or overlay click, ensuring consistent tracking across all dismissal methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->