### PR TITLE
FROM feat/resiliency-idempotency TO development

### DIFF
--- a/backend/src/services/idempotency.py
+++ b/backend/src/services/idempotency.py
@@ -1,0 +1,65 @@
+"""Idempotency service for distributed worker deduplication.
+
+Provides a Redis-backed claim-at-entry guard so that duplicate dispatches
+of the same run_id are detected and short-circuited before any heavyweight
+work (LLM calls, DB writes, stream setup) begins.
+
+Key design:
+- Key pattern: ``run:dedup:{run_id}``
+- Atomic SET ... NX EX: returns True (claimed) on first caller, False on
+  every subsequent caller — no race window between GET and SET.
+- TTL matches the stream TTL so keys are garbage-collected automatically.
+
+Usage::
+
+    claimed = await claim_run(run_id, redis_client=redis_client)
+    if not claimed:
+        return {"status": "duplicate", "stream_key": stream_key}
+    # proceed with execution ...
+"""
+
+import redis.asyncio as redis
+
+from src.utils.logger import logger
+
+# Prefix mirrors the abort:signal: pattern in abort.py
+DEDUP_KEY_PREFIX = "run:dedup:"
+
+# TTL for dedup keys — long enough to cover any plausible queue redelivery
+# window; matches STREAM_KEY_TTL_SECONDS (24 h) imported from utils.stream.
+DEDUP_TTL_SECONDS = 86400  # 24 hours
+
+
+async def claim_run(
+    run_id: str,
+    *,
+    redis_client: redis.Redis,
+    ttl: int = DEDUP_TTL_SECONDS,
+) -> bool:
+    """Atomically claim a run_id idempotency slot in Redis.
+
+    Uses ``SET key value NX EX ttl`` so the claim is atomic — no race
+    window between checking and writing.
+
+    Args:
+        run_id: The unique run identifier to claim.
+        redis_client: An already-open async Redis client (caller owns lifecycle).
+        ttl: Key TTL in seconds; defaults to DEDUP_TTL_SECONDS (24 h).
+
+    Returns:
+        True  — key was not present; this caller now owns the run.
+        False — key already existed; this is a duplicate dispatch.
+    """
+    key = f"{DEDUP_KEY_PREFIX}{run_id}"
+    result = await redis_client.set(key, "1", nx=True, ex=ttl)
+    claimed = result is not None  # SET NX returns None when key already exists
+    if not claimed:
+        logger.info(
+            "run_duplicate_detected",
+            extra={
+                "event": "run_duplicate_detected",
+                "run_id": run_id,
+                "dedup_key": key,
+            },
+        )
+    return claimed

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -21,6 +21,7 @@ from src.contexts.service import ServiceContext
 from src.schemas.entities import LLMRequest
 from src.workers.broker import broker
 from src.constants.redis import REDIS_URL
+from src.services.idempotency import claim_run
 from src.utils.stream import get_distributed_stream_key, STREAM_KEY_TTL_SECONDS
 
 
