### PR TITLE
FROM feat/resiliency-dlq TO development

### DIFF
--- a/backend/src/routes/v0/llm.py
+++ b/backend/src/routes/v0/llm.py
@@ -160,6 +160,33 @@ async def llm_stream(
 
 
 ################################################################################
+### Replay Dead-Lettered Run
+################################################################################
+@llm_router.post(
+    "/dlq/{run_id}/replay",
+    name="Replay DLQ Run",
+    operation_id="ruska_replay_dlq_run",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(get_optional_user_from_token)],
+)
+async def replay_dlq_run(
+    run_id: str,
+    user: ProtectedUser = Depends(get_optional_user_from_token),
+) -> JSONResponse:
+    """Replay a permanently-failed (dead-lettered) agent run.
+
+    Reads the stored DLQ payload for ``run_id`` and re-enqueues it under a fresh
+    run_id so the idempotency guard does not short-circuit the replay. Returns
+    202 with ``{"status": "replayed", "new_run_id": ...}`` on success, or
+    ``{"status": "not_found"}`` when no DLQ entry exists for the run.
+    """
+    from src.workers import dlq
+
+    result = await dlq.replay(run_id)
+    return JSONResponse(content=result, status_code=status.HTTP_202_ACCEPTED)
+
+
+################################################################################
 ### Transcribe
 ################################################################################
 @llm_router.post("/transcribe")

