### PR TITLE
task: move env location to ~/.config/orchestra/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
             always_run: false
           - id: backend-test
             name: Backend Test
-            entry: bash -c 'cd backend && make test ENV_FILE=~/.env/orchestra/.env.backend.test'
+            entry: bash -c 'cd backend && make test ENV_FILE=~/.config/orchestra/.env.test'
             language: system
             files: ^backend/
             pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ backend:
     description: This is the REST API for the ./frontend and ./cli clients.
     deployment: https://chat.ruska.ai/docs
     commands:
-        - `make test` Run ALL test cases (uses ENV_FILE=~/.env/orchestra/.env.backend).
-        - `make test ENV_FILE=~/.env/orchestra/.env.backend.test` Run tests with test env.
+        - `make test` Run ALL test cases (uses ENV_FILE=~/.config/orchestra/.env).
+        - `make test ENV_FILE=~/.config/orchestra/.env.test` Run tests with test env.
         - `make format` Format project files with ruff. Use after making changes.
         - `make lint` Lint check with ruff (no auto-fix).
         - `make dev` Run dev server.
@@ -59,7 +59,7 @@ The main way external AI Agents find out information about RUSKA will be from th
 
 ## Build, Test, and Development Commands
 - **Setup**: Run `make setup` from the repo root to install pre-commit hooks.
-- Backend: `cd backend && uv venv && source .venv/bin/activate && uv sync` installs dependencies, `make dev` runs the API with reload, and `make test` executes the suite. Use `ENV_FILE=~/.env/orchestra/.env.backend.test` for the test environment.
+- Backend: `cd backend && uv venv && source .venv/bin/activate && uv sync` installs dependencies, `make dev` runs the API with reload, and `make test` executes the suite. Use `ENV_FILE=~/.config/orchestra/.env.test` for the test environment.
 - Frontend: `cd frontend && npm install`, `npm run dev` for local dev, `npm run build` for production bundles, and `npm run docs` regenerates MkDocs API docs.
 - Infrastructure: the full stack lives in `infra/docker-compose.yml`; `make dev.docker.up` builds and starts it, `make dev.docker.down` stops it.
 
@@ -81,7 +81,7 @@ The main way external AI Agents find out information about RUSKA will be from th
   - `make dev.docker.down` — stop and clean up
   - `make dev.docker.migrate` — run Alembic migrations inside the app container
   - `make dev.docker.test.up` — run the stack against the test database (adds `infra/docker-compose.test.yml`)
-- **Key details**: Source directories are volume-mounted for hot-reload. The app runs `uv sync` and `alembic upgrade head` on startup automatically. Backend env is loaded from `~/.env/orchestra/.env.backend` via the compose `env_file`.
+- **Key details**: Source directories are volume-mounted for hot-reload. The app runs `uv sync` and `alembic upgrade head` on startup automatically. Backend env is loaded from `~/.config/orchestra/.env` via the compose `env_file`.
 
 ## Coding Style & Naming Conventions
 - Run `pre-commit run --all-files`; hooks run backend format/lint/test and frontend prettier/lint/test.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.8.6
+
+### Changed
+  - task/950-config-env-path — move the environment file location from `~/.env/orchestra/` to `~/.config/orchestra/`. The primary backend env is now `~/.config/orchestra/.env` (was `.env.backend`); the test and frontend envs move to the same directory but keep distinct names (`.env.test`, `.env.frontend`) so `make test` and the pre-commit hook keep running against the test database rather than the development one. Updates `backend/Makefile`, `frontend/package.json`, `infra/docker-compose.yml`, `.pre-commit-config.yaml`, `backend/.vscode/launch.json`, the four `evals/probes/resiliency-*.sh`, the example notebooks, and the agent docs. Existing checkouts need `mkdir -p ~/.config/orchestra` and to move their env files across.
+
 ## 2026.6.15
 
 ### Changed

