### PR TITLE
FROM fix/walkthrough-visibility-zindex TO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day
 
 ### Fixed
   - fix/onboarding-tour-persist-on-close — persist onboarding completion when the welcome tour is dismissed via the X button or overlay click (`ACTIONS.CLOSE`), so it no longer re-fires on every login. Previously only Skip/Done persisted; closing hid the tour for the session but left `onboarding_completed` unset.
+  - fix/walkthrough-visibility-zindex — make the onboarding walkthrough's highlighted element clearly visible (darker overlay dim + a vivid spotlight ring) in both light and dark themes, and stop the Help/walkthrough button from overlaying the Files drawer by only elevating it above the tour overlay while the tour is running.
 
 ## 2026.3.6-2
 

--- a/frontend/src/components/buttons/HelpButton.tsx
+++ b/frontend/src/components/buttons/HelpButton.tsx
@@ -1,5 +1,6 @@
 import { HelpCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useOnboarding } from "@/context/OnboardingContext";
 
 export function HelpButton() {
@@ -9,7 +10,10 @@ export function HelpButton() {
 		<Button
 			variant={run ? "default" : "outline"}
 			size="icon"
-			className="relative z-[10001] h-9 w-9"
+			// Only float above the tour overlay (z-10000) while the tour is
+			// running; otherwise keep normal stacking so the button doesn't
+			// overlay the Files drawer / editor and other panels.
+			className={cn("relative h-9 w-9", run && "z-[10001]")}
 			onClick={toggleTour}
 			aria-label="Help tour"
 			title={run ? "Stop tour" : "Replay onboarding tour"}

--- a/frontend/src/layouts/chat-layout-v2.tsx
+++ b/frontend/src/layouts/chat-layout-v2.tsx
@@ -27,7 +27,16 @@ export function ChatLayout({ children }: { children: React.ReactNode }) {
 					hideArrow: true,
 					styles: { floater: { maxWidth: "calc(100vw - 1rem)" } },
 				}}
-				styles={{ options: { zIndex: 10000 } }}
+				styles={{
+					// Darker dim + a vivid spotlight ring so the highlighted target
+					// is clearly distinguishable in both light and dark themes — a
+					// 0.5 dim over the dark UI left the highlighted element invisible.
+					options: { zIndex: 10000, overlayColor: "rgba(0, 0, 0, 0.7)" },
+					spotlight: {
+						border: "3px solid #38bdf8",
+						borderRadius: "10px",
+					},
+				}}
 			/>
 			<AppSidebar />
 			<main className="flex-1 flex flex-col max-h-screen overflow-hidden">


### PR DESCRIPTION
## Problem

Two onboarding-walkthrough (react-joyride) usability issues, reported against `console.mifune.dev` and reproduced with `/agent-browser` at 1920×1080 in both themes:

1. **Hard to see what's highlighted.** The spotlight used react-joyride's default `rgba(0,0,0,0.5)` dim with no ring on the target. Over the dark UI, the "highlighted" element was visually indistinguishable from the dimmed page — you couldn't tell what the step was pointing at.
2. **Help/walkthrough button overlays the Files drawer.** `HelpButton` was hard-pinned to `z-[10001]` at all times (so it can float above the tour overlay at `z-10000`). That always-on elevation also put it above the Files editor/drawer and any modal/sheet (`z-50`).

## Fix

**Visibility** (`layouts/chat-layout-v2.tsx`):
- `options.overlayColor: rgba(0, 0, 0, 0.7)` — stronger dim for clear separation.
- `styles.spotlight: { border: 3px solid #38bdf8, borderRadius: 10px }` — a vivid ring (brand cyan) framing the highlighted element. Uses `border` (not `box-shadow`) so it doesn't disturb react-joyride's hole-punch dim.

**Z-index** (`components/buttons/HelpButton.tsx`):
- Apply `z-[10001]` only while the tour is `run`ning; otherwise normal stacking, so the button no longer overlays panels/drawers.

## Validation

- Reproduced and previewed live in **dark and light** modes — highlighted region now clearly pops (brighter target + cyan boundary against a darker dim) in both. Screenshots captured during triage.
- `tsc --noEmit` ✅ · `eslint` ✅ · `vitest ChatNav.test.tsx` ✅ (4/4)

Follow-up to #930 (tour persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)