### PR TITLE
FROM task/936-pages-workflow-source TO development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.6.14
+
+### Fixed
+  - task/936-pages-workflow-source — deprecate the legacy GitHub Pages branch source in favor of the `slides.yml` GitHub Actions deployment and correct stale deck deployment documentation.
+
 ## 2026.6.13
 
 ### Changed

--- a/decks/AGENTS.md
+++ b/decks/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-reveal.js slide deck for [github.com/ruska-ai/orchestra](https://github.com/ruska-ai/orchestra).
+reveal.js slide deck for [github.com/mifunedev/orchestra](https://github.com/mifunedev/orchestra).
 
-- **Live URL:** <https://ruska-ai.github.io/orchestra/>
+- **Live URL:** <https://mifunedev.github.io/orchestra/>
 - **Tech:** Static HTML with reveal.js via CDN - no build step required
 - **Edit:** `decks/slides/index.html` directly
 
@@ -43,7 +43,7 @@ Use the `agent-browser` CLI to verify the slide deck loads and navigates correct
 
 ```bash
 # 1. Start a local server in the background
-python -m http.server 8080 --directory docs &
+python -m http.server 8080 --directory decks &
 
 # 2. Open the slide deck
 agent-browser open http://localhost:8080/slides/
@@ -88,11 +88,11 @@ agent-browser open http://localhost:8080/slides/
 agent-browser press ArrowRight  # Navigate as needed
 
 # Capture current slide
-agent-browser screenshot docs/slides/screenshots/slide-title.png
+agent-browser screenshot decks/slides/screenshots/slide-title.png
 
 # Capture full-page overview (e.g., after pressing 'o' for overview mode)
 agent-browser press o
-agent-browser screenshot --full docs/slides/screenshots/overview.png
+agent-browser screenshot --full decks/slides/screenshots/overview.png
 ```
 
 ## Deployment
@@ -101,6 +101,7 @@ Auto-deploys via `.github/workflows/slides.yml`:
 
 - **Trigger:** push to `development` when files in `decks/slides/**` change, or manual `workflow_dispatch`
 - **Action:** uploads the entire `decks/` directory as a GitHub Pages artifact
+- **Pages source:** GitHub Actions. Do not configure the legacy branch source (`development` + `/docs`); the repository has no root `docs/` directory.
 - **Concurrency:** only one deployment runs at a time
 
 ## Editing Slides

--- a/decks/README.md
+++ b/decks/README.md
@@ -2,7 +2,7 @@
 
 GitHub Pages site for Orchestra presentations and slide decks.
 
-**Live:** <https://ruska-ai.github.io/orchestra/>
+**Live:** <https://mifunedev.github.io/orchestra/>
 
 ## Directory Structure
 
@@ -32,6 +32,7 @@ Automatic via `.github/workflows/slides.yml`:
 
 - **Trigger:** push to `development` when files in `decks/slides/**` change (or manual `workflow_dispatch`)
 - **Action:** uploads the entire `decks/` directory as a GitHub Pages artifact
+- **Pages source:** GitHub Actions. Do not configure the legacy branch source (`development` + `/docs`); the repository has no root `docs/` directory.
 - **Concurrency:** only one deployment runs at a time
 
 ## Adding Content

--- a/decks/slides/README.md
+++ b/decks/slides/README.md
@@ -4,7 +4,7 @@ Static HTML presentation built with [reveal.js](https://revealjs.com/) for showc
 
 ## Live URL
 
-Once deployed, the slides are available at: **https://ruska-ai.github.io/orchestra/slides/**
+Once deployed, the slides are available at: **https://mifunedev.github.io/orchestra/slides/**
 
 ## Local Development
 
@@ -12,10 +12,10 @@ Once deployed, the slides are available at: **https://ruska-ai.github.io/orchest
 
 ```bash
 # From repository root
-npx serve docs/slides
+npx serve decks/slides
 
 # Or with live reload
-npx live-server docs/slides --port=8080
+npx live-server decks/slides --port=8080
 ```
 
 Then open http://localhost:8080 in your browser.
@@ -23,8 +23,8 @@ Then open http://localhost:8080 in your browser.
 ### Python Alternative
 
 ```bash
-# From docs/slides directory
-cd docs/slides
+# From decks/slides directory
+cd decks/slides
 python -m http.server 8080
 ```
 
@@ -94,23 +94,17 @@ Edit `index.html` directly. The presentation uses reveal.js via CDN, so no build
 
 ## Deployment
 
-Slides are automatically deployed to GitHub Pages when changes are merged to the `development` branch.
+Slides are automatically deployed by `.github/workflows/slides.yml` when changes under `decks/slides/` are merged to the `development` branch. GitHub Pages must use **Build and deployment → Source: GitHub Actions**; the legacy branch source (`development` + `/docs`) is deprecated because the repository no longer has a root `docs/` directory.
 
 ### Manual Deployment
 
-If you need to deploy manually:
-
-1. Go to GitHub repository **Settings** → **Pages**
-2. Under "Source", select branch `development` and folder `/docs`
-3. Save
-
-The workflow `.github/workflows/slides.yml` handles automatic deployment.
+If you need to deploy manually, run the **Deploy Slides to GitHub Pages** workflow from the Actions tab. Do not switch Pages back to a branch source.
 
 ## Adding New Slides
 
-1. Edit `docs/slides/index.html`
+1. Edit `decks/slides/index.html`
 2. Add new `<section>` elements where appropriate
-3. Preview locally with `npx serve docs/slides`
+3. Preview locally with `npx serve decks/slides`
 4. Commit and push to trigger deployment
 
 ## Resources


### PR DESCRIPTION
Closes #936

## Summary
- Confirmed the failed pipeline is GitHub's implicit legacy Pages Jekyll build (`pages build and deployment`), not a checked-in workflow.
- Switched repository Pages build source from legacy branch build to GitHub Actions so `.github/workflows/slides.yml` remains the only Pages publisher.
- Updated deck deployment docs away from the obsolete `development` + `/docs` source and stale `ruska-ai.github.io` URLs.

## Validation
- `gh api repos/mifunedev/orchestra/pages` → `build_type: workflow`, `status: built`.
- Manual `Deploy Slides to GitHub Pages` run succeeded: https://github.com/mifunedev/orchestra/actions/runs/27486272444
- `curl -I -L https://mifunedev.github.io/orchestra/slides/` → HTTP 200.
- `git diff --check` passed.
