### PR TITLE
feat: resiliency fitness-function eval harness (RED baseline)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,12 @@ jobs:
             OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
             REDIS_URL: redis://localhost:6379/0
+            # The resiliency features (idempotency dedup, DLQ + replay,
+            # correlation-id bind, drain) live in the worker's run_agent_stream,
+            # and the frontend uses the distributed POST /llm/stream + SSE-poll
+            # flow. Both are gated on DISTRIBUTED_WORKERS; without it the API
+            # streams in-process, the worker stays idle, and every e2e spec fails.
+            DISTRIBUTED_WORKERS: "true"
         services:
             postgres:
                 image: pgvector/pgvector:pg16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
               env:
                   PYTHONPATH: ./src:.
               run: |
-                  uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 &
+                  uv run uvicorn main:app --host 0.0.0.0 --port 8000 &
                   echo "API_PID=$!" >> "$GITHUB_ENV"
                   # Wait for the API to be ready
                   timeout 60 bash -c 'until curl -sf http://localhost:8000/health; do sleep 2; done' \
@@ -269,7 +269,7 @@ jobs:
               env:
                   PYTHONPATH: ./src:.
               run: |
-                  uv run taskiq worker src.worker:broker --workers 1 &
+                  uv run taskiq worker src.workers.tasks:broker --workers 1 &
                   echo "WORKER_PID=$!" >> "$GITHUB_ENV"
 
             - name: Start frontend dev server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,3 +157,138 @@ jobs:
                   mkdir -p ./.test-data/postgres
                   # Run your tests
                   uv run pytest -rs
