### PR TITLE
Fix slide Mermaid rendering across navigation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day
 ## 2026.6.14
 
 ### Fixed
+  - fix/940-mermaid-navigation — preserve Mermaid diagram source before rendering so slide diagrams stay visible after navigating between nested slides.
   - task/938-mifune-slide-brand — align the GitHub Pages slide deck and one-page handout with Mifune branding, green-only accents, mifune.dev links, and support@mifune.dev contact details.
   - task/936-pages-workflow-source — deprecate the legacy GitHub Pages branch source in favor of the `slides.yml` GitHub Actions deployment and correct stale deck deployment documentation.
 

--- a/decks/slides/index.html
+++ b/decks/slides/index.html
@@ -426,17 +426,22 @@ graph LR
   </script>
   <script>
     async function renderVisibleMermaid() {
-      const visibleSlides = document.querySelectorAll('.reveal .slides section.present');
-      const nodes = [];
-      visibleSlides.forEach(slide => {
-        slide.querySelectorAll('.mermaid-src').forEach(el => {
-          const src = el.textContent.trim();
-          // Create a fresh .mermaid div each time
-          el.innerHTML = src;
-          el.classList.add('mermaid');
-          nodes.push(el);
-        });
+      const currentSlide = Reveal.getCurrentSlide();
+      if (!currentSlide) return;
+
+      const nodes = Array.from(currentSlide.querySelectorAll('.mermaid-src'));
+      nodes.forEach(el => {
+        if (!el.dataset.mermaidSource) {
+          el.dataset.mermaidSource = el.textContent.trim();
+        }
+
+        // Mermaid replaces the source with generated SVG. Restore the original
+        // source before each render so diagrams survive slide navigation.
+        el.textContent = el.dataset.mermaidSource;
+        el.removeAttribute('data-processed');
+        el.classList.add('mermaid');
       });
+
       if (nodes.length > 0) {
         await mermaid.run({ nodes });
       }


### PR DESCRIPTION
Closes #940

## Summary
- Preserve each Mermaid block's original source before Mermaid replaces it with generated SVG.
- Render Mermaid diagrams only for `Reveal.getCurrentSlide()` so nested stacks do not rerender hidden sibling diagrams.
- Reset Mermaid's processed marker before rerendering the current slide so diagrams survive up/down navigation.

## Validation
- `git diff --check`
- Local agent-browser on the deck: navigate to `#/4/3`, then ArrowUp and ArrowDown; current slide remains `Pipeline` with `currentSvg: 1` after returning.
- No agent-browser page errors during local navigation validation.