--- a/backend/src/services/errors.py
+++ b/backend/src/services/errors.py
@@ -147,6 +147,14 @@ def classify_checkpoint_error(error: Exception) -> Type[CheckpointError]:
         >>> classify_checkpoint_error(psycopg.OperationalError("authentication failed"))
         <class 'PermanentCheckpointError'>
     """
+    # Honor already-classified errors: a RetryableCheckpointError /
+    # PermanentCheckpointError carries its verdict in its type. Re-deriving it
+    # from the (sanitized) message would misclassify it as retryable by default.
+    if isinstance(error, RetryableCheckpointError):
+        return RetryableCheckpointError
+    if isinstance(error, PermanentCheckpointError):
+        return PermanentCheckpointError
+
     # Handle psycopg OperationalError (most connection errors)
     if isinstance(error, psycopg.OperationalError):
         error_msg = str(error).lower()

--- a/backend/src/workers/dlq.py
+++ b/backend/src/workers/dlq.py
@@ -1,0 +1,149 @@
+"""Dead-letter queue (DLQ) for permanently-failed agent runs.
+
+When ``run_agent_stream`` hits a PERMANENT (non-retryable) failure, the failed
+job payload is persisted to a Redis-backed dead-letter store so the run is not
+silently lost. A permanent failure is therefore *recorded* (DLQ entry),
+*surfaced* (SSE error event emitted by the task), and *replayable* (via
+``replay``) instead of vanishing.
+
+Key design:
+- Key pattern: ``dlq:{run_id}`` — one entry per dead-lettered run.
+- Value: a ujson payload carrying everything needed to re-enqueue the job.
+- TTL: 7 days, long enough for a human/operator to notice and replay.
+
+Retryable errors do NOT land here — those are left to the TaskIQ broker's
+retry mechanism. Only permanent failures are dead-lettered.
+
+Replay mints a FRESH run_id so the idempotency guard (``run:dedup:{run_id}``)
+does not short-circuit the replayed dispatch as a duplicate of the dead run.
+"""
+
+from uuid import uuid4
+
+import redis.asyncio as redis
+import ujson
+
+from src.constants.redis import REDIS_URL
+from src.utils.logger import logger
+
+# Key prefix mirrors the run:dedup: / abort:signal: patterns elsewhere.
+DLQ_KEY_PREFIX = "dlq:"
+
+# TTL for DLQ entries — 7 days. Long enough for an operator to notice a
+# permanently-failed run and replay it before the record is garbage-collected.
+DLQ_TTL_SECONDS = 7 * 24 * 60 * 60  # 604800
+
+
+async def write_dlq(
+    redis_client: redis.Redis,
+    run_id: str,
+    *,
+    task_dict: dict,
+    user_id: str,
+    thread_id: str,
+    error: Exception,
+) -> None:
+    """Persist a permanently-failed run to the dead-letter store.
+
+    Writes ``dlq:{run_id}`` with the full re-enqueue payload and a 7-day TTL.
+
+    Args:
+        redis_client: An already-open async Redis client (caller owns lifecycle).
+        run_id: The run identifier that failed permanently.
+        task_dict: Serialized LLMRequest dict — the payload needed to replay.
+        user_id: User ID associated with the failed run.
+        thread_id: Thread ID associated with the failed run.
+        error: The permanent exception that caused the dead-letter.
+    """
+    key = f"{DLQ_KEY_PREFIX}{run_id}"
+    payload = {
+        "run_id": run_id,
+        "task_dict": task_dict,
+        "user_id": user_id,
+        "thread_id": thread_id,
+        "error": str(error),
+        "error_type": type(error).__name__,
+    }
+    await redis_client.set(key, ujson.dumps(payload), ex=DLQ_TTL_SECONDS)
+    logger.error(
+        "dlq_entry_written",
+        extra={
+            "event": "dlq_entry_written",
+            "run_id": run_id,
+            "thread_id": thread_id,
+            "user_id": user_id,
+            "dlq_key": key,
+            "error": str(error),
+            "error_type": type(error).__name__,
+        },
+    )
+
+
+async def replay(run_id: str, *, redis_client: redis.Redis | None = None) -> dict:
+    """Replay a dead-lettered run by re-enqueuing its stored payload.
+
+    Reads ``dlq:{run_id}`` and, if present, re-dispatches ``run_agent_stream``
+    with a FRESH run_id so the idempotency guard does not treat the replay as a
+    duplicate of the original (dead) run. The original DLQ entry is removed on a
+    successful re-enqueue.
+
+    Args:
+        run_id: The dead-lettered run identifier to replay.
+        redis_client: Optional async Redis client; one is created (and closed)
+            internally when not provided.
+
+    Returns:
+        ``{"status": "not_found"}`` when no DLQ entry exists for ``run_id``, or
+        ``{"status": "replayed", "new_run_id": <id>}`` after re-enqueue.
+    """
+    # Lazy import to avoid a circular import (tasks.py imports nothing from dlq
+    # at module load; replay pulls in the task only when invoked).
+    from src.workers.tasks import run_agent_stream
+
+    owns_client = redis_client is None
+    if owns_client:
+        redis_client = redis.from_url(REDIS_URL)
+
+    try:
+        key = f"{DLQ_KEY_PREFIX}{run_id}"
+        raw = await redis_client.get(key)
+        if raw is None:
+            logger.info(
+                "dlq_replay_not_found",
+                extra={"event": "dlq_replay_not_found", "run_id": run_id, "dlq_key": key},
+            )
+            return {"status": "not_found"}
+
+        entry = ujson.loads(raw)
+        task_dict = entry["task_dict"]
+        user_id = entry.get("user_id", "")
+        thread_id = entry["thread_id"]
+
+        # Mint a fresh run_id so the idempotency guard (run:dedup:{run_id}) does
+        # NOT short-circuit the replay as a duplicate of the dead run.
+        new_run_id = str(uuid4())
+
+        await run_agent_stream.kiq(
+            task_dict,
+            user_id,
+            thread_id,
+            run_id=new_run_id,
+        )
+
+        # Drop the DLQ entry now that the job has been re-enqueued.
+        await redis_client.delete(key)
+
+        logger.info(
+            "dlq_replay_enqueued",
+            extra={
+                "event": "dlq_replay_enqueued",
+                "run_id": run_id,
+                "new_run_id": new_run_id,
+                "thread_id": thread_id,
+                "user_id": user_id,
+            },
+        )
+        return {"status": "replayed", "new_run_id": new_run_id}
+    finally:
+        if owns_client:
+            await redis_client.aclose()

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -24,6 +24,39 @@ from src.constants.redis import REDIS_URL
 from src.services.idempotency import claim_run
 from src.utils.stream import get_distributed_stream_key, STREAM_KEY_TTL_SECONDS
 
+# Sentinel embedded in a user message to deterministically force a permanent
+# failure, exercising the DLQ record+surface+replay path end-to-end without a
+# real provider/auth fault. Used by the resiliency DLQ probe and the frontend
+# replay e2e — never emitted by normal traffic.
+_DLQ_TRIGGER_SENTINEL = "__DLQ_TRIGGER__"
+
+
+def _extract_user_message_text(task_dict: dict) -> str:
+    """Concatenate the text of all user messages in a serialized LLMRequest dict.
+
+    Mirrors the ``input.messages[*].content`` shape (string or multimodal list)
+    without reconstructing the full ``LLMRequest`` model, so the DLQ fault
+    injection can run before any heavyweight init work.
+    """
+    try:
+        messages = (task_dict or {}).get("input", {}).get("messages", []) or []
+    except AttributeError:
+        return ""
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    parts.append(str(block.get("text", "")))
+                else:
+                    parts.append(str(block))
+    return " ".join(parts)
+
 
 class _RunScopedStore:
     """Thin proxy around a shared store that isolates mutable attributes per-run.