@@ -141,6 +142,23 @@ async def run_agent_stream(
     service_context = None
 
     try:
+        # Idempotency guard: claim this run_id atomically before any work.
+        # A duplicate dispatch (at-least-once redelivery, double-click, etc.)
+        # will find the key already set and short-circuit here.
+        if not await claim_run(run_id, redis_client=redis_client):
+            from src.utils.logger import logger
+
+            logger.info(
+                "run_agent_stream_duplicate_skipped",
+                extra={
+                    "event": "run_agent_stream_duplicate_skipped",
+                    "run_id": run_id,
+                    "thread_id": thread_id,
+                    "user_id": user_id,
+                },
+            )
+            return {"status": "duplicate", "stream_key": stream_key}
+
         # Write initializing event immediately so clients waiting for the stream
         # see activity before the heavy init work (model loading, DB connections, etc.)
         await redis_client.xadd(stream_key, {"data": ujson.dumps(("initializing", {"run_id": run_id}))})

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -9,6 +9,6 @@ in [`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
 | resiliency-correlation-id | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — correlation-id plan (backend/tests/resiliency/test_correlation_id.py) |
 | resiliency-dlq | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — DLQ replay plan (backend/tests/resiliency/test_dlq_replay.py) |
 | resiliency-heartbeat-drain | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — heartbeat-drain plan (backend/tests/resiliency/test_heartbeat_drain.py) |
-| resiliency-idempotency | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py) |
+| resiliency-idempotency | resiliency | 2026-06-14 03:33 | PASS | resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/frontend/e2e/idempotency.spec.ts
+++ b/frontend/e2e/idempotency.spec.ts
@@ -2,64 +2,97 @@
  * Resiliency spec: Double-submit idempotency
  *
  * Sending a message twice in rapid succession (two clicks / two Enter presses
- * before the first response arrives) must produce exactly ONE assistant reply
- * bubble — not two.  Today, the frontend does not guard against this and a
- * second identical run is kicked off, so the test is annotated test.fail().
+ * before the first response arrives) must produce exactly ONE assistant run —
+ * not two.  A short-window content dedup guard in useMessageQueue rejects the
+ * duplicate submit so only a single run is kicked off.
  *
- * FLIP: remove test.fail() once the double-submit guard lands.
+ * Oracle: each accepted submit renders exactly one user message bubble
+ * (`div.rounded-br-sm`).  Counting user bubbles measures the number of runs
+ * directly and is independent of whether/how the assistant reply renders (a
+ * single assistant turn emits several `rounded-bl-sm` part elements, so the
+ * assistant-bubble count cannot distinguish one run from two).  After a
+ * deduped double-submit there must be exactly ONE user bubble.
+ *
+ * The chat list is virtualized (ChatMessages.tsx useVirtualizer): a long
+ * streaming reply scrolls row 0 (the user bubble) out of the virtual window
+ * and unmounts it, so the count must be taken with the list scrolled to the
+ * top.  `countUserBubbles` scrolls to top, lets the virtualizer re-mount, then
+ * counts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { loginAsAdmin } from "./helpers/auth";
 
 // Selector constants derived from verified live selectors in the briefing
 const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
 const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
-// Assistant response bubble class confirmed in ChatMessages.tsx line ~194-204
-const ASSISTANT_BUBBLE = "div.rounded-bl-sm";
+// User (human) message bubble class — one per accepted submit (ChatMessages.tsx:100)
+const USER_BUBBLE = "div.rounded-br-sm";
+
+/**
+ * Scroll the virtualized chat list to the top so row 0 (the user bubble) is
+ * mounted, then return the number of user bubbles. Without scrolling to top a
+ * long streaming reply can unmount row 0 and yield a false 0 count.
+ */
+async function countUserBubbles(page: Page): Promise<number> {
+  await page.evaluate(() => {
+    const scroller = document.querySelector("div.overflow-auto");
+    if (scroller) scroller.scrollTop = 0;
+  });
+  // Give the virtualizer a frame to re-mount the top rows
+  await page.waitForTimeout(300);
+  return page.locator(USER_BUBBLE).count();
+}
 
 test.describe("Double-submit idempotency", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
-    // Navigate to chat; adjust if the default route is different
-    await page.goto("/", { waitUntil: "networkidle" });
+    // Navigate straight to /chat (the authed default route) to avoid the
+    // "/" -> "/chat" redirect race that can delay the input mount.  Use
+    // domcontentloaded (not networkidle) — the chat page holds a long-lived
+    // streaming connection, so the network never goes idle and networkidle
+    // would abort the navigation.
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+    await page.locator(CHAT_INPUT).waitFor({ state: "visible", timeout: 30_000 });
   });
 
-  // FLIP: remove test.fail() once the double-submit guard lands.
-  test.fail(
-    true,
-    "Double-submit currently produces two assistant bubbles; expected one (guard not yet implemented)",
-  );
-
-  test("typing a message and submitting twice produces exactly one assistant bubble", async ({
+  test("typing a message and submitting twice produces exactly one user bubble", async ({
     page,
   }) => {
     // Type a short deterministic message
     const input = page.locator(CHAT_INPUT);
     await input.fill("ping idempotency test");
 
-    // Submit twice as fast as possible
+    // Submit twice as fast as possible (force-click to bypass actionability
+    // waits and devtools overlay so the two clicks land in rapid succession).
     const submitBtn = page.locator(SUBMIT_BUTTON);
-    await submitBtn.click();
-    // Second click immediately — no await between them
-    await submitBtn.click();
+    await submitBtn.click({ force: true });
+    // Second click immediately — no await between dispatch and re-fire
+    await submitBtn.click({ force: true });
 
-    // Wait for at least one assistant bubble to appear (the backend will reply)
-    await expect(page.locator(ASSISTANT_BUBBLE).first()).toBeVisible({
+    // Wait for the first user bubble to render
+    await expect(page.locator(USER_BUBBLE).first()).toBeVisible({
       timeout: 30_000,
     });
 
-    // Allow up to 5 s for a second bubble to materialise (it shouldn't)
+    // Allow up to 5 s for a second run to materialise (it shouldn't)
     await page.waitForTimeout(5_000);
 
-    // RESILIENT OUTCOME: exactly one assistant bubble
-    const bubbles = page.locator(ASSISTANT_BUBBLE);
-    await expect(bubbles).toHaveCount(1);
+    // RESILIENT OUTCOME: exactly one user bubble (one accepted run)
+    expect(await countUserBubbles(page)).toBe(1);
   });
 
-  test("pressing Enter twice rapidly produces exactly one assistant bubble", async ({
+  test("pressing Enter twice rapidly produces exactly one user bubble", async ({
     page,
-  }) => {
+  }, testInfo) => {
+    // Enter-to-submit is intentionally disabled on mobile (ChatInput.tsx:157
+    // gates handleEnqueue on `!isLikelyMobile()`), so the double-Enter path
+    // does not exist on touch devices — there is nothing to dedup there.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Enter-to-submit is disabled on mobile by design (ChatInput.tsx:157)",
+    );
+
     const input = page.locator(CHAT_INPUT);
     await input.fill("ping idempotency enter");
 
@@ -67,13 +100,12 @@ test.describe("Double-submit idempotency", () => {
     await input.press("Enter");
     await input.press("Enter");
 
-    await expect(page.locator(ASSISTANT_BUBBLE).first()).toBeVisible({
+    await expect(page.locator(USER_BUBBLE).first()).toBeVisible({
       timeout: 30_000,
     });
 
     await page.waitForTimeout(5_000);
 
-    const bubbles = page.locator(ASSISTANT_BUBBLE);
-    await expect(bubbles).toHaveCount(1);
+    expect(await countUserBubbles(page)).toBe(1);
   });
 });

--- a/frontend/src/hooks/useMessageQueue.ts
+++ b/frontend/src/hooks/useMessageQueue.ts
@@ -13,6 +13,12 @@ const MAX_RETRIES = 3;
 const MAX_QUEUE_SIZE = 10;
 
 /**
+ * Time window (ms) within which an identical, non-empty enqueue is treated as
+ * an accidental double-submit (double-click / double-Enter) and rejected.
+ */
+const DEDUP_WINDOW_MS = 1500;
+
+/**
  * Custom hook for managing a frontend message queue.
  *
  * Allows users to submit multiple messages while a stream is in progress.
@@ -62,6 +68,10 @@ export function useMessageQueue(
 
 	// Guard to prevent concurrent processNext calls
 	const processingRef = useRef(false);
+
+	// Tracks the last accepted enqueue so an identical-content message arriving
+	// within DEDUP_WINDOW_MS (a double-click / double-Enter) can be rejected.
+	const lastEnqueueRef = useRef<{ query: string; at: number } | null>(null);
 
 	// Ref to track editingId for use in processNext callback
 	const editingIdRef = useRef<string | null>(null);
@@ -167,6 +177,25 @@ export function useMessageQueue(
 	 */
 	const enqueue = useCallback(
 		(query: string, images: File[] = []): boolean => {
+			// Content dedup: reject an identical, non-empty message submitted
+			// within DEDUP_WINDOW_MS (accidental double-click / double-Enter)
+			// without appending or dispatching. Empty queries are already a
+			// no-op downstream, so only the identical-non-empty case is blocked.
+			const trimmedQuery = query.trim();
+			const last = lastEnqueueRef.current;
+			if (
+				trimmedQuery.length > 0 &&
+				last !== null &&
+				last.query === trimmedQuery &&
+				Date.now() - last.at < DEDUP_WINDOW_MS
+			) {
+				console.debug(
+					"[MessageQueue] Dropped duplicate submit within dedup window:",
+					trimmedQuery.slice(0, 50),
+				);
+				return false;
+			}
+
 			// Enforce MAX_QUEUE_SIZE: drop oldest messages to make room
 			if (queueRef.current.length >= MAX_QUEUE_SIZE) {
 				const droppedCount = queueRef.current.length - MAX_QUEUE_SIZE + 1;
@@ -192,6 +221,13 @@ export function useMessageQueue(
 
 			queueRef.current = [...queueRef.current, newMessage];
 			syncQueueState();
+
+			// Record this accepted enqueue for short-window dedup. Empty
+			// queries are not tracked so a real message after a blank send is
+			// never mistaken for a duplicate.
+			if (trimmedQuery.length > 0) {
+				lastEnqueueRef.current = { query: trimmedQuery, at: Date.now() };
+			}
 
 			// If not streaming, process immediately
 			if (!isStreaming && !processingRef.current) {

--- a/frontend/src/tests/hooks/useMessageQueue.test.ts
+++ b/frontend/src/tests/hooks/useMessageQueue.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useMessageQueue } from "@/hooks/useMessageQueue";
+
+/**
+ * Unit coverage for the short-window content dedup guard in `enqueue`.
+ *
+ * A rapid double-submit of identical, non-empty content (double-click /
+ * double-Enter) must dispatch exactly ONE assistant run, not two. The guard
+ * rejects the duplicate enqueue within DEDUP_WINDOW_MS without appending or
+ * dispatching, while leaving distinct messages and deliberate out-of-window
+ * repeats untouched.
+ */
+describe("useMessageQueue dedup guard", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("dispatches an identical rapid double-submit exactly once", async () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: false, executeSubmit }),
+		);
+
+		let firstAccepted = false;
+		let secondAccepted = true;
+		await act(async () => {
+			firstAccepted = result.current.enqueue("ping idempotency test");
+			// Second identical submit immediately afterwards (no clock advance)
+			secondAccepted = result.current.enqueue("ping idempotency test");
+		});
+
+		expect(firstAccepted).toBe(true);
+		expect(secondAccepted).toBe(false);
+		// Only the first message is dispatched
+		expect(executeSubmit).toHaveBeenCalledTimes(1);
+		expect(executeSubmit).toHaveBeenCalledWith("ping idempotency test", []);
+	});
+
+	it("does not dedup distinct messages", async () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: false, executeSubmit }),
+		);
+
+		let a = false;
+		let b = false;
+		await act(async () => {
+			a = result.current.enqueue("first message");
+			b = result.current.enqueue("second message");
+		});
+
+		expect(a).toBe(true);
+		expect(b).toBe(true);
+		expect(executeSubmit).toHaveBeenCalledWith("first message", []);
+	});
+
+	it("allows a deliberate identical repeat after the dedup window elapses", async () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: false, executeSubmit }),
+		);
+
+		let first = false;
+		await act(async () => {
+			first = result.current.enqueue("repeat me");
+		});
+		expect(first).toBe(true);
+
+		// Advance past DEDUP_WINDOW_MS (1500ms) — a later identical send is legit
+		act(() => {
+			vi.advanceTimersByTime(1600);
+		});
+
+		let second = false;
+		await act(async () => {
+			second = result.current.enqueue("repeat me");
+		});
+		expect(second).toBe(true);
+	});
+
+	it("dedups identical content ignoring surrounding whitespace", async () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: false, executeSubmit }),
+		);
+
+		let first = false;
+		let second = true;
+		await act(async () => {
+			first = result.current.enqueue("trimmed");
+			second = result.current.enqueue("  trimmed  ");
+		});
+
+		expect(first).toBe(true);
+		expect(second).toBe(false);
+	});
+
+	it("queues an identical rapid double-submit only once while streaming", () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: true, executeSubmit }),
+		);
+
+		act(() => {
+			result.current.enqueue("queued ping");
+			result.current.enqueue("queued ping");
+		});
+
+		// While streaming, the message is queued (not dispatched) — exactly one
+		// entry should be present, proving the duplicate was rejected.
+		expect(result.current.queueLength).toBe(1);
+		expect(executeSubmit).not.toHaveBeenCalled();
+	});
+
+	it("does not dedup empty (whitespace-only) submissions", () => {
+		const executeSubmit = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useMessageQueue({ isStreaming: true, executeSubmit }),
+		);
+
+		let a = false;
+		let b = false;
+		act(() => {
+			a = result.current.enqueue("   ");
+			b = result.current.enqueue("   ");
+		});
+
+		// Empty queries are accepted (a no-op downstream) and never tracked, so
+		// they must not poison the dedup state for a following real message.
+		expect(a).toBe(true);
+		expect(b).toBe(true);
+	});
+});


### PR DESCRIPTION
## Resiliency Track 1 — Idempotency & dedup

Part of the resiliency fitness-function effort (stacked on #933, the eval-harness RED baseline). Makes long-horizon distributed agent runs **idempotent** against the two ways a single user intent can fan out into duplicate runs.

### The gap (RED on `development`)
- **Backend**: a TaskIQ at-least-once *redelivery* of the same `run_id` re-executes the whole agent stream — duplicate LLM calls, duplicate stream writes.
- **Frontend**: a rapid double-click / double-Enter enqueues the identical message twice; the FIFO queue dispatches the second run after the first completes → **two assistant runs** for one intent.

### The fix (GREEN)
- **`backend/src/services/idempotency.py`** — `claim_run()` does an atomic Redis `SET NX EX` on `run:dedup:{run_id}` (mirrors the `abort.py` key convention). TTL 24h.
- **`backend/src/workers/tasks.py`** — `run_agent_stream()` claims at entry; a duplicate `run_id` short-circuits with `{status: "duplicate"}` before any work.
- **`frontend/src/hooks/useMessageQueue.ts`** — `enqueue()` gains a 1.5s content-window guard: an identical message re-submitted in rapid succession is rejected (no append, no dispatch), so a double-submit yields exactly one run.

### Determination — RED→GREEN, verifiable
| Probe | Before (`development`) | After (this PR) |
|---|---|---|
| `backend/tests/resiliency/test_idempotency.py` | FAIL | **2 passed** |
| `evals/run.sh --probe resiliency-idempotency` | REGRESSION | **PASS** (`REGRESSION->PASS`) |
| `frontend/e2e/idempotency.spec.ts` (Playwright) | `test.fail()` (RED) | **PASS** desktop 1920×1080 + mobile 414×896 |

UI determination driven front-to-back against the running stack at both viewports. Mobile double-Enter is skipped by design (Enter-to-submit is gated off on touch at `ChatInput.tsx:157`). 6 new unit tests cover the dedup window; full vitest suite **223 passed**.

### Notes
- Backend dedup and frontend dedup are complementary, not redundant: the backend covers broker *redelivery* (same `run_id`); the frontend covers *user* double-submit (distinct `run_id`s, since `llm.py:101` mints a fresh `uuid4()` per request).
- Stacked on #933. Keep draft until orchestra CI (backend + Playwright e2e) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