--- a/backend/.vscode/launch.json
+++ b/backend/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "${workspaceFolder}/main.py",
             "console": "integratedTerminal",
             "justMyCode": false,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.backend"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env"
         },
         {
             "name": "Python: Single Test",
@@ -18,7 +18,7 @@
             "args": ["tests/integration/test_project_routes.py", "-v"],
             "console": "integratedTerminal",
             "justMyCode": true,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.test"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env.test"
         },
         {
             "name": "Python: Run Tests",
@@ -28,7 +28,7 @@
             "args": ["tests/", "-v"],
             "console": "integratedTerminal",
             "justMyCode": false,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.test"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env.test"
         },
         {
             "name": "Python: Run Unit Tests Only",
@@ -38,7 +38,7 @@
             "args": ["tests/unit/", "-v"],
             "console": "integratedTerminal",
             "justMyCode": false,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.test"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env.test"
         },
         {
             "name": "Python: Run Integration Tests Only",
@@ -48,7 +48,7 @@
             "args": ["tests/integration/", "-v"],
             "console": "integratedTerminal",
             "justMyCode": false,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.test"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env.test"
         },
         {
             "name": "Python: TaskIQ Worker",
@@ -58,7 +58,7 @@
             "args": ["worker", "src.workers.tasks:broker"],
             "console": "integratedTerminal",
             "justMyCode": false,
-            "envFile": "/home/ryaneggz/.env/orchestra/.env.backend"
+            "envFile": "/home/ryaneggz/.config/orchestra/.env"
         },
         {
             "name": "Python: Remote Attach",

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -21,14 +21,14 @@ uv sync
 
 ### 2. Environment Configuration
 
-The backend uses environment files stored at `~/.env/orchestra/.env.backend`.
+The backend uses environment files stored at `~/.config/orchestra/.env`.
 
 ```bash
 # Ensure the env directory exists
-mkdir -p ~/.env/orchestra
+mkdir -p ~/.config/orchestra
 
 # Copy example env if setting up for first time
-cp .example.env ~/.env/orchestra/.env.backend
+cp .example.env ~/.config/orchestra/.env
 ```
 
 ### 3. Start the Application
@@ -41,10 +41,10 @@ make dev
 **With explicit port (use if default port is taken):**
 ```bash
 # Port 8001
-uv run uvicorn main:app --reload --host 0.0.0.0 --port 8001 --log-level debug --env-file ~/.env/orchestra/.env.backend
+uv run uvicorn main:app --reload --host 0.0.0.0 --port 8001 --log-level debug --env-file ~/.config/orchestra/.env
 
 # Port 8002
-uv run uvicorn main:app --reload --host 0.0.0.0 --port 8002 --log-level debug --env-file ~/.env/orchestra/.env.backend
+uv run uvicorn main:app --reload --host 0.0.0.0 --port 8002 --log-level debug --env-file ~/.config/orchestra/.env
 ```
 
 **Auto-increment port if default is taken:**
@@ -54,7 +54,7 @@ PORT=8000
 while lsof -i :$PORT >/dev/null 2>&1; do
   PORT=$((PORT + 1))
 done
-uv run uvicorn main:app --reload --host 0.0.0.0 --port $PORT --log-level debug --env-file ~/.env/orchestra/.env.backend
+uv run uvicorn main:app --reload --host 0.0.0.0 --port $PORT --log-level debug --env-file ~/.config/orchestra/.env
 ```
 
 ## Common Commands
@@ -71,7 +71,7 @@ uv run uvicorn main:app --reload --host 0.0.0.0 --port $PORT --log-level debug -
 
 ## Database Migrations
 
-All migration commands use the env file at `~/.env/orchestra/.env.backend`:
+All migration commands use the env file at `~/.config/orchestra/.env`:
 
 ```bash
 # Apply all migrations

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev claude build run tag seeds seeds.memory test format lint
 
-ENV_FILE ?= $(HOME)/.env/orchestra/.env.backend
+ENV_FILE ?= $(HOME)/.config/orchestra/.env
 
 dev:
 	uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000 --log-level debug --env-file $(ENV_FILE)

--- a/evals/README.md
+++ b/evals/README.md
@@ -68,7 +68,7 @@ A probe that cannot determine the result MUST exit `2`, never `0`.
 **Primary (deterministic, always runs)**:
 
 ```bash
-cd backend && ENV_FILE=~/.env/orchestra/.env.backend.test \
+cd backend && ENV_FILE=~/.config/orchestra/.env.test \
   PYTHONPATH=./src:. uv run pytest -m resiliency \
   tests/resiliency/test_<track>.py -q
 ```

--- a/evals/probes/resiliency-correlation-id.sh
+++ b/evals/probes/resiliency-correlation-id.sh
@@ -30,7 +30,7 @@ if ! command -v uv &>/dev/null; then
 fi
 
 # --- load backend test env (optional: absent file is silently skipped for CI) ---
-ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.config/orchestra/.env.test}"
 # shellcheck source=/dev/null
 [ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
 

--- a/evals/probes/resiliency-dlq.sh
+++ b/evals/probes/resiliency-dlq.sh
@@ -30,7 +30,7 @@ if ! command -v uv &>/dev/null; then
 fi
 
 # --- load backend test env (optional: absent file is silently skipped for CI) ---
-ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.config/orchestra/.env.test}"
 # shellcheck source=/dev/null
 [ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
 

--- a/evals/probes/resiliency-heartbeat-drain.sh
+++ b/evals/probes/resiliency-heartbeat-drain.sh
@@ -30,7 +30,7 @@ if ! command -v uv &>/dev/null; then
 fi
 
 # --- load backend test env (optional: absent file is silently skipped for CI) ---
-ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.config/orchestra/.env.test}"
 # shellcheck source=/dev/null
 [ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
 

--- a/evals/probes/resiliency-idempotency.sh
+++ b/evals/probes/resiliency-idempotency.sh
@@ -30,7 +30,7 @@ if ! command -v uv &>/dev/null; then
 fi
 
 # --- load backend test env (optional: absent file is silently skipped for CI) ---
-ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.env/orchestra/.env.backend.test}"
+ENV_FILE="${ORCHESTRA_ENV_FILE:-$HOME/.config/orchestra/.env.test}"
 # shellcheck source=/dev/null
 [ -f "$ENV_FILE" ] && { set -a; . "$ENV_FILE"; set +a; }
 