@@ -130,8 +163,13 @@ async def run_agent_stream(
     from src.contexts.service import ServiceContext
     from src.utils.logger import logger
     from src.constants import CHECKPOINT_USE_RESILIENT
-    from src.services.errors import CheckpointConnectionError
+    from src.services.errors import (
+        CheckpointConnectionError,
+        PermanentCheckpointError,
+        is_retryable_error,
+    )
     from src.services.abort import AbortService
+    from src.workers.dlq import write_dlq
 
     stream_key = get_distributed_stream_key(thread_id, run_id)
     redis_client = redis.from_url(REDIS_URL)
@@ -158,6 +196,13 @@ async def run_agent_stream(
                 },
             )
             return {"status": "duplicate", "stream_key": stream_key}
+
+        # Deterministic fault injection (e2e DLQ trigger): if the user message
+        # carries the sentinel, raise a PERMANENT error so the DLQ path below
+        # records + surfaces + makes the run replayable. Kept inside the try so
+        # the permanent-error handler dead-letters it like any real failure.
+        if _DLQ_TRIGGER_SENTINEL in _extract_user_message_text(task_dict):
+            raise PermanentCheckpointError("forced permanent failure (e2e DLQ trigger)")
 
         # Write initializing event immediately so clients waiting for the stream
         # see activity before the heavy init work (model loading, DB connections, etc.)
@@ -277,15 +322,71 @@ async def run_agent_stream(
                     error=f"Checkpoint error: {e}",
                 ),
             )
-        raise
+        # CheckpointConnectionError means retries are exhausted with no fallback.
+        # Classify it: a retryable underlying cause is re-raised for the broker;
+        # a permanent one is dead-lettered (recorded + replayable) instead.
+        if is_retryable_error(e):
+            raise
+        await write_dlq(
+            redis_client,
+            run_id,
+            task_dict=task_dict,
+            user_id=user_id,
+            thread_id=thread_id,
+            error=e,
+        )
+        return {"status": "error", "stream_key": stream_key, "dead_lettered": True}
 
     except Exception as e:
         logger.exception(f"Task failed for thread {thread_id}: {e}")
+        # Classify the failure. Retryable errors are re-raised so the TaskIQ
+        # broker retries them. Permanent errors are dead-lettered: recorded to
+        # the DLQ, surfaced to SSE clients, and made replayable — NOT re-raised
+        # (re-raising would trigger broker retries that defeat the DLQ).
+        retryable = is_retryable_error(e)
+        if retryable:
+            try:
+                await redis_client.xadd(stream_key, {"error": str(e), "done": "true"})
+                await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
+            except Exception as redis_err:
+                logger.error(f"Failed to send error to Redis for thread {thread_id}: {redis_err}")
+            if service_context and config:
+                await _update_thread_stream_state(
+                    service_context=service_context,
+                    thread_id=thread_id,
+                    config=config,
+                    files_map=files_map,
+                    todos_list=todos_list,
+                    metadata=_build_stream_metadata(
+                        run_id=run_id,
+                        status="error",
+                        started_at=None,
+                        finished_at=None,
+                        error=str(e),
+                    ),
+                )
+            raise
+
+        # Permanent failure → dead-letter it.
+        await write_dlq(
+            redis_client,
+            run_id,
+            task_dict=task_dict,
+            user_id=user_id,
+            thread_id=thread_id,
+            error=e,
+        )
         try:
