### PR TITLE
feat: add Mermaid diagram zoom controls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.6.15
+
+### Changed
+  - feat/mermaid-zoom-support — add zoom in/out/reset controls to rendered Mermaid diagrams in markdown and Mermaid file previews.
+
 ## 2026.6.14
 
 ### Fixed

--- a/frontend/src/components/cards/MarkdownCard.test.tsx
+++ b/frontend/src/components/cards/MarkdownCard.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import mermaid from "mermaid";
+import MarkdownCard from "./MarkdownCard";
+
+vi.mock("mermaid", () => ({
+	default: {
+		initialize: vi.fn(),
+		render: vi.fn(),
+	},
+}));
+
+vi.mock("@/hooks/useTheme", () => ({
+	useTheme: () => ({ theme: "light" }),
+}));
+
+vi.mock("@/hooks/useImageHook", () => ({
+	default: () => ({
+		handleImageClick: vi.fn(),
+		handleImageClear: vi.fn(),
+		previewImage: null,
+		previewImageIndex: 0,
+	}),
+}));
+
+const mermaidMock = vi.mocked(mermaid);
+
+describe("MarkdownCard Mermaid diagrams", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mermaidMock.render.mockResolvedValue({
+			svg: '<svg role="img" aria-label="test diagram" viewBox="0 0 100 100"></svg>',
+			diagramType: "flowchart-v2",
+		} as Awaited<ReturnType<typeof mermaid.render>>);
+	});
+
+	it("renders zoom controls for Mermaid diagrams", async () => {
+		render(<MarkdownCard content={"```mermaid\nflowchart TD\nA-->B\n```"} />);
+
+		expect(await screen.findByTestId("mermaid-diagram")).toBeInTheDocument();
+		expect(screen.getByLabelText("Zoom Mermaid diagram out")).toBeEnabled();
+		expect(
+			screen.getByLabelText("Mermaid diagram zoom level"),
+		).toHaveTextContent("100%");
+		expect(screen.getByLabelText("Zoom Mermaid diagram in")).toBeEnabled();
+		expect(screen.getByLabelText("Reset Mermaid diagram zoom")).toBeDisabled();
+		expect(screen.getByLabelText("Copy Mermaid source")).toBeEnabled();
+	});
+
+	it("zooms Mermaid diagrams in, out, and back to default", async () => {
+		render(<MarkdownCard content={"```mermaid\nflowchart TD\nA-->B\n```"} />);
+
+		const diagram = await screen.findByTestId("mermaid-diagram");
+		const svg = diagram.querySelector("svg");
+		expect(svg).not.toBeNull();
+
+		await waitFor(() => expect(svg).toHaveStyle({ width: "100%" }));
+
+		fireEvent.click(screen.getByLabelText("Zoom Mermaid diagram in"));
+		expect(
+			screen.getByLabelText("Mermaid diagram zoom level"),
+		).toHaveTextContent("125%");
+		await waitFor(() => expect(svg).toHaveStyle({ width: "125%" }));
+
+		fireEvent.click(screen.getByLabelText("Zoom Mermaid diagram out"));
+		expect(
+			screen.getByLabelText("Mermaid diagram zoom level"),
+		).toHaveTextContent("100%");
+		await waitFor(() => expect(svg).toHaveStyle({ width: "100%" }));
+
+		fireEvent.click(screen.getByLabelText("Zoom Mermaid diagram in"));
+		fireEvent.click(screen.getByLabelText("Reset Mermaid diagram zoom"));
+		expect(
+			screen.getByLabelText("Mermaid diagram zoom level"),
+		).toHaveTextContent("100%");
+		await waitFor(() => expect(svg).toHaveStyle({ width: "100%" }));
+	});
+});

--- a/frontend/src/components/cards/MarkdownCard.tsx
+++ b/frontend/src/components/cards/MarkdownCard.tsx
@@ -1,6 +1,14 @@
 import { useState, useRef, useEffect } from "react";
 import { Button } from "../ui/button";
-import { Check, Copy, ChevronDown, ChevronUp } from "lucide-react";
+import {
+	Check,
+	Copy,
+	ChevronDown,
+	ChevronUp,
+	RotateCcw,
+	ZoomIn,
+	ZoomOut,
+} from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
 	oneDark,
@@ -23,6 +31,13 @@ interface CodeBlockProps {
 	children: React.ReactNode;
 }
 
+const MERMAID_ZOOM_MIN = 0.5;
+const MERMAID_ZOOM_MAX = 2;
+const MERMAID_ZOOM_STEP = 0.25;
+
+const clampMermaidZoom = (zoom: number) =>
+	Math.min(MERMAID_ZOOM_MAX, Math.max(MERMAID_ZOOM_MIN, zoom));
+
 const CodeBlock: React.FC<CodeBlockProps> = ({
 	inline,
 	className,
@@ -32,6 +47,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 	const [copied, setCopied] = useState(false);
 	const [mermaidSvg, setMermaidSvg] = useState<string>("");
 	const [mermaidError, setMermaidError] = useState<string>("");
+	const [mermaidZoom, setMermaidZoom] = useState(1);
 	const mermaidRef = useRef<HTMLDivElement>(null);
 	const { theme } = useTheme();
 	const match = /language-(\w+)/.exec(className || "");
@@ -57,6 +73,10 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 		}
 	};
 