--- a/examples/agents/RLM.ipynb
+++ b/examples/agents/RLM.ipynb
@@ -39,8 +39,8 @@
         "from dotenv import load_dotenv\n",
         "\n",
         "# Load environment variables from standard location\n",
-        "# ~/.env/orchestra/.env.backend\n",
-        "env_path = Path.home() / \".env\" / \"orchestra\" / \".env.backend\"\n",
+        "# ~/.config/orchestra/.env\n",
+        "env_path = Path.home() / \".config\" / \"orchestra\" / \".env\"\n",
         "load_dotenv(env_path)"
       ]
     },

--- a/examples/agents/deep_agent_backend.ipynb
+++ b/examples/agents/deep_agent_backend.ipynb
@@ -34,8 +34,8 @@
         "from dotenv import load_dotenv\n",
         "\n",
         "# Load environment variables from standard location\n",
-        "# ~/.env/orchestra/.env.backend\n",
-        "env_path = Path.home() / \".env\" / \"orchestra\" / \".env.backend\"\n",
+        "# ~/.config/orchestra/.env\n",
+        "env_path = Path.home() / \".config\" / \"orchestra\" / \".env\"\n",
         "load_dotenv(env_path)"
       ]
     },

--- a/examples/agents/stream_subagent_updates.ipynb
+++ b/examples/agents/stream_subagent_updates.ipynb
@@ -39,8 +39,8 @@
         "from dotenv import load_dotenv\n",
         "\n",
         "# Load environment variables from standard location\n",
-        "# ~/.env/orchestra/.env.backend\n",
-        "env_path = Path.home() / \".env\" / \"orchestra\" / \".env.backend\"\n",
+        "# ~/.config/orchestra/.env\n",
+        "env_path = Path.home() / \".config\" / \"orchestra\" / \".env\"\n",
         "load_dotenv(env_path)"
       ]
     },

--- a/examples/tools/api_as_tool.ipynb
+++ b/examples/tools/api_as_tool.ipynb
@@ -27,7 +27,7 @@
         "from dotenv import load_dotenv\n",
         "\n",
         "# Load environment variables from standard location\n",
-        "env_path = Path.home() / \".env\" / \"orchestra\" / \".env.backend\"\n",
+        "env_path = Path.home() / \".config\" / \"orchestra\" / \".env\"\n",
         "load_dotenv(env_path)\n",
         "\n",
         "# Auth token for API requests\n",

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -15,14 +15,14 @@ npm install
 
 ### 2. Environment Configuration
 