-            await redis_client.xadd(stream_key, {"error": str(e), "done": "true"})
+            # Surface to SSE clients: recoverable=True signals the UI can offer a
+            # replay action for this dead-lettered run.
+            await redis_client.xadd(
+                stream_key,
+                {"data": ujson.dumps(("error", {"run_id": run_id, "error": str(e), "recoverable": True}))},
+            )
+            await redis_client.xadd(stream_key, {"done": "true"})
             await redis_client.expire(stream_key, STREAM_KEY_TTL_SECONDS)
         except Exception as redis_err:
-            logger.error(f"Failed to send error to Redis for thread {thread_id}: {redis_err}")
+            logger.error(f"Failed to send DLQ error to Redis for thread {thread_id}: {redis_err}")
         if service_context and config:
             await _update_thread_stream_state(
                 service_context=service_context,
@@ -301,7 +402,7 @@ async def run_agent_stream(
                     error=str(e),
                 ),
             )
-        raise
+        return {"status": "error", "stream_key": stream_key, "dead_lettered": True}
     finally:
         await redis_client.aclose()
 

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -7,8 +7,8 @@ in [`evals/README.md`](README.md). `SKIPPED` does not count toward pass-rate.
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
 | resiliency-correlation-id | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — correlation-id plan (backend/tests/resiliency/test_correlation_id.py) |
-| resiliency-dlq | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — DLQ replay plan (backend/tests/resiliency/test_dlq_replay.py) |
+| resiliency-dlq | resiliency | 2026-06-14 04:27 | PASS | resiliency track — DLQ replay plan (backend/tests/resiliency/test_dlq_replay.py) |
 | resiliency-heartbeat-drain | resiliency | 2026-06-13 23:49 | REGRESSION | resiliency track — heartbeat-drain plan (backend/tests/resiliency/test_heartbeat_drain.py) |
-| resiliency-idempotency | resiliency | 2026-06-14 03:33 | PASS | resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py) |
+| resiliency-idempotency | resiliency | 2026-06-14 04:27 | PASS | resiliency track — idempotency plan (backend/tests/resiliency/test_idempotency.py) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/frontend/e2e/dlq-replay.spec.ts
+++ b/frontend/e2e/dlq-replay.spec.ts
@@ -7,20 +7,22 @@
  *   2. Offer a replay / retry affordance (button, link, or actionable text) so
  *      the user can recover without refreshing.
  *
- * Today, failed runs may leave the UI in a loading/hanging state with no replay
- * option, so this test is annotated test.fail().
- *
- * FLIP: remove test.fail() once DLQ replay affordance lands.
+ * A permanently-failing run now surfaces a persistent error banner with an
+ * enabled Replay affordance (wired to the DLQ replay endpoint), so the UI
+ * settles instead of hanging.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, Page, Locator } from "@playwright/test";
 import { loginAsAdmin } from "./helpers/auth";
 
 const CHAT_INPUT = 'textarea[placeholder="How can I help you be more productive?"]';
 const SUBMIT_BUTTON = '[data-tour="chat-submit-button"]';
 
-// Selectors for expected error / replay UI (to be confirmed once feature lands)
+// Selectors for expected error / replay UI.
 // These are intentionally flexible — match any visible error region or retry CTA.
+// NOTE: these mix CSS and Playwright text engines (text=, :has-text), which
+// cannot be comma-joined into a single page.locator() CSS string. They are
+// OR-composed via Locator.or() below instead.
 const ERROR_STATE_SELECTORS = [
   "[data-testid='message-error']",
   "[data-testid='replay-button']",
@@ -31,17 +33,25 @@ const ERROR_STATE_SELECTORS = [
   "text=error",
 ];
 
+const REPLAY_AFFORDANCE_SELECTORS = [
+  "button:has-text('Retry')",
+  "button:has-text('Replay')",
+  "[data-testid='replay-button']",
+];
+
+// Compose a set of selectors (which may mix CSS and Playwright text engines)
+// into a single OR'd locator via Locator.or(), the supported cross-engine union.
+function anyOf(page: Page, selectors: string[]): Locator {
+  return selectors
+    .map((selector) => page.locator(selector))
+    .reduce((acc, locator) => acc.or(locator));
+}
+
 test.describe("DLQ replay affordance", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
     await page.goto("/", { waitUntil: "networkidle" });
   });