+
+    ###############################################################
+    ## E2E Tests (Playwright) — non-blocking
+    ## Specs are authored with test.fail() at baseline so they
+    ## pass today even though the resilient behaviours are not yet
+    ## implemented.  Once a resiliency fix lands, remove the
+    ## corresponding test.fail() annotation to flip the spec to a
+    ## hard failure (the GREEN signal).
+    # TODO: make blocking (remove continue-on-error) once full
+    #       stack bring-up in CI is reliable and all specs pass.
+    ###############################################################
+    test-e2e:
+        runs-on: ubuntu-latest
+        environment: Test
+        # Non-blocking: failures here do not fail required checks.
+        continue-on-error: true
+        env:
+            APP_ENV: test
+            APP_LOG_LEVEL: debug
+            APP_SECRET_KEY: ${{ secrets.APP_SECRET_KEY }}
+            POSTGRES_CONNECTION_STRING: postgresql://admin:test1234@localhost:5432/lg_template_test
+            OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+            ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            REDIS_URL: redis://localhost:6379/0
+        services:
+            postgres:
+                image: pgvector/pgvector:pg16
+                env:
+                    POSTGRES_USER: admin
+                    POSTGRES_PASSWORD: test1234
+                    POSTGRES_DB: lg_template_test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+            redis:
+                image: redis:alpine
+                ports:
+                    - 6379:6379
+                options: >-
+                    --health-cmd "redis-cli ping"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Install Python dependencies
+              working-directory: ./backend
+              run: |
+                  mkdir -p src/public/docs
+                  mkdir -p src/public/assets
+                  pip install --upgrade pip
+                  pip install uv
+                  uv sync --frozen --no-cache --dev --extra api
+
+            - name: Wait for PostgreSQL
+              run: |
+                  timeout 30 bash -c 'until pg_isready -h localhost -p 5432 -U admin; do sleep 1; done'
+
+            - name: Run database migrations
+              working-directory: ./backend
+              env:
+                  PYTHONPATH: ./src:.
+              run: |
+                  uv run alembic upgrade head
+
+            - name: Seed default user
+              working-directory: ./backend
+              env:
+                  PYTHONPATH: ./src:.
+              run: |
+                  uv run python -m seeds.user_seeder || echo "Seeder not found or failed — skipping"
+
+            - name: Install frontend dependencies
+              working-directory: ./frontend
+              run: npm ci
+
+            - name: Install Playwright browsers
+              working-directory: ./frontend
+              run: npx playwright install --with-deps chromium
+
+            - name: Start backend API
+              working-directory: ./backend
+              env:
+                  PYTHONPATH: ./src:.
+              run: |
+                  uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 &
+                  echo "API_PID=$!" >> "$GITHUB_ENV"
+                  # Wait for the API to be ready
+                  timeout 60 bash -c 'until curl -sf http://localhost:8000/health; do sleep 2; done' \
+                    || echo "Warning: API health check timed out"
+
+            - name: Start background worker
+              working-directory: ./backend
+              env:
+                  PYTHONPATH: ./src:.
+              run: |
+                  uv run taskiq worker src.worker:broker --workers 1 &
+                  echo "WORKER_PID=$!" >> "$GITHUB_ENV"
+
+            - name: Start frontend dev server
+              working-directory: ./frontend
+              run: |
+                  VITE_API_URL=http://localhost:8000/api npx vite --port 5173 &
+                  echo "VITE_PID=$!" >> "$GITHUB_ENV"
+                  # Wait for Vite to be ready
+                  timeout 60 bash -c 'until curl -sf http://localhost:5173; do sleep 2; done' \
+                    || echo "Warning: Vite health check timed out"
+
+            - name: Run Playwright E2E specs
+              working-directory: ./frontend
+              run: npx playwright test
+
+            - name: Upload Playwright artifacts
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: playwright-artifacts
+                  path: frontend/e2e/.artifacts/**
+                  retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,11 +281,20 @@ jobs:
             - name: Start frontend dev server
               working-directory: ./frontend
               run: |
-                  VITE_API_URL=http://localhost:8000/api npx vite --port 5173 &
+                  # Pre-bundle deps so the first spec doesn't pay Vite's cold optimize cost.
+                  npx vite optimize --force >/dev/null 2>&1 || true
+                  VITE_API_URL=http://localhost:8000/api npx vite --port 5173 --host 0.0.0.0 &
                   echo "VITE_PID=$!" >> "$GITHUB_ENV"
                   # Wait for Vite to be ready
-                  timeout 60 bash -c 'until curl -sf http://localhost:5173; do sleep 2; done' \
+                  timeout 60 bash -c 'until curl -sf http://localhost:5173 >/dev/null; do sleep 2; done' \
                     || echo "Warning: Vite health check timed out"
+                  # Warm the full module graph in a real browser so the first Playwright spec
+                  # finds a hot dev server. The first on-demand compile of the /chat route
+                  # under single-runner CPU contention can exceed the per-test timeout; a
+                  # timeout escapes test.fail() and becomes a hard failure, so the RED
+                  # baseline probes must fail by assertion, not by cold-compile timeout.
+                  node -e "const {chromium}=require('@playwright/test');(async()=>{const b=await chromium.launch();const p=await b.newPage();await p.goto('http://localhost:5173/chat',{waitUntil:'networkidle',timeout:90000}).catch(()=>{});await b.close();})().catch(()=>{})" \
+                    || echo "Warning: frontend warm-up navigation failed (non-fatal)"
 
             - name: Run Playwright E2E specs
               working-directory: ./frontend

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,3 +6,6 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+markers =
+    resiliency: resiliency fitness-function probes (excluded from default run; run explicitly with -m resiliency)
+addopts = -m "not resiliency"

--- a/backend/tests/resiliency/__init__.py
+++ b/backend/tests/resiliency/__init__.py
@@ -1,0 +1,5 @@
+# Resiliency fitness-function probes.
+# These tests assert properties that do NOT yet exist in production code.
+# They are intentionally RED (fail) on current development.
+# They are excluded from the default pytest run via the `resiliency` marker.
+# Run explicitly with: pytest -m resiliency

--- a/backend/tests/resiliency/test_correlation_id.py
+++ b/backend/tests/resiliency/test_correlation_id.py
@@ -1,0 +1,100 @@
+"""Resiliency probe: correlation / request-ID propagation.
+
+Property asserted (does NOT exist today → RED):
+    Every run_agent_stream invocation must bind a correlation ID into a
+    ContextVar so that structured log entries emitted during the run can be
+    traced back to the originating request.
+
+    Concretely:
+    - src.utils.correlation must exist and expose a ContextVar (or getter)
+      named ``correlation_id``.
+    - run_agent_stream must call a bind/set function on that ContextVar before
+      delegating to _execute_agent_stream.
+    - The value stored must equal the run_id passed to the task (or a header
+      value — run_id is the canonical trace token for worker tasks).
+
+Why it fails today:
+    There is no src/utils/correlation.py module.  run_agent_stream has no
+    ContextVar binding.  Importing the module raises ImportError.
+"""
+
+import pytest
+from unittest.mock import patch
+from uuid import uuid4
+
+
+@pytest.mark.resiliency
+def test_correlation_module_exists():
+    """src.utils.correlation must be importable with a correlation_id ContextVar.
+
+    Today the module does not exist → ImportError → pytest.fail (collected & FAILED).
+    """
+    try:
+        import src.utils.correlation as correlation_module  # noqa: F401
+    except ImportError:
+        pytest.fail(
+            "src.utils.correlation does not exist. "
+            "A correlation ID ContextVar module must be implemented. "
+            "Intentionally RED — module is absent today."
+        )
+
+    # The module must expose a way to get/set the current correlation ID.
+    has_getter = hasattr(correlation_module, "get_correlation_id") or hasattr(correlation_module, "correlation_id")
+    assert has_getter, (
+        "src.utils.correlation exists but does not expose 'get_correlation_id' or 'correlation_id'. Intentionally RED."
+    )
+
+
+@pytest.mark.resiliency
+async def test_run_agent_stream_binds_correlation_id(fake_redis):
+    """run_agent_stream must bind the run_id as the correlation ID before executing.
+
+    We intercept _execute_agent_stream and inspect what was bound in the
+    correlation ContextVar at the moment the call was made.
+
+    Today nothing is bound → the ContextVar getter returns None/default → FAIL.
+    """
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "trace me"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    captured_correlation_id: list = []
+
+    async def capture_correlation(*args, **kwargs):
+        # Attempt to read the correlation ID that should have been bound by now.
+        try:
+            from src.utils.correlation import get_correlation_id
+
+            captured_correlation_id.append(get_correlation_id())
+        except (ImportError, AttributeError):
+            # Module absent or getter missing — record sentinel so we can fail below
+            captured_correlation_id.append("__not_set__")
+        return {"status": "complete", "stream_key": f"agent:stream:{thread_id}:{run_id}"}
+
+    with patch("src.workers.tasks._execute_agent_stream", side_effect=capture_correlation):
+        with patch("src.workers.tasks.redis.from_url", return_value=fake_redis):
+            try:
+                from src.workers.tasks import run_agent_stream
+
+                await run_agent_stream(
+                    task_dict=task_dict,
+                    user_id=user_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                )
+            except Exception:
+                pass
+
+    assert captured_correlation_id, "capture hook was never called — task did not reach _execute_agent_stream"
+    bound_value = captured_correlation_id[0]
+    assert bound_value == run_id, (
+        f"Expected correlation_id to be bound to run_id={run_id!r} "
+        f"but got {bound_value!r}. "
+        "Correlation ContextVar binding is absent — intentionally RED."
+    )

--- a/backend/tests/resiliency/test_dlq_replay.py
+++ b/backend/tests/resiliency/test_dlq_replay.py
@@ -1,0 +1,140 @@
+"""Resiliency probe: dead-letter queue (DLQ) recording and replay.
+
+Property asserted (does NOT exist today → RED):
+    When run_agent_stream hits a PERMANENT (non-retryable) failure, the failed
+    job payload must be persisted to a dead-letter store so it can be replayed
+    later without re-enqueuing from the API.
+
+Why it fails today:
+    There is no DLQ module under src/workers/ or src/services/.  PermanentCheckpointError
+    and other fatal errors are logged and re-raised, but nothing writes to a DLQ.
+    The ``replay()`` entry-point expected by these probes does not exist.
+"""
+
+import pytest
+from unittest.mock import patch
+from uuid import uuid4
+
+
+@pytest.mark.resiliency
+async def test_permanent_failure_records_to_dlq(fake_redis):
+    """A non-retryable error must write the job to a dead-letter store.
+
+    After a PermanentCheckpointError the task must:
+    1. NOT silently swallow the error.
+    2. Write a DLQ entry keyed on run_id so the job is replayable.
+
+    Today no DLQ write exists, so this probe fails.
+    """
+    from src.services.errors import PermanentCheckpointError
+
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "fail me"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    permanent_error = PermanentCheckpointError("authentication failed")
+
+    with patch("src.workers.tasks._execute_agent_stream", side_effect=permanent_error):
+        with patch("src.workers.tasks.redis.from_url", return_value=fake_redis):
+            try:
+                from src.workers.tasks import run_agent_stream
+
+                await run_agent_stream(
+                    task_dict=task_dict,
+                    user_id=user_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                )
+            except Exception:
+                pass  # expected to raise; we inspect the DLQ below
+
+    # The DLQ module must exist and must have written an entry for this run_id.
+    # Expected key pattern: dlq:{run_id}  or similar in Redis / a DLQ list.
+    dlq_key = f"dlq:{run_id}"
+    entry = await fake_redis.get(dlq_key)
+    assert entry is not None, (
+        f"Expected a DLQ entry at {dlq_key!r} after permanent failure but nothing was written. "
+        "No DLQ mechanism exists yet — intentionally RED."
+    )
+
+
+@pytest.mark.resiliency
+def test_dlq_replay_function_exists():
+    """A replay() entry-point must exist for DLQ job re-enqueue.
+
+    The DLQ module (src.workers.dlq) must expose a replay() coroutine that
+    accepts a run_id and re-enqueues the stored job payload.
+
+    Today the module does not exist, so this import fails — which is a
+    collected-and-failed assertion, not an errors-during-collection issue.
+    """
+    try:
+        from src.workers import dlq as dlq_module  # noqa: F401
+    except ImportError:
+        pytest.fail(
+            "src.workers.dlq does not exist. "
+            "A DLQ module with a replay() function must be implemented. "
+            "Intentionally RED — no DLQ exists today."
+        )
+
+    assert hasattr(dlq_module, "replay"), (
+        "src.workers.dlq exists but does not expose a replay() function. Intentionally RED."
+    )
+    assert callable(dlq_module.replay), "dlq.replay must be callable."
+
+
+@pytest.mark.resiliency
+async def test_retryable_error_does_not_write_dlq(fake_redis):
+    """A retryable error must NOT write to the DLQ (let TaskIQ retry instead).
+
+    Only permanent failures should land in the DLQ.  Retryable errors (e.g.
+    SSL drops) should be left to the broker retry mechanism.
+
+    This probe will pass trivially until the DLQ write logic exists, but we
+    include it now so it documents the invariant alongside the positive case
+    and runs in the same suite.  It is marked resiliency so it is gated
+    together with the rest.
+    """
+    from src.services.errors import RetryableCheckpointError
+
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "retry me"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    retryable_error = RetryableCheckpointError("ssl connection has been closed")
+
+    with patch("src.workers.tasks._execute_agent_stream", side_effect=retryable_error):
+        with patch("src.workers.tasks.redis.from_url", return_value=fake_redis):
+            try:
+                from src.workers.tasks import run_agent_stream
+
+                await run_agent_stream(
+                    task_dict=task_dict,
+                    user_id=user_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                )
+            except Exception:
+                pass
+
+    dlq_key = f"dlq:{run_id}"
+    entry = await fake_redis.get(dlq_key)
+    # A retryable error must NOT be DLQ'd — but since DLQ doesn't exist yet,
+    # no entry will be written regardless.  This sub-assertion stays GREEN
+    # during baseline; we still mark the test resiliency so it runs with the suite.
+    assert entry is None, (
+        f"Retryable error must NOT write to DLQ key {dlq_key!r}. "
+        "If this fails after DLQ is implemented, the is_retryable_error guard is broken."
+    )

--- a/backend/tests/resiliency/test_heartbeat_drain.py
+++ b/backend/tests/resiliency/test_heartbeat_drain.py
@@ -1,0 +1,162 @@
+"""Resiliency probe: worker heartbeat and graceful drain.
+
+Property asserted (does NOT exist today → RED):
+    The worker must expose:
+    1. A ``mark_draining()`` classmethod on WorkerState (or equivalent) that
+       sets a boolean flag.
+    2. A liveness / heartbeat key written to Redis so external health-checkers
+       can detect stale workers.
+    3. When draining, run_agent_stream must refuse NEW work (return early with a
+       ``draining`` status) so in-flight runs can complete before the worker shuts down.
+
+Why it fails today:
+    WorkerState has no ``draining`` flag and no ``mark_draining`` method.
+    No heartbeat key is written to Redis on startup or during task processing.
+    run_agent_stream has no drain check.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+
+@pytest.mark.resiliency
+def test_worker_state_has_mark_draining():
+    """WorkerState must expose a mark_draining() classmethod that sets a flag.
+
+    Today WorkerState has no such method → AttributeError → FAIL.
+    """
+    from src.workers.state import WorkerState
+
+    assert hasattr(WorkerState, "mark_draining"), (
+        "WorkerState does not have a mark_draining() method. Intentionally RED — draining flag is absent today."
+    )
+    assert callable(WorkerState.mark_draining), "WorkerState.mark_draining must be callable."
+
+
+@pytest.mark.resiliency
+def test_worker_state_has_is_draining():
+    """WorkerState must expose an is_draining() predicate (or property).
+
+    Today WorkerState has no such attribute → FAIL.
+    """
+    from src.workers.state import WorkerState
+
+    has_predicate = hasattr(WorkerState, "is_draining") or hasattr(WorkerState.get_instance(), "draining")
+    assert has_predicate, (
+        "WorkerState does not have an is_draining() predicate or .draining flag. "
+        "Intentionally RED — draining flag is absent today."
+    )
+
+
+@pytest.mark.resiliency
+async def test_draining_worker_refuses_new_tasks(fake_redis):
+    """When the worker is draining, run_agent_stream must return early with status='draining'.
+
+    The test:
+    1. Calls WorkerState.mark_draining() to set the drain flag.
+    2. Dispatches run_agent_stream.
+    3. Asserts the result status is 'draining' and _execute_agent_stream was NOT called.
+
+    Today mark_draining doesn't exist, so this fails at step 1.
+    """
+    from src.workers.state import WorkerState
+
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "while draining"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    # Set the drain flag — this will raise AttributeError today (RED).
+    try:
+        WorkerState.mark_draining()
+    except AttributeError:
+        pytest.fail("WorkerState.mark_draining() does not exist. Cannot set drain flag — intentionally RED.")
+    finally:
+        # Best-effort reset so we don't poison other tests
+        try:
+            WorkerState.unmark_draining()  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+    with patch("src.workers.tasks._execute_agent_stream", new_callable=AsyncMock) as mock_exec:
+        with patch("src.workers.tasks.redis.from_url", return_value=fake_redis):
+            from src.workers.tasks import run_agent_stream
+
+            result = await run_agent_stream(
+                task_dict=task_dict,
+                user_id=user_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+
+    mock_exec.assert_not_called()
+    assert isinstance(result, dict), "run_agent_stream must return a dict when draining"
+    assert result.get("status") == "draining", (
+        f"Expected status='draining' but got {result!r}. Drain-aware early-exit is absent — intentionally RED."
+    )
+
+
+@pytest.mark.resiliency
+async def test_heartbeat_key_written_to_redis(fake_redis):
+    """A liveness heartbeat key must exist in Redis while the worker is alive.
+
+    The heartbeat key pattern must be: ``worker:heartbeat:<worker_id>``
+    and must carry a TTL so dead workers are detectable automatically.
+
+    Today WorkerState.initialize() writes no such key → FAIL.
+    """
+    from src.workers.state import WorkerState
+
+    # Reset state so initialize() runs fresh
+    instance = WorkerState.get_instance()
+    instance._initialized = False
+    instance._checkpointer = None
+    instance._store = None
+
+    with (
+        patch("src.workers.state.ResilientAsyncPostgresSaver") as mock_saver_cls,
+        patch("src.workers.state.get_store_db") as mock_store_db,
+        patch("src.workers.state.redis", create=True) as mock_redis_mod,
+    ):
+        # Stub out saver
+        mock_saver = AsyncMock()
+        mock_saver_cls.return_value = mock_saver
+
+        # Stub out store context manager
+        import contextlib
+
+        mock_store = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def _fake_store_db():
+            yield mock_store
+
+        mock_store_db.return_value = _fake_store_db()
+
+        # Point any redis.from_url call inside state.py to our fake_redis
+        mock_redis_mod.from_url = lambda *a, **kw: fake_redis
+
+        try:
+            await WorkerState.initialize()
+        except Exception:
+            pass  # We only care about whether the key was written
+
+    # Look for any key matching worker:heartbeat:*
+    heartbeat_keys = await fake_redis.keys("worker:heartbeat:*")
+    assert heartbeat_keys, (
+        "No worker:heartbeat:* key found in Redis after WorkerState.initialize(). "
+        "Liveness heartbeat is absent — intentionally RED."
+    )
+
+    # The key must have a TTL (so stale workers are detectable)
+    ttl = await fake_redis.ttl(heartbeat_keys[0])
+    assert ttl > 0, (
+        f"Heartbeat key {heartbeat_keys[0]!r} has no TTL (ttl={ttl}). "
+        "Heartbeat keys must expire so dead workers are detectable."
+    )

--- a/backend/tests/resiliency/test_idempotency.py
+++ b/backend/tests/resiliency/test_idempotency.py
@@ -1,0 +1,132 @@
+"""Resiliency probe: run_agent_stream idempotency.
+
+Property asserted (does NOT exist today → RED):
+    Enqueuing run_agent_stream twice with the same (user_id, thread_id, run_id)
+    results in exactly ONE logical execution / one assistant message written to
+    the thread store.  A dedup guard must prevent double-processing.
+
+Why it fails today:
+    There is no idempotency key check anywhere in run_agent_stream or the
+    broker layer.  Two identical enqueue calls would both execute, potentially
+    writing duplicate assistant messages.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+
+@pytest.mark.resiliency
+async def test_dedup_key_written_to_redis_before_execution(fake_redis):
+    """An idempotency key must be SET in Redis atomically before task work begins.
+
+    The key pattern must be ``run:dedup:{run_id}`` and must be written (with a
+    TTL) before _execute_agent_stream is called so that a concurrent worker
+    processing the same message would see the key and bail.
+
+    Today no such key is written, so this probe fails.
+    """
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "ping"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    execute_mock = AsyncMock(return_value={"status": "complete", "stream_key": f"agent:stream:{thread_id}:{run_id}"})
+
+    # Also patch AbortService and WorkerState to avoid network/DB calls
+    with (
+        patch("src.workers.tasks._execute_agent_stream", execute_mock),
+        patch("src.workers.tasks.redis.from_url", return_value=fake_redis),
+        patch("src.services.abort.AbortService.check_abort_signal", new_callable=AsyncMock, return_value=False),
+        patch("src.workers.state.WorkerState.is_initialized", return_value=True),
+        patch("src.workers.state.WorkerState.get_checkpointer", return_value=AsyncMock()),
+        patch("src.workers.state.WorkerState.get_store", return_value=AsyncMock()),
+    ):
+        from src.workers.tasks import run_agent_stream
+
+        try:
+            await run_agent_stream(
+                task_dict=task_dict,
+                user_id=user_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+        except Exception:
+            pass  # we only care about the dedup key
+
+    expected_key = f"run:dedup:{run_id}"
+    stored = await fake_redis.get(expected_key)
+    assert stored is not None, (
+        f"Expected idempotency key {expected_key!r} to exist in Redis after dispatch "
+        "but no such key was written. Dedup guard is absent — intentionally RED."
+    )
+
+
+@pytest.mark.resiliency
+async def test_duplicate_run_ids_produce_single_execution(fake_redis):
+    """Two identical (user_id, thread_id, run_id) dispatches produce ONE execution.
+
+    The task layer must detect the duplicate run_id and short-circuit the second
+    invocation before it processes the LLM request.  Today there is no such guard,
+    so this assertion fails.
+    """
+    user_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())  # same run_id for both enqueues
+
+    task_dict = {
+        "input": {"messages": [{"role": "user", "content": "hello"}]},
+        "model": "openai:gpt-4.1-mini",
+        "metadata": {},
+    }
+
+    execution_count = 0
+
+    async def counting_execute(*args, **kwargs):
+        nonlocal execution_count
+        execution_count += 1
+        return {"status": "complete", "stream_key": f"agent:stream:{thread_id}:{run_id}"}
+
+    with (
+        patch("src.workers.tasks._execute_agent_stream", side_effect=counting_execute),
+        patch("src.workers.tasks.redis.from_url", return_value=fake_redis),
+        patch("src.services.abort.AbortService.check_abort_signal", new_callable=AsyncMock, return_value=False),
+        patch("src.workers.state.WorkerState.is_initialized", return_value=True),
+        patch("src.workers.state.WorkerState.get_checkpointer", return_value=AsyncMock()),
+        patch("src.workers.state.WorkerState.get_store", return_value=AsyncMock()),
+    ):
+        from src.workers.tasks import run_agent_stream
+
+        # First invocation
+        try:
+            await run_agent_stream(
+                task_dict=task_dict,
+                user_id=user_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+        except Exception:
+            pass
+
+        # Second invocation — same run_id
+        try:
+            await run_agent_stream(
+                task_dict=task_dict,
+                user_id=user_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+        except Exception:
+            pass
+
+    # The dedup guard must have prevented the second execution
+    assert execution_count == 1, (
+        f"Expected exactly 1 execution for run_id={run_id!r} "
+        f"but _execute_agent_stream was called {execution_count} times. "
+        "No idempotency guard exists yet — this probe is intentionally RED."
+    )

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,141 @@
+# evals/ — Resiliency fitness-function probe corpus
+
+This directory is Orchestra's **fitness function**: a corpus of deterministic
+**probes** that encode resiliency properties as runnable, exit-code-scored checks
+against *real state*. A fix is provably "done" when its probe turns green; a
+recurrence surfaces as a was-green-now-red regression.
+
+**Baseline**: all rows start `REGRESSION` (RED). Implementing a resiliency property
+flips its row to `PASS` (GREEN). `SKIPPED` means the verification stack (tests,
+`uv`, the backend) is absent — correct behavior during parallel sibling-agent
+development.
+
+## Subfolders
+
+| Path | Holds |
+|------|-------|
+| `probes/` | One `<id>.sh` per probe (`# tier: resiliency`). |
+| `screenshots/` | Before/after determination images (manual reference). |
+| `RESULTS.md` | The benchmark scoreboard — current status per probe id. |
+
+## How to run
+
+```bash
+# Run all probes and update RESULTS.md:
+bash evals/run.sh
+
+# Run a single probe by id:
+bash evals/run.sh --probe resiliency-idempotency
+
+# Run with optional E2E UI probes (needs frontend stack at http://localhost:5173):
+ORCHESTRA_E2E=1 bash evals/run.sh
+```
+
+## Probe contract
+
+A probe is an executable shell script at `evals/probes/<id>.sh` with a
+**3-state exit-code oracle**:
+
+| Exit | Meaning | Counts toward benchmark? |
+|------|---------|--------------------------|
+| `0` | **PASS** — desired property holds | yes (pass) |
+| `1` | **REGRESSION** — property violated or absent | yes (fail) |
+| `2` | **SKIPPED** — cannot verify (stack/tools absent, test file not yet written) | no |
+| `124` | **TIMEOUT** — probe exceeded `TIMEOUT_SECS` | yes (fail) |
+
+Exit `0` when a probe *cannot verify anything* is **forbidden** — use `2`
+so a silent green never masks an unverifiable check.
+
+### Probe header (metadata)
+
+Every probe declares three comment lines (the runner extracts them with
+`grep -E '^# (tier|source|desc):'`):
+
+```sh
+#!/usr/bin/env bash
+# tier: resiliency
+# source: resiliency track — <track> plan (backend/tests/resiliency/test_<track>.py)
+# desc: one-line description of the property being checked
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"  # evals/probes/<id>.sh -> repo root
+```
+
+Probes MUST inspect real state (pytest exit codes, file presence) — never mocks.
+A probe that cannot determine the result MUST exit `2`, never `0`.
+
+### Determination strategy
+
+**Primary (deterministic, always runs)**:
+
+```bash
+cd backend && ENV_FILE=~/.env/orchestra/.env.backend.test \
+  PYTHONPATH=./src:. uv run pytest -m resiliency \
+  tests/resiliency/test_<track>.py -q
+```
+
+- pytest exit `0` → probe PASS (GREEN)
+- pytest exit `1` (tests failed) → probe REGRESSION (RED)
+- pytest collection error / file missing / `uv` absent → probe SKIPPED (`2`)
+
+The `resiliency` marker (`-m resiliency`) must be declared in `pytest.ini` and
+applied to every test in the resiliency suite for the `-m` flag to filter
+correctly. Without the marker the collection will warn but not fail; adding the
+marker is part of implementing each resiliency property.
+
+**Optional UI determination** (only when `ORCHESTRA_E2E=1`):
+
+```bash
+cd frontend && npx playwright test e2e/<track>.spec.ts
+```
+
+This requires the full frontend+backend stack running at `http://localhost:5173`.
+It is opt-in and **does not run by default** — the backend pytest is the headline
+deterministic signal.
+
+### Track → file mapping
+
+| Probe id | Backend test | E2E spec |
+|----------|-------------|----------|
+| `resiliency-idempotency` | `tests/resiliency/test_idempotency.py` | `e2e/idempotency.spec.ts` |
+| `resiliency-dlq` | `tests/resiliency/test_dlq_replay.py` | `e2e/dlq-replay.spec.ts` |
+| `resiliency-correlation-id` | `tests/resiliency/test_correlation_id.py` | `e2e/correlation-id.spec.ts` |
+| `resiliency-heartbeat-drain` | `tests/resiliency/test_heartbeat_drain.py` | `e2e/heartbeat-drain.spec.ts` |
+
+## RESULTS.md schema
+
+`RESULTS.md` is the benchmark scoreboard. Policy: **overwrite the current-status
+row per probe id**; git history is the time series (no unbounded append). On the
+first run (no prior rows) every probe emits `new-pass`/`new-fail` and NO
+`REGRESSION` is raised — the baseline run always exits `0`.
+
+| Column | Meaning |
+|--------|---------|
+| `probe` | probe id (`<id>` of `evals/probes/<id>.sh`) |
+| `tier` | `resiliency` |
+| `last-run (UTC)` | timestamp of the most recent `bash evals/run.sh` that ran it |
+| `status` | `PASS` \| `REGRESSION` \| `SKIPPED` \| `TIMEOUT` |
+| `source` | the resiliency property / test file this probe closes |
+
+## Runner aggregate exit code
+
+| Exit | Meaning |
+|------|---------|
+| `0` | No new GREEN→RED regressions this run. Pre-existing `REGRESSION` rows that are unchanged do **not** trigger non-zero exit. |
+| `1` | One or more probes transitioned from a prior `PASS` to `REGRESSION` in this run. |
+
+The scoreboard is built into a temp sibling file (`RESULTS.md.tmp.$$`) and
+swapped in with a single atomic `mv -f` — never truncated-then-appended in place —
+so a crash or concurrent run can never leave a partially-written scoreboard. A
+filtered run (`--probe <id>`) carries forward untouched rows from a pre-write
+snapshot of the original file; it cannot erase rows it did not run.
+
+## RED → GREEN meaning
+
+`REGRESSION` (RED) = the resiliency property is absent or broken. Implement
+the property in `backend/` (and optionally `frontend/`) so the pytest suite
+passes, then rerun `bash evals/run.sh` to confirm the row flips to `PASS`.
+
+`SKIPPED` = the test file hasn't been written yet by the sibling agent, or
+`uv` is unavailable. This is the correct and expected state during parallel
+development. The row will automatically become `PASS` or `REGRESSION` once the
+test file exists.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -1,0 +1,14 @@
+# Probe results — benchmark scoreboard
+
+Current status per probe id, written by `bash evals/run.sh`. Policy: **overwrite the
+row per probe id; git history is the time series.** Schema and exit-code semantics are
+in [`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
+
+| probe | tier | last-run (UTC) | status | source |
+|-------|------|----------------|--------|--------|
+| resiliency-correlation-id | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — correlation-id plan (backend/tests/resiliency/test_correlation_id.py) |
+| resiliency-dlq | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — DLQ replay plan (backend/tests/resiliency/test_dlq_replay.py) |
+| resiliency-heartbeat-drain | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — heartbeat-drain plan (backend/tests/resiliency/test_heartbeat_drain.py) |
+| resiliency-idempotency | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py) |
+
+<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/resiliency-correlation-id.sh
+++ b/evals/probes/resiliency-correlation-id.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# tier: resiliency
+# source: resiliency track — correlation-id plan (backend/tests/resiliency/test_correlation_id.py)
+# desc: every request is tagged with a correlation ID that threads through the entire
+#       processing chain (API → worker → logs), enabling end-to-end request tracing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # evals/probes/<id>.sh -> evals/ -> repo root
+
+BACKEND_DIR="$ROOT/backend"
+TEST_FILE="$BACKEND_DIR/tests/resiliency/test_correlation_id.py"
+E2E_SPEC="$ROOT/frontend/e2e/correlation-id.spec.ts"
+
+# --- prerequisite: backend dir must exist ---
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "SKIPPED: backend directory absent: $BACKEND_DIR" >&2
+  exit 2
+fi
+
+# --- prerequisite: test file must exist ---
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "SKIPPED: test file absent: $TEST_FILE" >&2
+  exit 2
+fi
+
+# --- prerequisite: uv must be available ---
+if ! command -v uv &>/dev/null; then
+  echo "SKIPPED: uv not found in PATH" >&2
+  exit 2
+fi
+
+# --- load backend test env (optional: absent file is silently skipped for CI) ---
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+# shellcheck source=/dev/null
+[ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
+
+# --- primary determination: backend pytest (deterministic) ---
+# Note: test_run_agent_stream_binds_correlation_id opens a real DB connection
+# during teardown that hangs on cleanup.  We run pytest with an inner timeout
+# (60 s) so the probe itself exits cleanly before run.sh's outer 120 s limit.
+# Exit 124 from the inner timeout means pytest ran but cleanup hung — the tests
+# themselves emitted FAILED output, so we treat this as REGRESSION (not SKIPPED).
+_pytest_tmp="$(mktemp)"
+set +e
+# Use -v so that FAILED/PASSED markers appear per-test before teardown hangs.
+timeout 60 bash -c "cd '$BACKEND_DIR' && PYTHONPATH=./src:. uv run pytest -m resiliency tests/resiliency/test_correlation_id.py -v" > "$_pytest_tmp" 2>&1
+pytest_exit=$?
+set -e
+pytest_out="$(cat "$_pytest_tmp")"
+rm -f "$_pytest_tmp"
+
+case "$pytest_exit" in
+  0)
+    echo "PASS: correlation-id pytest passed" >&2
+    ;;
+  1)
+    echo "REGRESSION: correlation-id pytest failed — $pytest_out" >&2
+    exit 1
+    ;;
+  124)
+    # Inner timeout fired — pytest hung during teardown after running tests.
+    # Check whether FAILED output was produced (tests ran and failed → RED).
+    if echo "$pytest_out" | grep -q "FAILED\|failed"; then
+      echo "REGRESSION: correlation-id pytest failed (cleanup hung, tests FAILED) — $pytest_out" >&2
+      exit 1
+    else
+      echo "SKIPPED: pytest timed out before producing results (exit 124): $pytest_out" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    # collection error, missing deps, uv failure → SKIPPED
+    echo "SKIPPED: pytest collection/setup error (exit $pytest_exit): $pytest_out" >&2
+    exit 2
+    ;;
+esac
+
+# --- optional E2E determination (only when ORCHESTRA_E2E=1 and stack reachable) ---
+if [[ "${ORCHESTRA_E2E:-0}" = "1" ]]; then
+  if [[ ! -f "$E2E_SPEC" ]]; then
+    echo "SKIPPED (E2E): spec absent: $E2E_SPEC" >&2
+    exit 2
+  fi
+  if ! curl -sf http://localhost:5173 &>/dev/null; then
+    echo "SKIPPED (E2E): frontend stack not reachable at http://localhost:5173" >&2
+    exit 2
+  fi
+  set +e
+  e2e_out="$(cd "$ROOT/frontend" && npx playwright test e2e/correlation-id.spec.ts 2>&1)"
+  e2e_exit=$?
+  set -e
+  if [[ "$e2e_exit" -ne 0 ]]; then
+    echo "REGRESSION (E2E): playwright correlation-id spec failed — $e2e_out" >&2
+    exit 1
+  fi
+  echo "PASS: correlation-id E2E passed" >&2
+fi
+
+exit 0

--- a/evals/probes/resiliency-dlq.sh
+++ b/evals/probes/resiliency-dlq.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tier: resiliency
+# source: resiliency track — DLQ replay plan (backend/tests/resiliency/test_dlq_replay.py)
+# desc: failed tasks land in the dead-letter queue and can be replayed without data loss
+#       or duplication; the DLQ replay mechanism correctly re-enqueues and processes them.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # evals/probes/<id>.sh -> evals/ -> repo root
+
+BACKEND_DIR="$ROOT/backend"
+TEST_FILE="$BACKEND_DIR/tests/resiliency/test_dlq_replay.py"
+E2E_SPEC="$ROOT/frontend/e2e/dlq-replay.spec.ts"
+
+# --- prerequisite: backend dir must exist ---
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "SKIPPED: backend directory absent: $BACKEND_DIR" >&2
+  exit 2
+fi
+
+# --- prerequisite: test file must exist ---
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "SKIPPED: test file absent: $TEST_FILE" >&2
+  exit 2
+fi
+
+# --- prerequisite: uv must be available ---
+if ! command -v uv &>/dev/null; then
+  echo "SKIPPED: uv not found in PATH" >&2
+  exit 2
+fi
+
+# --- load backend test env (optional: absent file is silently skipped for CI) ---
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+# shellcheck source=/dev/null
+[ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
+
+# --- primary determination: backend pytest (deterministic) ---
+set +e
+pytest_out="$(cd "$BACKEND_DIR" && PYTHONPATH=./src:. uv run pytest -m resiliency tests/resiliency/test_dlq_replay.py -q 2>&1)"
+pytest_exit=$?
+set -e
+
+case "$pytest_exit" in
+  0)
+    echo "PASS: DLQ replay pytest passed" >&2
+    ;;
+  1)
+    echo "REGRESSION: DLQ replay pytest failed — $pytest_out" >&2
+    exit 1
+    ;;
+  *)
+    # collection error, missing deps, uv failure → SKIPPED
+    echo "SKIPPED: pytest collection/setup error (exit $pytest_exit): $pytest_out" >&2
+    exit 2
+    ;;
+esac
+
+# --- optional E2E determination (only when ORCHESTRA_E2E=1 and stack reachable) ---
+if [[ "${ORCHESTRA_E2E:-0}" = "1" ]]; then
+  if [[ ! -f "$E2E_SPEC" ]]; then
+    echo "SKIPPED (E2E): spec absent: $E2E_SPEC" >&2
+    exit 2
+  fi
+  if ! curl -sf http://localhost:5173 &>/dev/null; then
+    echo "SKIPPED (E2E): frontend stack not reachable at http://localhost:5173" >&2
+    exit 2
+  fi
+  set +e
+  e2e_out="$(cd "$ROOT/frontend" && npx playwright test e2e/dlq-replay.spec.ts 2>&1)"
+  e2e_exit=$?
+  set -e
+  if [[ "$e2e_exit" -ne 0 ]]; then
+    echo "REGRESSION (E2E): playwright DLQ replay spec failed — $e2e_out" >&2
+    exit 1
+  fi
+  echo "PASS: DLQ replay E2E passed" >&2
+fi
+
+exit 0

--- a/evals/probes/resiliency-heartbeat-drain.sh
+++ b/evals/probes/resiliency-heartbeat-drain.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tier: resiliency
+# source: resiliency track — heartbeat-drain plan (backend/tests/resiliency/test_heartbeat_drain.py)
+# desc: worker heartbeats are drained gracefully on shutdown — in-flight tasks are
+#       completed or checkpointed, and no heartbeat is left dangling after shutdown.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # evals/probes/<id>.sh -> evals/ -> repo root
+
+BACKEND_DIR="$ROOT/backend"
+TEST_FILE="$BACKEND_DIR/tests/resiliency/test_heartbeat_drain.py"
+E2E_SPEC="$ROOT/frontend/e2e/heartbeat-drain.spec.ts"
+
+# --- prerequisite: backend dir must exist ---
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "SKIPPED: backend directory absent: $BACKEND_DIR" >&2
+  exit 2
+fi
+
+# --- prerequisite: test file must exist ---
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "SKIPPED: test file absent: $TEST_FILE" >&2
+  exit 2
+fi
+
+# --- prerequisite: uv must be available ---
+if ! command -v uv &>/dev/null; then
+  echo "SKIPPED: uv not found in PATH" >&2
+  exit 2
+fi
+
+# --- load backend test env (optional: absent file is silently skipped for CI) ---
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+# shellcheck source=/dev/null
+[ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
+
+# --- primary determination: backend pytest (deterministic) ---
+set +e
+pytest_out="$(cd "$BACKEND_DIR" && PYTHONPATH=./src:. uv run pytest -m resiliency tests/resiliency/test_heartbeat_drain.py -q 2>&1)"
+pytest_exit=$?
+set -e
+
+case "$pytest_exit" in
+  0)
+    echo "PASS: heartbeat-drain pytest passed" >&2
+    ;;
+  1)
+    echo "REGRESSION: heartbeat-drain pytest failed — $pytest_out" >&2
+    exit 1
+    ;;
+  *)
+    # collection error, missing deps, uv failure → SKIPPED
+    echo "SKIPPED: pytest collection/setup error (exit $pytest_exit): $pytest_out" >&2
+    exit 2
+    ;;
+esac
+
+# --- optional E2E determination (only when ORCHESTRA_E2E=1 and stack reachable) ---
+if [[ "${ORCHESTRA_E2E:-0}" = "1" ]]; then
+  if [[ ! -f "$E2E_SPEC" ]]; then
+    echo "SKIPPED (E2E): spec absent: $E2E_SPEC" >&2
+    exit 2
+  fi
+  if ! curl -sf http://localhost:5173 &>/dev/null; then
+    echo "SKIPPED (E2E): frontend stack not reachable at http://localhost:5173" >&2
+    exit 2
+  fi
+  set +e
+  e2e_out="$(cd "$ROOT/frontend" && npx playwright test e2e/heartbeat-drain.spec.ts 2>&1)"
+  e2e_exit=$?
+  set -e
+  if [[ "$e2e_exit" -ne 0 ]]; then
+    echo "REGRESSION (E2E): playwright heartbeat-drain spec failed — $e2e_out" >&2
+    exit 1
+  fi
+  echo "PASS: heartbeat-drain E2E passed" >&2
+fi
+
+exit 0

--- a/evals/probes/resiliency-idempotency.sh
+++ b/evals/probes/resiliency-idempotency.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# tier: resiliency
+# source: resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py)
+# desc: duplicate task submissions are idempotent — the backend rejects or deduplicates
+#       re-submitted tasks that carry the same idempotency key, with no double-execution.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # evals/probes/<id>.sh -> evals/ -> repo root
+
+BACKEND_DIR="$ROOT/backend"
+TEST_FILE="$BACKEND_DIR/tests/resiliency/test_idempotency.py"
+E2E_SPEC="$ROOT/frontend/e2e/idempotency.spec.ts"
+
+# --- prerequisite: backend dir must exist ---
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "SKIPPED: backend directory absent: $BACKEND_DIR" >&2
+  exit 2
+fi
+
+# --- prerequisite: test file must exist ---
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "SKIPPED: test file absent: $TEST_FILE" >&2
+  exit 2
+fi
+
+# --- prerequisite: uv must be available ---
+if ! command -v uv &>/dev/null; then
+  echo "SKIPPED: uv not found in PATH" >&2
+  exit 2
+fi
+
+# --- load backend test env (optional: absent file is silently skipped for CI) ---
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+# shellcheck source=/dev/null
+[ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
+
+# --- primary determination: backend pytest (deterministic) ---
+set +e
+pytest_out="$(cd "$BACKEND_DIR" && PYTHONPATH=./src:. uv run pytest -m resiliency tests/resiliency/test_idempotency.py -q 2>&1)"
+pytest_exit=$?
+set -e
+
+case "$pytest_exit" in
+  0)
+    echo "PASS: idempotency pytest passed" >&2
+    ;;
+  1)
+    echo "REGRESSION: idempotency pytest failed — $pytest_out" >&2
+    exit 1
+    ;;
+  *)
+    # collection error, missing deps, uv failure → SKIPPED
+    echo "SKIPPED: pytest collection/setup error (exit $pytest_exit): $pytest_out" >&2
+    exit 2
+    ;;
+esac
+
+# --- optional E2E determination (only when ORCHESTRA_E2E=1 and stack reachable) ---
+if [[ "${ORCHESTRA_E2E:-0}" = "1" ]]; then
+  if [[ ! -f "$E2E_SPEC" ]]; then
+    echo "SKIPPED (E2E): spec absent: $E2E_SPEC" >&2
+    exit 2
+  fi
+  if ! curl -sf http://localhost:5173 &>/dev/null; then
+    echo "SKIPPED (E2E): frontend stack not reachable at http://localhost:5173" >&2
+    exit 2
+  fi
+  set +e
+  e2e_out="$(cd "$ROOT/frontend" && npx playwright test e2e/idempotency.spec.ts 2>&1)"
+  e2e_exit=$?
+  set -e
+  if [[ "$e2e_exit" -ne 0 ]]; then
+    echo "REGRESSION (E2E): playwright idempotency spec failed — $e2e_out" >&2
+    exit 1
+  fi
+  echo "PASS: idempotency E2E passed" >&2
+fi
+
+exit 0

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# evals/run.sh — discover evals/probes/*.sh, run each against real state, and
+# write evals/RESULTS.md benchmark scoreboard (overwrite-row-per-probe).
+# Exit-code oracle per probe: 0=PASS 1=REGRESSION 2=SKIPPED 124=TIMEOUT other=ERROR.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"    # evals/run.sh -> repo root (one level up)
+PROBES_DIR="$ROOT/evals/probes"
+RESULTS="$ROOT/evals/RESULTS.md"
+TIMEOUT_SECS=120
+
+FILTER_PROBE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --probe) FILTER_PROBE="${2:-}"; shift 2 ;;
+    -h|--help) echo "usage: run.sh [--probe <id>]"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+
+# Temp-file handle for the atomic scoreboard write.
+tmp=""
+trap '[ -n "$tmp" ] && rm -f "$tmp"' EXIT
+
+# Capture the pre-write scoreboard ONCE. Carry-forward (prior_row) reads this
+# snapshot, never the live $RESULTS — a filtered run cannot erase untouched
+# rows, and a crash mid-write leaves the original file intact (atomic mv below).
+RESULTS_ORIG=""
+[ -f "$RESULTS" ] && RESULTS_ORIG="$(cat "$RESULTS")"
+
+hdr() { grep -E "^# $1:" "$2" 2>/dev/null | head -1 | sed "s/^# $1:[[:space:]]*//" || true; }
+prior_row() { grep -E "^\| ${1} \|" <<<"$RESULTS_ORIG" 2>/dev/null | head -1 || true; }
+prior_status() { prior_row "$1" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'; }
+
+now="$(date -u +'%Y-%m-%d %H:%M')"
+declare -A NEWROW
+regressions=()
+ran=0
+
+shopt -s nullglob
+for probe in "$PROBES_DIR"/*.sh; do
+  id="$(basename "$probe" .sh)"
+  tier="$(hdr tier "$probe")";  tier="${tier:-?}"
+  src="$(hdr source "$probe")"; src="${src:-?}"
+  [ -n "$FILTER_PROBE" ] && [ "$id" != "$FILTER_PROBE" ] && continue
+
+  set +e
+  reason="$(timeout "$TIMEOUT_SECS" bash "$probe" 2>&1 1>/dev/null)"
+  code=$?
+  set -e
+  case "$code" in
+    0)   status="PASS" ;;
+    1)   status="REGRESSION" ;;
+    2)   status="SKIPPED" ;;
+    124) status="TIMEOUT" ;;
+    *)   status="ERROR" ;;
+  esac
+  reason="${reason%%$'\n'*}"   # first stderr line only
+
+  prior="$(prior_status "$id")"
+  if [ -z "$prior" ]; then
+    if [ "$status" = "PASS" ]; then delta="new-pass"; else delta="new-fail"; fi
+  elif [ "$prior" = "$status" ]; then
+    delta="unchanged"
+  else
+    delta="${prior}->${status}"
+  fi
+  # green->red is the regression signal; first run has no prior, so never fires
+  if [ "$prior" = "PASS" ] && [ "$status" != "PASS" ] && [ "$status" != "SKIPPED" ]; then
+    regressions+=("$id ($src): was PASS, now $status — ${reason:-no reason}")
+  fi
+
+  NEWROW[$id]="| $id | $tier | $now | $status | $src |"
+  printf '%-40s %-11s %s\n' "$id" "$status" "$delta" >&2
+  ran=$((ran + 1))
+done
+
+# --- rewrite RESULTS.md: build the full scoreboard into a temp sibling file, then
+#     replace the live file in ONE atomic mv -f. New rows for probes run this
+#     invocation; carry prior rows (from RESULTS_ORIG snapshot) for the rest.
+#     The temp path is a SIBLING of $RESULTS (same filesystem) so mv -f is atomic. ---
+tmp="$RESULTS.tmp.$$"
+cat > "$tmp" <<'HDR'
+# Probe results — benchmark scoreboard
+
+Current status per probe id, written by `bash evals/run.sh`. Policy: **overwrite the
+row per probe id; git history is the time series.** Schema and exit-code semantics are
+in [`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
+
+| probe | tier | last-run (UTC) | status | source |
+|-------|------|----------------|--------|--------|
+HDR
+for probe in "$PROBES_DIR"/*.sh; do
+  id="$(basename "$probe" .sh)"
+  if [ -n "${NEWROW[$id]+x}" ]; then
+    printf '%s\n' "${NEWROW[$id]}" >> "$tmp"
+  else
+    pr="$(prior_row "$id")"
+    if [ -n "$pr" ]; then
+      printf '%s\n' "$pr" >> "$tmp"
+    else
+      printf '| %s | %s | — | (not run) | %s |\n' "$id" "$(hdr tier "$probe")" "$(hdr source "$probe")" >> "$tmp"
+    fi
+  fi
+done
+printf '\n<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->\n' >> "$tmp"
+mv -f "$tmp" "$RESULTS"
+tmp=""
+
+# --- summary to stdout: regressions first ---
+if [ "${#regressions[@]}" -gt 0 ]; then
+  echo "REGRESSIONS (${#regressions[@]}):"
+  for r in "${regressions[@]}"; do echo "  - $r"; done
+fi
+echo "ran $ran probe(s); wrote $RESULTS"
+if [ "${#regressions[@]}" -gt 0 ]; then exit 1; fi
+exit 0

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+e2e/.artifacts/
+playwright-report/
+test-results/

--- a/frontend/e2e/correlation-id.spec.ts
+++ b/frontend/e2e/correlation-id.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Resiliency spec: Correlation / request ID surfaced on error
+ *
+ * When the API returns an error, the UI must display a correlation or request
+ * reference identifier on the error surface so users can include it in bug
+ * reports and operators can trace the request in logs.
+ *
+ * Expected format: any alphanumeric/UUID string accompanying an error message,
+ * e.g. "Request ID: abc123-…" or a `data-correlation-id` attribute.
+ *
+ * Today, error messages are surfaced without a reference ID, so this test is
+ * annotated test.fail().
+ *
+ * FLIP: remove test.fail() once correlation-ID surfacing lands.
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
+const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
+
+// UUID / correlation-ID pattern: any run of hex + hyphens of reasonable length
+const CORRELATION_ID_PATTERN = /[0-9a-f-]{8,}/i;
+
+test.describe("Correlation ID on error surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto("/", { waitUntil: "networkidle" });
+  });
+
+  // FLIP: remove test.fail() once correlation-ID surfacing lands.
+  test.fail(
+    true,
+    "Error surfaces today do not display a correlation/request ID (feature not yet implemented)",
+  );
+
+  test("an API error response surfaces a correlation ID visible to the user", async ({
+    page,
+  }) => {
+    // Intercept and force an error response from the API so we get a
+    // deterministic failure without relying on an unstable backend path.
+    await page.route("**/api/runs**", (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          detail: "Internal Server Error",
+          // The backend is expected to include a request/correlation ID.
+          // This mock documents the intended shape; replace once the backend
+          // ships the field.
+          request_id: "e2e-mock-correlation-00000000-0000-0000-0000-000000000000",
+        }),
+      });
+    });
+
+    const input = page.locator(CHAT_INPUT);
+    await input.fill("trigger correlation id test");
+    await page.locator(SUBMIT_BUTTON).click();
+
+    // Wait for any error surface
+    const errorRegion = page.locator(
+      "[role='alert'], [data-testid='error-message'], text=error, text=Error",
+    );
+    await expect(errorRegion.first()).toBeVisible({ timeout: 15_000 });
+
+    // The error surface must contain a string matching a correlation/request ID
+    const errorText = await page.locator("body").textContent();
+    expect(errorText).toMatch(CORRELATION_ID_PATTERN);
+
+    // Preferred: a labelled reference ID element
+    const labelledId = page.locator(
+      "[data-testid='correlation-id'], [data-correlation-id], :text-matches('(Request|Correlation|Trace|Request ID)[:\\s]+[0-9a-f-]{8,}', 'i')",
+    );
+    await expect(labelledId.first()).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/frontend/e2e/dlq-replay.spec.ts
+++ b/frontend/e2e/dlq-replay.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Resiliency spec: Dead-letter queue (DLQ) replay affordance
+ *
+ * When a message hits a permanent processing failure (e.g., an intentionally
+ * malformed payload or a model that rejects the request outright), the UI must:
+ *   1. NOT silently hang — it must surface a failed/error state.
+ *   2. Offer a replay / retry affordance (button, link, or actionable text) so
+ *      the user can recover without refreshing.
+ *
+ * Today, failed runs may leave the UI in a loading/hanging state with no replay
+ * option, so this test is annotated test.fail().
+ *
+ * FLIP: remove test.fail() once DLQ replay affordance lands.
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
+const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
+
+// Selectors for expected error / replay UI (to be confirmed once feature lands)
+// These are intentionally flexible — match any visible error region or retry CTA.
+const ERROR_STATE_SELECTORS = [
+  "[data-testid='message-error']",
+  "[data-testid='replay-button']",
+  "button:has-text('Retry')",
+  "button:has-text('Replay')",
+  "[role='alert']",
+  "text=failed",
+  "text=error",
+];
+
+test.describe("DLQ replay affordance", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto("/", { waitUntil: "networkidle" });
+  });
+
+  // FLIP: remove test.fail() once DLQ replay affordance lands.
+  test.fail(
+    true,
+    "Permanent failure currently leaves UI in a hanging/loading state with no replay affordance (not yet implemented)",
+  );
+
+  test("a permanently-failing message surfaces an error state and a replay affordance", async ({
+    page,
+  }) => {
+    // Send a payload crafted to trigger a permanent failure.
+    // "__DLQ_TRIGGER__" is a sentinel the backend (once wired) can use to
+    // force-fail immediately without retrying.  For now the spec documents the
+    // intended injection point.
+    const input = page.locator(CHAT_INPUT);
+    await input.fill("__DLQ_TRIGGER__: force permanent failure for e2e test");
+
+    await page.locator(SUBMIT_BUTTON).click();
+
+    // Wait up to 30 s for ANY error/replay signal to appear
+    const errorLocators = page.locator(ERROR_STATE_SELECTORS.join(", "));
+    await expect(errorLocators.first()).toBeVisible({ timeout: 30_000 });
+
+    // Additional assertion: the loading spinner must NOT still be visible after
+    // the error surface appears (i.e., the UI has settled, not hung).
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: 5_000 });
+
+    // The replay affordance must be interactive
+    const replayAffordance = page.locator(
+      "button:has-text('Retry'), button:has-text('Replay'), [data-testid='replay-button']",
+    );
+    await expect(replayAffordance.first()).toBeEnabled();
+  });
+});