+	const zoomMermaid = (delta: number) => {
+		setMermaidZoom((currentZoom) => clampMermaidZoom(currentZoom + delta));
+	};
+
 	// Initialize mermaid with theme
 	useEffect(() => {
 		const mermaidTheme = theme === "light" ? "default" : "dark";
@@ -72,7 +92,9 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 		if (language === "mermaid" && code) {
 			const renderDiagram = async () => {
 				try {
+					setMermaidSvg("");
 					setMermaidError("");
+					setMermaidZoom(1);
 					const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
 					const { svg } = await mermaid.render(id, code);
 					setMermaidSvg(svg);
@@ -86,6 +108,16 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 			renderDiagram();
 		}
 	}, [language, code, theme]);
+
+	useEffect(() => {
+		const svg = mermaidRef.current?.querySelector("svg");
+		if (!svg) return;
+
+		svg.style.width = `${mermaidZoom * 100}%`;
+		svg.style.maxWidth = "none";
+		svg.style.height = "auto";
+		svg.style.flexShrink = "0";
+	}, [mermaidSvg, mermaidZoom]);
 
 	// Check if this is inline code (no newlines) or a code block (has newlines)
 	const isInlineCode = inline || !code.includes("\n");
@@ -121,22 +153,64 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 	if (language === "mermaid") {
 		return (
 			<div className="relative group my-2">
-				<div className="flex items-center justify-between bg-muted/50 px-3 py-1.5 rounded-t-lg border-b border-border">
+				<div className="flex items-center justify-between gap-2 bg-muted/50 px-3 py-1.5 rounded-t-lg border-b border-border">
 					<span className="text-xs text-muted-foreground font-medium">
 						mermaid diagram
 					</span>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={handleCopy}
-						className="h-6 w-6 p-0 hover:bg-muted"
-					>
-						{copied ? (
-							<Check className="h-3 w-3 text-green-500" />
-						) : (
-							<Copy className="h-3 w-3" />
-						)}
-					</Button>
+					<div className="flex items-center gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => zoomMermaid(-MERMAID_ZOOM_STEP)}
+							disabled={!mermaidSvg || mermaidZoom <= MERMAID_ZOOM_MIN}
+							aria-label="Zoom Mermaid diagram out"
+							title="Zoom out"
+							className="h-6 w-6 p-0 hover:bg-muted disabled:opacity-40"
+						>
+							<ZoomOut className="h-3 w-3" />
+						</Button>
+						<span
+							className="min-w-10 text-center text-[10px] tabular-nums text-muted-foreground"
+							aria-label="Mermaid diagram zoom level"
+						>
+							{Math.round(mermaidZoom * 100)}%
+						</span>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => zoomMermaid(MERMAID_ZOOM_STEP)}
+							disabled={!mermaidSvg || mermaidZoom >= MERMAID_ZOOM_MAX}
+							aria-label="Zoom Mermaid diagram in"
+							title="Zoom in"
+							className="h-6 w-6 p-0 hover:bg-muted disabled:opacity-40"
+						>
+							<ZoomIn className="h-3 w-3" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setMermaidZoom(1)}
+							disabled={!mermaidSvg || mermaidZoom === 1}
+							aria-label="Reset Mermaid diagram zoom"
+							title="Reset zoom"
+							className="h-6 w-6 p-0 hover:bg-muted disabled:opacity-40"
+						>
+							<RotateCcw className="h-3 w-3" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={handleCopy}
+							aria-label="Copy Mermaid source"
+							className="h-6 w-6 p-0 hover:bg-muted"
+						>
+							{copied ? (
+								<Check className="h-3 w-3 text-green-500" />
+							) : (
+								<Copy className="h-3 w-3" />
+							)}
+						</Button>
+					</div>
 				</div>
 				{mermaidError ? (
 					<div className="bg-red-500/10 border border-red-500/20 rounded-b-lg p-4">
@@ -150,7 +224,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 				) : mermaidSvg ? (
 					<div
 						ref={mermaidRef}
-						className="bg-muted/50 rounded-b-lg p-4 flex justify-center items-center overflow-x-auto"
+						className="bg-muted/50 rounded-b-lg p-4 flex justify-center items-start overflow-auto"
+						data-testid="mermaid-diagram"
 						dangerouslySetInnerHTML={{ __html: mermaidSvg }}
 					/>
 				) : (


### PR DESCRIPTION
## Summary
- add Mermaid diagram zoom controls (zoom out, zoom in, reset) to the frontend markdown renderer
- apply zoom directly to rendered SVGs while preserving scroll overflow
- keep the existing copy-source action and add regression coverage

## Verification
- `cd frontend && npm test -- MarkdownCard.test.tsx`
- `cd frontend && npx eslint src/components/cards/MarkdownCard.tsx src/components/cards/MarkdownCard.test.tsx`
- `cd frontend && npm run build`
- `cd frontend && npm test`
- Browser smoke: Vite page rendered one Mermaid SVG; zoom-in changed label `100% -> 125%` and SVG width `830px -> 1037.5px`; reset returned to `100%` / `830px`.

Closes #946


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams now feature interactive zoom controls for improved readability and user experience. Users can zoom in and out with dedicated buttons, reset to default zoom levels, and view the current zoom percentage in real-time. These controls are available when viewing Mermaid diagrams in markdown content and Mermaid file previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->