-
-  // FLIP: remove test.fail() once DLQ replay affordance lands.
-  test.fail(
-    true,
-    "Permanent failure currently leaves UI in a hanging/loading state with no replay affordance (not yet implemented)",
-  );
 
   test("a permanently-failing message surfaces an error state and a replay affordance", async ({
     page,
@@ -56,7 +66,7 @@ test.describe("DLQ replay affordance", () => {
     await page.locator(SUBMIT_BUTTON).click();
 
     // Wait up to 30 s for ANY error/replay signal to appear
-    const errorLocators = page.locator(ERROR_STATE_SELECTORS.join(", "));
+    const errorLocators = anyOf(page, ERROR_STATE_SELECTORS);
     await expect(errorLocators.first()).toBeVisible({ timeout: 30_000 });
 
     // Additional assertion: the loading spinner must NOT still be visible after
@@ -64,9 +74,7 @@ test.describe("DLQ replay affordance", () => {
     await expect(page.locator(".animate-spin")).toBeHidden({ timeout: 5_000 });
 
     // The replay affordance must be interactive
-    const replayAffordance = page.locator(
-      "button:has-text('Retry'), button:has-text('Replay'), [data-testid='replay-button']",
-    );
+    const replayAffordance = anyOf(page, REPLAY_AFFORDANCE_SELECTORS);
     await expect(replayAffordance.first()).toBeEnabled();
   });
 });

--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useCallback, memo, useState } from "react";
-import { Loader2, Edit, Check, X } from "lucide-react";
+import {
+	Loader2,
+	Edit,
+	Check,
+	X,
+	AlertTriangle,
+	RotateCcw,
+} from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { useAppContext } from "@/context/AppContext";
@@ -247,6 +254,69 @@ export const Message = memo(
 	},
 );
 
+type RunError = {
+	runId: string;
+	message: string;
+	recoverable: boolean;
+};
+
+// Persistent error surface for permanently-failed runs. Rendered inline in the
+// chat message area (not a toast) so it survives until the user replays or
+// submits a fresh request. Drives the DLQ replay affordance.
+function RunErrorBanner({
+	runError,
+	onReplay,
+}: {
+	runError: RunError;
+	onReplay: (runId: string) => void | Promise<void>;
+}) {
+	const [isReplaying, setIsReplaying] = useState(false);
+
+	const handleReplay = async () => {
+		if (isReplaying) return;
+		setIsReplaying(true);
+		try {
+			await onReplay(runError.runId);
+		} finally {
+			setIsReplaying(false);
+		}
+	};
+
+	return (
+		<div className="flex justify-start p-3 max-w-4xl mx-auto px-5 w-full">
+			<div
+				data-testid="message-error"
+				role="alert"
+				className="flex w-full max-w-[90vw] md:max-w-[80%] flex-col gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+			>
+				<div className="flex items-start gap-2">
+					<AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+					<div className="flex-1">
+						<p className="font-medium">The request failed.</p>
+						<p className="text-destructive/90 break-words">
+							{runError.message || "An unexpected error occurred."}
+						</p>
+					</div>
+				</div>
+				<div className="flex justify-end">
+					<button
+						type="button"
+						data-testid="replay-button"
+						onClick={handleReplay}
+						disabled={isReplaying}
+						className="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 disabled:opacity-60"
+					>
+						<RotateCcw
+							className={`h-3.5 w-3.5 ${isReplaying ? "animate-spin" : ""}`}
+						/>
+						{isReplaying ? "Replaying…" : "Replay"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 	const { loading, loadingMessage } = useAppContext();
 	const {
@@ -256,6 +326,8 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 		submitStartTime,
 		appendToQuery,
 		displayModel,
+		runError,
+		replayRun,
 	} = useChatContext();
 	const [elapsedTime, setElapsedTime] = useState<number | null>(null);
 	const scrollRef = useRef<HTMLDivElement>(null);
@@ -366,8 +438,14 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 
 	if (messages.length === 0) {
 		return (
-			<div className="flex justify-center items-center h-full">
-				<p className="text-muted-foreground">No messages yet</p>
+			<div className="flex flex-col justify-center items-center h-full">
+				{runError ? (
+					<div className="w-full">
+						<RunErrorBanner runError={runError} onReplay={replayRun} />
+					</div>
+				) : (
+					<p className="text-muted-foreground">No messages yet</p>
+				)}
 			</div>
 		);
 	}
@@ -433,6 +511,9 @@ const ChatMessages = memo(({ messages }: { messages: any[] }) => {
 							</span>
 						)}
 					</div>
+				)}
+				{runError && !loading && (
+					<RunErrorBanner runError={runError} onReplay={replayRun} />
 				)}
 			</div>
 		</div>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -27,6 +27,12 @@ import { useMountEffect } from "@/hooks/useMountEffect";
 
 type StreamMode = "messages" | "values" | "updates" | "debug" | "tasks";
 
+export type RunError = {
+	runId: string;
+	message: string;
+	recoverable: boolean;
+};
+
 let in_mem_messages: any[] = [];
 
 export type ChatContextType = {
@@ -90,6 +96,10 @@ export type ChatContextType = {
 		lastEventId?: string | null;
 		route?: string;
 	}) => Promise<void>;
+	// Persistent error surface for permanently-failed runs (DLQ replay)
+	runError: RunError | null;
+	setRunError: (error: RunError | null) => void;
+	replayRun: (runId: string) => Promise<void>;
 };
 
 export default function useChat(): ChatContextType {
@@ -120,6 +130,11 @@ export default function useChat(): ChatContextType {
 	});
 
 	const [controller, setController] = useState<AbortController | null>(null);
+
+	// Persistent error state for permanently-failed runs (DLQ replay affordance).
+	// Set by the distributed "error" stream event; cleared on a fresh submit or
+	// once a replay is issued.
+	const [runError, setRunError] = useState<RunError | null>(null);
 
 	const [streamingRate, setStreamingRate] = useState<{
 		count: number;
@@ -210,7 +225,11 @@ export default function useChat(): ChatContextType {
 			case "values":
 				return ["values", event.data];
 			case "error":
-				return ["error", event.data.error];
+				// Forward the full error payload ({ run_id, error, recoverable })
+				// so handleMessages can surface a persistent, replayable error
+				// state. recoveryMode errors are handled upstream in
+				// startManagedStream and never reach this converter.
+				return ["error", event.data];
 			case "aborted":
 				return ["aborted", event.data];
 			case "done":
@@ -559,6 +578,9 @@ export default function useChat(): ChatContextType {
 	const handleSubmit = async (argQuery?: string, images: File[] = []) => {
 		setLoadingMessage("Request submitted...");
 		setLoading(true);
+		// Clear any stale error surface from a previous failed run so it does
+		// not persist into the new run.
+		setRunError(null);
 		setTtft(null);
 		const now = Date.now();
 		submitStartTimeRef.current = now;
@@ -651,7 +673,24 @@ export default function useChat(): ChatContextType {
 		const streamMode = payload[0];
 
 		if (streamMode === "error") {
-			alert("Error on stream: " + payload[1]);
+			// Distributed permanent failure. payload[1] is the error object
+			// ({ run_id, error, recoverable }) forwarded by convertEventToLegacy.
+			// Surface a persistent, replayable error state instead of a transient
+			// alert() so the user can recover without refreshing.
+			const errorPayload = payload[1];
+			const isErrorObject =
+				typeof errorPayload === "object" && errorPayload !== null;
+			const runId = isErrorObject
+				? (errorPayload.run_id ?? metadata?.run_id ?? "")
+				: (metadata?.run_id ?? "");
+			const message = isErrorObject
+				? (errorPayload.error ?? "The request failed permanently.")
+				: String(errorPayload);
+			const recoverable = isErrorObject
+				? errorPayload.recoverable !== false
+				: true;
+
+			setRunError({ runId, message, recoverable });
 			setLoading(false);
 			setController(null);
 			return;
@@ -843,6 +882,50 @@ export default function useChat(): ChatContextType {
 		}
 	};
 
+	/**
+	 * Replays a permanently-failed run via the backend DLQ replay endpoint.
+	 * On success the failed run is re-enqueued under a new run_id; we clear the
+	 * error surface and attach to the new distributed stream so its output
+	 * renders live.
+	 */
+	const replayRun = async (runId: string) => {
+		if (!runId) {
+			toast.error("Cannot replay: missing run id.");
+			return;
+		}
+
+		const threadId = metadata?.thread_id;
+
+		try {
+			const response = await apiClient.post(`/llm/dlq/${runId}/replay`);
+			const data = response?.data ?? {};
+
+			if (data.status === "not_found") {
+				toast.error("Replay failed: run no longer available.");
+				return;
+			}
+
+			// Clear the error surface now that a replay has been accepted.
+			setRunError(null);
+			toast("Replaying…");
+
+			const newRunId = data.new_run_id;
+			if (threadId && newRunId) {
+				setLoading(true);
+				setLoadingMessage("Replaying request...");
+				await attachToDistributedStream({
+					threadId,
+					runId: newRunId,
+				});
+			}
+		} catch (error: any) {
+			console.error("Failed to replay run:", error);
+			toast.error(
+				error?.response?.data?.detail || "Failed to replay the request.",
+			);
+		}
+	};
+
 	// assistant_id is set at submission time in getMetadata() — no effect needed
 
 	// File CRUD operations (wrapped in useCallback for stable references)
@@ -969,5 +1052,8 @@ export default function useChat(): ChatContextType {
 		renameFile,
 		getFilesForSubmission,
 		attachToDistributedStream,
+		runError,
+		setRunError,
+		replayRun,
 	};
 }


### PR DESCRIPTION
## Resiliency Track 2 — Dead-letter queue + replay

Stacked on #942 (Track 1). Closes the "a permanent failure silently loses the run" gap for long-horizon distributed agent runs.

### The gap (RED on `development`)
A permanent (non-retryable) failure mid-run was re-raised by the worker and surfaced in the UI as a native `alert()` — no record of the failed job, no way to recover it. A long-running conversation that hit a permanent fault was simply lost.

### The fix (GREEN)
**Backend**
- `workers/dlq.py` — `write_dlq()` persists the failed job to Redis (`dlq:{run_id}`, 7-day TTL); `replay()` re-enqueues it under a **fresh** `run_id` so the idempotency guard (Track 1) doesn't short-circuit the replay.
- `workers/tasks.py` — `run_agent_stream()` classifies errors via `is_retryable_error`: **permanent** → `write_dlq` + emit a `recoverable` stream error event + return (no re-raise, so the broker won't retry a dead job); **retryable** → re-raise for broker retry. A `__DLQ_TRIGGER__` message sentinel forces a deterministic permanent failure for e2e.
- `services/errors.py` — `classify_checkpoint_error` now honors already-typed `Retryable`/`Permanent` errors instead of defaulting to retryable.
- `routes/v0/llm.py` — `POST /llm/dlq/{run_id}/replay` → `{status, new_run_id}`.

**Frontend**
- `useChat.ts` — the distributed `error` stream event now sets a persistent `runError` state (replacing the native `alert`) and clears the spinner; `replayRun()` POSTs the replay endpoint and attaches to the new run.
- `ChatMessages.tsx` — a `RunErrorBanner` (`role="alert"`, `data-testid="message-error"`) with an enabled **Replay** button (`data-testid="replay-button"`), rendered outside the virtualizer so it always shows.

### Determination — RED→GREEN, verifiable
| Probe | Before (`development`) | After (this PR) |
|---|---|---|
| `backend/tests/resiliency/test_dlq_replay.py` | FAIL | **3 passed** |
| `evals/run.sh --probe resiliency-dlq` | REGRESSION | **PASS** |
| `frontend/e2e/dlq-replay.spec.ts` (Playwright) | `test.fail()` (RED) | **PASS** desktop 1920×1080 + mobile 414×896 |

Backend pytest: idempotency stays 2 passed; full vitest suite 223 passed.

### Notes
- Builds directly on Track 1's idempotency guard — the replay path mints a fresh `run_id` precisely so dedup doesn't reject the replayed job.
- Stacked on #942. Keep draft until orchestra CI (backend + Playwright e2e) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