--- a/frontend/e2e/heartbeat-drain.spec.ts
+++ b/frontend/e2e/heartbeat-drain.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Resiliency spec: Heartbeat / stream drain on worker loss
+ *
+ * Scenario:
+ *   1. Start a streaming run (send a message that will trigger a long response).
+ *   2. Simulate worker loss mid-stream by intercepting SSE and closing the
+ *      connection prematurely.
+ *   3. Reload the page.
+ *   4. The active-stream recovery hook (useActiveStreamRecovery.ts) should
+ *      detect the in-progress run via `ruska.active_streams.v1` in localStorage
+ *      and re-attach, surfacing the "Lost connection… refresh to retry" message
+ *      or automatically resuming.
+ *
+ * Today, worker loss leaves the stream silently broken with no recovery on
+ * reload, so this test is annotated test.fail().
+ *
+ * FLIP: remove test.fail() once heartbeat-drain + stream recovery lands.
+ *
+ * Injection hook notes:
+ *   - localStorage key: "ruska.active_streams.v1"
+ *     Shape: { [threadId]: { runId: string; lastEventId: string | null } }
+ *   - The recovery hook reads this key in useActiveStreamRecovery.ts and calls
+ *     attachToDistributedStream() if thread.metadata.stream_status === "running".
+ *   - "Lost connection… refresh to retry" text lives in streamClient.ts /
+ *     the component that surfaces reconnect events.
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
+const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
+const ASSISTANT_BUBBLE = "div.rounded-bl-sm";
+
+// localStorage key used by the active-stream recovery subsystem
+const ACTIVE_STREAMS_KEY = "ruska.active_streams.v1";
+
+// Text that the recovery subsystem surfaces when reconnection is needed
+const LOST_CONNECTION_TEXT = "Lost connection";
+
+test.describe("Heartbeat / stream drain recovery", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto("/", { waitUntil: "networkidle" });
+  });
+
+  // FLIP: remove test.fail() once heartbeat-drain + stream recovery lands.
+  test.fail(
+    true,
+    "Worker-loss recovery is not yet implemented; reload after mid-stream disconnect does not resume or surface the reconnect message",
+  );
+
+  test("after simulated worker loss, reload surfaces recovery message or resumes the stream", async ({
+    page,
+  }) => {
+    // Step 1: Start a streaming run
+    const input = page.locator(CHAT_INPUT);
+    await input.fill(
+      "Write a very long essay about distributed systems resilience, at least 500 words.",
+    );
+    await page.locator(SUBMIT_BUTTON).click();
+
+    // Wait for at least one token to arrive (loading spinner appears first)
+    await expect(page.locator(".animate-spin").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Step 2: Capture the current thread URL so we can re-navigate after reload
+    const threadUrl = page.url();
+
+    // Step 3: Simulate worker loss by aborting all SSE connections mid-stream
+    // and injecting a recovery record into localStorage.
+    // The injection mirrors what the app would have written if the connection
+    // dropped naturally — the spec documents the hook, not a live connection.
+    await page.evaluate((key) => {
+      // Inject a synthetic "in-progress" recovery record.
+      // In production this would be written by the app before the disconnect.
+      const syntheticRecord: Record<string, { runId: string; lastEventId: string | null }> = {};
+      // Use a placeholder run ID; the backend mock (not running here) would
+      // use a real UUID.  The recovery hook will attempt to reattach and fail
+      // gracefully, surfacing the lost-connection message.
+      const threadIdMatch = window.location.pathname.match(/thread\/([^/]+)/);
+      const threadId = threadIdMatch ? threadIdMatch[1] : "synthetic-thread-id";
+      syntheticRecord[threadId] = {
+        runId: "synthetic-run-id-00000000-0000-0000-0000-000000000000",
+        lastEventId: null,
+      };
+      localStorage.setItem(key, JSON.stringify(syntheticRecord));
+    }, ACTIVE_STREAMS_KEY);
+
+    // Abort all in-flight requests to simulate the worker going away
+    await page.route("**/api/runs/**", (route) => route.abort("connectionreset"));
+
+    // Step 4: Reload the page
+    await page.goto(threadUrl, { waitUntil: "networkidle" });
+
+    // Step 5: Assert recovery — either the reconnect message is shown OR the
+    // stream resumes (an assistant bubble appears within a reasonable window).
+    const lostConnectionLocator = page.locator(`text=${LOST_CONNECTION_TEXT}`);
+    const assistantBubble = page.locator(ASSISTANT_BUBBLE).first();
+
+    // At least one of these must materialise within 20 s
+    await expect(
+      lostConnectionLocator.or(assistantBubble),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // Additionally verify that the recovery key was consumed (cleared) after
+    // a successful reattachment, OR still present while reconnecting
+    const storageValue = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      ACTIVE_STREAMS_KEY,
+    );
+    // Either cleared (recovered) or still set (in-progress reconnect) is acceptable;
+    // what is NOT acceptable is a completely silent UI with no recovery signal.
+    // This assertion documents the expected state rather than gating on it.
+    console.log(`[heartbeat-drain] ${ACTIVE_STREAMS_KEY} after reload:`, storageValue);
+  });
+});

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,0 +1,30 @@
+import { Page } from "@playwright/test";
+
+const API_URL = "http://localhost:8000";
+const TOKEN_KEY = "enso:auth:token";
+
+/**
+ * Log in as the seeded admin user and inject the token into localStorage so
+ * the React app's auth guard passes on the next navigation.
+ *
+ * Must be called BEFORE navigating to any protected page.
+ */
+export async function loginAsAdmin(page: Page): Promise<void> {
+  // Obtain a token from the backend
+  const response = await page.request.post(`${API_URL}/auth/login`, {
+    data: { email: "admin@example.com", password: "test1234" },
+  });
+
+  const body = await response.json();
+  const token: string = body.access_token;
+
+  // Seed localStorage before the app boots (navigate to the origin first so
+  // localStorage is accessible, then set the key).
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.evaluate(
+    ([key, value]) => {
+      localStorage.setItem(key, value);
+    },
+    [TOKEN_KEY, token],
+  );
+}

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -11,7 +11,7 @@ const TOKEN_KEY = "enso:auth:token";
  */
 export async function loginAsAdmin(page: Page): Promise<void> {
   // Obtain a token from the backend
-  const response = await page.request.post(`${API_URL}/auth/login`, {
+  const response = await page.request.post(`${API_URL}/api/auth/login`, {
     data: { email: "admin@example.com", password: "test1234" },
   });
 

--- a/frontend/e2e/idempotency.spec.ts
+++ b/frontend/e2e/idempotency.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Resiliency spec: Double-submit idempotency
+ *
+ * Sending a message twice in rapid succession (two clicks / two Enter presses
+ * before the first response arrives) must produce exactly ONE assistant reply
+ * bubble — not two.  Today, the frontend does not guard against this and a
+ * second identical run is kicked off, so the test is annotated test.fail().
+ *
+ * FLIP: remove test.fail() once the double-submit guard lands.
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+// Selector constants derived from verified live selectors in the briefing
+const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
+const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
+// Assistant response bubble class confirmed in ChatMessages.tsx line ~194-204
+const ASSISTANT_BUBBLE = "div.rounded-bl-sm";
+
+test.describe("Double-submit idempotency", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    // Navigate to chat; adjust if the default route is different
+    await page.goto("/", { waitUntil: "networkidle" });
+  });
+
+  // FLIP: remove test.fail() once the double-submit guard lands.
+  test.fail(
+    true,
+    "Double-submit currently produces two assistant bubbles; expected one (guard not yet implemented)",
+  );
+
+  test("typing a message and submitting twice produces exactly one assistant bubble", async ({
+    page,
+  }) => {
+    // Type a short deterministic message
+    const input = page.locator(CHAT_INPUT);
+    await input.fill("ping idempotency test");
+
+    // Submit twice as fast as possible
+    const submitBtn = page.locator(SUBMIT_BUTTON);
+    await submitBtn.click();
+    // Second click immediately — no await between them
+    await submitBtn.click();
+
+    // Wait for at least one assistant bubble to appear (the backend will reply)
+    await expect(page.locator(ASSISTANT_BUBBLE).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Allow up to 5 s for a second bubble to materialise (it shouldn't)
+    await page.waitForTimeout(5_000);
+
+    // RESILIENT OUTCOME: exactly one assistant bubble
+    const bubbles = page.locator(ASSISTANT_BUBBLE);
+    await expect(bubbles).toHaveCount(1);
+  });
+
+  test("pressing Enter twice rapidly produces exactly one assistant bubble", async ({
+    page,
+  }) => {
+    const input = page.locator(CHAT_INPUT);
+    await input.fill("ping idempotency enter");
+
+    // Two Enter presses with no gap
+    await input.press("Enter");
+    await input.press("Enter");
+
+    await expect(page.locator(ASSISTANT_BUBBLE).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.waitForTimeout(5_000);
+
+    const bubbles = page.locator(ASSISTANT_BUBBLE);
+    await expect(bubbles).toHaveCount(1);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,6 +82,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.15.0",
+				"@playwright/test": "^1.60.0",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "^16.1.0",
@@ -2626,6 +2627,22 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@plotly/d3": {
@@ -14500,6 +14517,53 @@
 				"confbox": "^0.1.8",
 				"mlly": "^1.7.4",
 				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plotly.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
 		"preview": "vite preview",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"e2e": "playwright test",
+		"e2e:install": "playwright install chromium"
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.2",
@@ -91,6 +93,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.15.0",
+		"@playwright/test": "^1.60.0",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.1.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E configuration for the Orchestra frontend.
+ *
+ * baseURL is the externally-provided Vite dev server (http://localhost:5173).
+ * No webServer block — the stack is started externally before tests run.
+ *
+ * Resiliency specs are authored with test.fail() at baseline so they pass CI
+ * today even though the resilient behaviours are not yet implemented.  Once a
+ * fix lands, remove the corresponding test.fail() annotation and the test will
+ * become a hard failure on regression (the GREEN signal).
+ */
+export default defineConfig({
+  testDir: "./e2e",
+
+  /* Artifacts on failure (screenshots, traces, videos) */
+  outputDir: "./e2e/.artifacts/results/",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "./e2e/.artifacts/report", open: "never" }],
+  ],
+
+  use: {
+    baseURL: "http://localhost:5173",
+
+    /* Capture screenshot + trace on every failure */
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1920, height: 1080 },
+      },
+    },
+    {
+      name: "mobile",
+      use: {
+        ...devices["Pixel 5"],
+        viewport: { width: 414, height: 896 },
+      },
+    },
+  ],
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,6 +14,16 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
 
+  /* CI runs the full stack (postgres + redis + api + worker + vite) on a single
+   * runner. Unbounded parallel Playwright workers starve the Vite dev server and
+   * the React app misses its 30s mount window (the chat input/submit never
+   * appears in time). Serialize in CI and retry to absorb cold-start/contention;
+   * locally (no CI env) keep the default parallelism. */
+  fullyParallel: false,
+  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 2 : 0,
+  timeout: process.env.CI ? 60_000 : 30_000,
+
   /* Artifacts on failure (screenshots, traces, videos) */
   outputDir: "./e2e/.artifacts/results/",
   reporter: [

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "jsdom",
+		exclude: [
+			"**/node_modules/**",
+			"**/dist/**",
+			"e2e/**",
+			"playwright.config.ts",
+		],
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Resiliency fitness-function eval harness (RED baseline)

The **determination of improvement** for a series of resiliency upgrades to orchestra's long-horizon background agents. Ports OpenHarness's `evals/` fitness function: every resiliency fix must move a probe from **RED → GREEN**, proving the gap was real and the fix closed it.

### What this PR adds (no runtime/app code — harness only)

| Surface | Contents |
|---|---|
| `backend/tests/resiliency/` | 4 pytest probes under a new `resiliency` marker — each asserts a resiliency property that does **not** exist today. Baseline: **10 failed / 1 invariant-pass**. |
| `backend/pytest.ini` | `addopts = -m "not resiliency"` → probes are a fitness function, **excluded from the default suite**, so `test-backend` CI stays green. |
| `evals/` | `run.sh` (3-state oracle 0 PASS / 1 REGRESSION / 2 SKIPPED), 4 probe wrappers, `RESULTS.md` scoreboard, `README.md`. Env-load is CI-overridable via `ORCHESTRA_ENV_FILE`. |
| `frontend/e2e/` | Playwright specs at **desktop 1920×1080 + mobile 414×896**, using `test.fail()` baselines that flip to hard failures once each fix lands. `vitest.config.ts` excludes `e2e/` so `test-frontend` stays green. |
| `.github/workflows/test.yml` | Non-blocking `test-e2e` job (`continue-on-error: true`) — runs the Playwright suite without gating required checks yet. |

### Baseline determination (RED) — `bash evals/run.sh`

| probe | status |
|-------|--------|
| resiliency-idempotency | **REGRESSION** |
| resiliency-dlq | **REGRESSION** |
| resiliency-correlation-id | **REGRESSION** |
| resiliency-heartbeat-drain | **REGRESSION** |

All four RED, as expected — the resiliency properties are absent on `development`. This merged RED baseline is the agreed, falsifiable gap.

### How RED→GREEN is encoded (CI-safe)

The baseline PR's own CI stays green while the fitness function records RED: backend probes are marker-excluded; E2E specs use `test.fail()`. A fix **flips** its probe (backend test passes; `test.fail()` becomes an unexpected-pass that must be removed) — that flip *is* the proof.

### Sequence

Foundation for **stacked fix PRs** (idempotency → DLQ → correlation-ID → heartbeat/drain), each flipping one probe GREEN with before/after agent-browser screenshots, plus a companion **Reliability & Recovery** docs PR to `mifunedev/wiki`.

> Draft pending `/pr-audit`. UI before/after screenshots land per fix track.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end Playwright resiliency coverage for correlation/request-id visibility, DLQ replay affordances, worker heartbeat draining behavior, and double-submit idempotency.
  * Added backend resiliency “fitness-function” probe tests for correlation binding, DLQ recording/replay, deduplication, and draining/heartbeat expectations.

* **Chores**
  * Updated CI to run Playwright-based end-to-end checks alongside backend readiness/migrations and publish test artifacts.
  * Added an eval runner and probe documentation/scoreboard to track probe outcomes over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->