-The frontend uses environment files stored at `~/.env/orchestra/.env.frontend`.
+The frontend uses environment files stored at `~/.config/orchestra/.env.frontend`.
 
 ```bash
 # Ensure the env directory exists
-mkdir -p ~/.env/orchestra
+mkdir -p ~/.config/orchestra
 
 # Copy example env if setting up for first time
-cp .example.env ~/.env/orchestra/.env.frontend
+cp .example.env ~/.config/orchestra/.env.frontend
 ```
 
 ### 3. Start the Application

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "dotenv -e ~/.env/orchestra/.env.frontend -- vite",
-		"dev:claude": "dotenv -e ~/.env/orchestra/.env.frontend -- vite --host 0.0.0.0 --port 8030",
+		"dev": "dotenv -e ~/.config/orchestra/.env.frontend -- vite",
+		"dev:claude": "dotenv -e ~/.config/orchestra/.env.frontend -- vite --host 0.0.0.0 --port 8030",
 		"docs": "cd ../backend && bash scripts/docs.sh",
 		"build": "tsc -b && vite build",
 		"build:embed": "vite build --config vite.embed.config.ts",

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -116,7 +116,7 @@ services:
         working_dir: /app
         init: true
         env_file:
-            - ~/.env/orchestra/.env.backend
+            - ~/.config/orchestra/.env
         environment:
             APP_ENV: development
             APP_LOG_LEVEL: DEBUG
@@ -172,7 +172,7 @@ services:
         working_dir: /app
         init: true
         env_file:
-            - ~/.env/orchestra/.env.backend
+            - ~/.config/orchestra/.env
         environment:
             APP_ENV: development
             APP_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Closes #950

## What changed

The environment files move out of `~/.env/orchestra/` and into `~/.config/orchestra/`, with the primary backend env becoming plain `.env`:

| old | new | referenced by |
|---|---|---|
| `~/.env/orchestra/.env.backend` | `~/.config/orchestra/.env` | `backend/Makefile`, `infra/docker-compose.yml`, docs, notebooks |
| `~/.env/orchestra/.env.backend.test` | `~/.config/orchestra/.env.test` | `.pre-commit-config.yaml`, `evals/probes/resiliency-*.sh`, `evals/README.md` |
| `~/.env/orchestra/.env.test` | `~/.config/orchestra/.env.test` | `backend/.vscode/launch.json` |
| `~/.env/orchestra/.env.frontend` | `~/.config/orchestra/.env.frontend` | `frontend/package.json`, `frontend/CLAUDE.md` |

17 files, 38 replacements. Path strings only — no behavioral change.

## Why the test and frontend envs keep separate names

Collapsing all four into a single `~/.config/orchestra/.env` was the other option, and it is the one to avoid: `make test` and the `backend-test` pre-commit hook currently load `.env.backend.test`, which carries a different `POSTGRES_CONNECTION_STRING`. One shared file would silently point the test suite and every pre-commit run at the development database. Keeping `.env.test` and `.env.frontend` distinct preserves that isolation.

## Migration for existing checkouts

```bash
mkdir -p ~/.config/orchestra
mv ~/.env/orchestra/.env.backend       ~/.config/orchestra/.env
mv ~/.env/orchestra/.env.backend.test  ~/.config/orchestra/.env.test
mv ~/.env/orchestra/.env.frontend      ~/.config/orchestra/.env.frontend
```

## Verification

- No reference to the old location survives anywhere in the repo.
- Replacement was ordered longest-pattern-first, so the bare-directory rewrite (`mkdir -p ~/.env/orchestra`) could not clobber the specific filename rules.
- `backend/.vscode/launch.json`, `frontend/package.json`, and three of the four notebooks re-validate as JSON after the edit.

## Two notes for review

1. **`examples/tools/api_as_tool.ipynb` does not parse as JSON — and did not before this PR.** It carries 13 unresolved merge conflict blocks committed by `d1f1dae0`. This PR updates the one env-path line inside it and deliberately leaves the conflicts alone, since resolving them is an authoring decision. Filed separately as #951.
2. `backend/.vscode/launch.json` still hardcodes `/home/ryaneggz/...`. I moved the path but left the hardcoded home as-is, since switching it to `${userHome}` is beyond a path migration. Happy to do it if you want.