### PR TITLE
fix: release the auth DB session before the handler runs (#955)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.8.6
+
+### Fixed
+  - task/955-db-pool-exhaustion — stop the SQLAlchemy connection pool from exhausting and returning 500 for every authenticated request. `verify_credentials` and the two `get_optional_user*` wrappers took the session as a FastAPI dependency, and dependency teardown runs *after* the path operation function returns — so one pooled connection stayed checked out for the whole request, which for `/llm/invoke` is an entire agent turn and for the SSE path the whole stream. Auth now opens its own short-lived session around the user lookup only. The engine was also created with no pool arguments at all, silently running on SQLAlchemy's defaults (size 5, overflow 10, timeout 30s); it is now configured explicitly via `DB_SQLA_POOL_SIZE`/`DB_SQLA_POOL_MAX_OVERFLOW`/`DB_SQLA_POOL_TIMEOUT`/`DB_SQLA_POOL_RECYCLE` with `pool_pre_ping`. `pool_timeout` drops to 5s deliberately: queueing silently for 30s is what turned one burst into a cascade of 500s. Symptom was an empty model picker — `GET /llm/models` 500s for a signed-in user while the same endpoint returns 200 unauthenticated, because the anonymous path never touches the pool.
+
+### Added
+  - task/955-db-pool-exhaustion — `GET /api/info/health/db` reports SQLAlchemy pool size, checked-in/checked-out counts, overflow, and configured limits. Pure introspection of the pool object, so it still answers while the pool is exhausted.
+
 ## 2026.6.15
 
 ### Changed

--- a/backend/src/constants/__init__.py
+++ b/backend/src/constants/__init__.py
@@ -39,10 +39,23 @@ def get_db_uri():
 DB_URI = get_db_uri()
 
 # Database Connection Pool Settings
+# NOTE: these configure the psycopg pool used by the LangGraph store (see
+# services/db.py get_store_db). The SQLAlchemy engine has its own DB_SQLA_*
+# settings below — the two pools have different min/max semantics, so keep
+# the names distinct or tuning one will silently retune the other.
 DB_POOL_MIN_SIZE = int(os.getenv("DB_POOL_MIN_SIZE", "5"))
 DB_POOL_MAX_SIZE = int(os.getenv("DB_POOL_MAX_SIZE", "20"))
 DB_POOL_MAX_IDLE_TIME = int(os.getenv("DB_POOL_MAX_IDLE_TIME", "300"))  # 5 minutes
 DB_POOL_MAX_LIFETIME = int(os.getenv("DB_POOL_MAX_LIFETIME", "3600"))  # 1 hour
+
+# SQLAlchemy async engine pool settings (per process — dev runs one uvicorn plus
+# two taskiq workers, each with its own pool, against a single Postgres).
+# pool_timeout is deliberately short: queueing silently for 30s is what turns a
+# burst into a cascade of 500s, because callers keep piling up behind the queue.
+DB_SQLA_POOL_SIZE = int(os.getenv("DB_SQLA_POOL_SIZE", "10"))
+DB_SQLA_POOL_MAX_OVERFLOW = int(os.getenv("DB_SQLA_POOL_MAX_OVERFLOW", "10"))
+DB_SQLA_POOL_TIMEOUT = int(os.getenv("DB_SQLA_POOL_TIMEOUT", "5"))  # seconds
+DB_SQLA_POOL_RECYCLE = int(os.getenv("DB_SQLA_POOL_RECYCLE", "1800"))  # 30 minutes
 
 
 # Checkpoint Database Configuration

--- a/backend/src/routes/v0/info/health.py
+++ b/backend/src/routes/v0/info/health.py
@@ -1,6 +1,11 @@
 from fastapi import Depends, APIRouter, HTTPException
-from src.constants import APP_VERSION
-from src.services.db import get_store, get_checkpoint_db
+from src.constants import (
+    APP_VERSION,
+    DB_SQLA_POOL_MAX_OVERFLOW,
+    DB_SQLA_POOL_SIZE,
+    DB_SQLA_POOL_TIMEOUT,
+)
+from src.services.db import async_engine, get_store, get_checkpoint_db
 from langgraph.store.postgres import AsyncPostgresStore
 from src.utils.logger import logger
 import asyncio
@@ -15,6 +20,31 @@ async def health_check():
         "status": "healthy",
         "message": "Service is running",
         "version": APP_VERSION,
+    }
+
+
+@router.get("/db", name="Database Pool Health Check")
+async def check_db_pool_health():
+    """Report SQLAlchemy connection pool utilisation.
+
+    Pure introspection of the pool object — issues no query, so it still answers
+    when the pool is exhausted. That is the point: pool exhaustion surfaces as a
+    500 on every authenticated route, and this makes it one curl to confirm.
+    """
+    pool = async_engine.pool
+    checked_out = pool.checkedout()
+    capacity = DB_SQLA_POOL_SIZE + DB_SQLA_POOL_MAX_OVERFLOW
+
+    return {
+        "status": "healthy" if checked_out < capacity else "exhausted",
+        "size": pool.size(),
+        "checked_in": pool.checkedin(),
+        "checked_out": checked_out,
+        "overflow": pool.overflow(),
+        "max_size": DB_SQLA_POOL_SIZE,
+        "max_overflow": DB_SQLA_POOL_MAX_OVERFLOW,
+        "capacity": capacity,
+        "timeout": DB_SQLA_POOL_TIMEOUT,
     }
 
 

--- a/backend/src/services/db.py
+++ b/backend/src/services/db.py
@@ -30,6 +30,10 @@ from src.constants import (
     DB_POOL_MAX_LIFETIME,
     DB_POOL_MAX_SIZE,
     DB_POOL_MIN_SIZE,
+    DB_SQLA_POOL_MAX_OVERFLOW,
+    DB_SQLA_POOL_RECYCLE,
+    DB_SQLA_POOL_SIZE,
+    DB_SQLA_POOL_TIMEOUT,
     DB_URI,
     DB_URI_SESSION,
 )
@@ -45,6 +49,11 @@ ASYNC_DB_URI = get_asyncpg_url(DB_URI)
 async_engine = create_async_engine(
     ASYNC_DB_URI,
     connect_args=get_asyncpg_connect_args(DB_URI),
+    pool_size=DB_SQLA_POOL_SIZE,
+    max_overflow=DB_SQLA_POOL_MAX_OVERFLOW,
+    pool_timeout=DB_SQLA_POOL_TIMEOUT,
+    pool_recycle=DB_SQLA_POOL_RECYCLE,
+    pool_pre_ping=True,
 )
 AsyncSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=async_engine)
 

--- a/backend/src/utils/auth.py
+++ b/backend/src/utils/auth.py
@@ -6,14 +6,13 @@ from fastapi import Request, status, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import jwt
 from jwt import PyJWTError
-from sqlalchemy.ext.asyncio import AsyncSession
 from src.constants.llm import get_free_models
 from src.repos.user_repo import UserRepo
 from src.repos.api_token_repo import ApiTokenRepo
 from src.constants import JWT_SECRET_KEY, JWT_ALGORITHM, JWT_TOKEN_EXPIRE_MINUTES
 from src.schemas.entities import LLMRequest
 from src.schemas.models import User
-from src.services.db import get_async_db
+from src.services.db import AsyncSessionLocal
 from src.services.assistant import AssistantService
 from src.utils.logger import logger
 
@@ -56,7 +55,6 @@ def is_authorized_model(model: str) -> bool:
 async def get_optional_user_from_token(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: AsyncSession = Depends(get_async_db, scope="function"),
 ) -> Optional[User]:
     """
     Get optional user from Bearer token or API key.
@@ -68,13 +66,13 @@ async def get_optional_user_from_token(
         api_key = request.headers.get("x-api-key")
         if api_key:
             try:
-                return await verify_credentials(request, credentials, db)
+                return await verify_credentials(request, credentials)
             except HTTPException:
                 pass
         return None
 
     try:
-        return await verify_credentials(request, credentials, db)
+        return await verify_credentials(request, credentials)
     except HTTPException:
         return None
 
@@ -83,14 +81,13 @@ async def get_optional_user(
     request: Request,
     params: LLMRequest,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: AsyncSession = Depends(get_async_db, scope="function"),
 ) -> Optional[User]:
     if credentials is None:
         # Check for API Key if no Bearer token
         api_key = request.headers.get("x-api-key")
         if api_key:
             try:
-                return await verify_credentials(request, credentials, db)
+                return await verify_credentials(request, credentials)
             except HTTPException:
                 pass
 
@@ -114,7 +111,7 @@ async def get_optional_user(
         return None
 
     try:
-        return await verify_credentials(request, credentials, db)
+        return await verify_credentials(request, credentials)
     except HTTPException:
         return None
 
@@ -122,7 +119,6 @@ async def get_optional_user(
 async def verify_credentials(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: AsyncSession = Depends(get_async_db, scope="function"),  # type: ignore
 ) -> User:
     # 1. Check for API Key in headers
     api_key = request.headers.get("x-api-key")
@@ -136,26 +132,31 @@ async def verify_credentials(
                 token = await token_repo.get_by_hash_global(hashed)
 
                 if token:
-                    user_repo = UserRepo(db, user_id=token.user_id)
-                    user = await user_repo.get_by_id()
+                    # Scope the pooled connection to the lookup itself. Holding it as a
+                    # FastAPI dependency would pin it for the whole request — including
+                    # an entire agent turn — and exhaust the pool. See issue #955.
+                    async with AsyncSessionLocal() as db:
+                        user_repo = UserRepo(db, user_id=token.user_id)
+                        user = await user_repo.get_by_id()
 
-                    if not user:
-                        logger.warning(f"User {token.user_id} not found for valid token {token.id}")
-                        raise HTTPException(
-                            status_code=status.HTTP_401_UNAUTHORIZED,
-                            detail="User not found",
-                        )
+                        if not user:
+                            logger.warning(f"User {token.user_id} not found for valid token {token.id}")
+                            raise HTTPException(
+                                status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="User not found",
+                            )
+
+                        # Build the detached payload before the session closes
+                        protected_user = user.protected()
 
                     # Update last used timestamp
                     user_token_repo = ApiTokenRepo(token.user_id, store)
                     await user_token_repo.update_last_used(token.id)
 
-                    logger.info(f"Authenticated user via API Token: {user.id} {user.email}")
-                    user_repo.user_id = user.id
-                    request.state.user = user.protected()
+                    logger.info(f"Authenticated user via API Token: {protected_user.id} {protected_user.email}")
+                    request.state.user = protected_user
                     request.state.token = api_key
-                    request.state.user_repo = user_repo
-                    return user.protected()
+                    return protected_user
 
                 # If api_key provided but invalid
                 raise HTTPException(
@@ -213,23 +214,26 @@ async def verify_credentials(
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Verify user exists in database
-        user_repo = UserRepo(db)
-        user = await user_repo.get_by_email(user_data["email"])
-        if not user:
-            logger.warning(f"User not found: {user_data['email']}")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="User not found",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
+        # Verify user exists in database. The session is scoped to this lookup only —
+        # see the note on the API-key branch above and issue #955.
+        async with AsyncSessionLocal() as db:
+            user_repo = UserRepo(db)
+            user = await user_repo.get_by_email(user_data["email"])
+            if not user:
+                logger.warning(f"User not found: {user_data['email']}")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="User not found",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
 
-        logger.info(f"Authenticated user: {user.id} {user.email}")
-        user_repo.user_id = user.id
-        request.state.user = user.protected()
+            # Build the detached payload before the session closes
+            protected_user = user.protected()
+
+        logger.info(f"Authenticated user: {protected_user.id} {protected_user.email}")
+        request.state.user = protected_user
         request.state.token = credentials.credentials
-        request.state.user_repo = user_repo
-        return user.protected()
+        return protected_user
 
     except PyJWTError:
         logger.exception(f"Could not validate credentials: {credentials.credentials}")

--- a/backend/tests/unit/services/test_db.py
+++ b/backend/tests/unit/services/test_db.py
@@ -1,0 +1,49 @@
+"""Regression pins for the SQLAlchemy connection pool (issue #955).
+
+The pool was previously created with no arguments at all, so it silently ran on
+SQLAlchemy's defaults (size 5, overflow 10, timeout 30s). Combined with auth
+holding a pooled connection for the whole request, that exhausted the pool and
+returned 500 for every authenticated route — which surfaced in the UI as an
+empty model picker.
+
+The other half of that fix is pinned in tests/unit/utils/test_auth_dependency_scope.py.
+"""
+
+from src.constants import (
+    DB_SQLA_POOL_MAX_OVERFLOW,
+    DB_SQLA_POOL_RECYCLE,
+    DB_SQLA_POOL_SIZE,
+    DB_SQLA_POOL_TIMEOUT,
+)
+from src.services.db import async_engine
+
+# SQLAlchemy's own defaults. The pool must not silently fall back to these.
+SQLALCHEMY_DEFAULT_POOL_SIZE = 5
+SQLALCHEMY_DEFAULT_TIMEOUT = 30
+
+
+class TestAsyncEnginePoolConfig:
+    def test_pool_is_explicitly_configured(self):
+        pool = async_engine.pool
+
+        assert pool.size() == DB_SQLA_POOL_SIZE
+        assert pool._max_overflow == DB_SQLA_POOL_MAX_OVERFLOW
+        assert pool._timeout == DB_SQLA_POOL_TIMEOUT
+        assert pool._recycle == DB_SQLA_POOL_RECYCLE
+
+    def test_pool_does_not_use_silent_defaults(self):
+        """The exact failure mode from #955: no kwargs passed to create_async_engine."""
+        pool = async_engine.pool
+
+        assert pool.size() != SQLALCHEMY_DEFAULT_POOL_SIZE, (
+            "Pool size fell back to the SQLAlchemy default — pool kwargs were likely dropped"
+        )
+        assert pool._timeout != SQLALCHEMY_DEFAULT_TIMEOUT, (
+            "Pool timeout fell back to 30s; queueing that long turns a burst into a cascade of 500s"
+        )
+
+    def test_pre_ping_enabled(self):
+        assert async_engine.pool._pre_ping is True
+
+    def test_timeout_fails_fast(self):
+        assert DB_SQLA_POOL_TIMEOUT <= 10, "pool_timeout must fail fast, not queue silently"

--- a/backend/tests/unit/utils/test_auth_dependency_scope.py
+++ b/backend/tests/unit/utils/test_auth_dependency_scope.py
@@ -1,3 +1,15 @@
+"""Auth must not hold a pooled DB connection for the duration of a request.
+
+Previously these dependencies took `db: AsyncSession = Depends(get_async_db, scope="function")`.
+Function scope releases the session when the *path operation function* returns — which for
+/llm/invoke is after a full agent turn, and for the SSE path after the whole stream. One
+pooled connection was therefore pinned per in-flight request, exhausting the pool and
+returning 500 for every authenticated route (issue #955).
+
+Auth now opens its own short-lived session around the user lookup, so these tests assert
+the stronger property: no session dependency at all.
+"""
+
 import inspect
 
 from src.utils.auth import (
@@ -6,14 +18,28 @@ from src.utils.auth import (
     verify_credentials,
 )
 
+AUTH_DEPENDENCIES = (
+    get_optional_user_from_token,
+    get_optional_user,
+    verify_credentials,
+)
 
-def test_auth_db_dependencies_close_at_function_scope() -> None:
-    functions = [
-        get_optional_user_from_token,
-        get_optional_user,
-        verify_credentials,
-    ]
 
-    for dependency in functions:
-        db_parameter = inspect.signature(dependency).parameters["db"]
-        assert db_parameter.default.scope == "function"
+def test_auth_does_not_take_a_session_dependency() -> None:
+    """A `db` parameter here means the connection is held for the whole request again."""
+    for dependency in AUTH_DEPENDENCIES:
+        parameters = inspect.signature(dependency).parameters
+        assert "db" not in parameters, (
+            f"{dependency.__name__}() declares a 'db' dependency. FastAPI runs dependency "
+            f"teardown after the endpoint returns, so this pins a pooled connection for the "
+            f"entire request — the pool-exhaustion regression from issue #955."
+        )
+
+
+def test_auth_opens_its_own_short_lived_session() -> None:
+    source = inspect.getsource(verify_credentials)
+
+    assert "async with AsyncSessionLocal()" in source, (
+        "verify_credentials must scope its session to the user lookup itself"
+    )
+    assert "Depends(get_async_db" not in source


### PR DESCRIPTION
Closes #955.

## The symptom vs. the cause

Reported as "the app is running but there are no models to select." That reads like missing provider API keys. It isn't — the backend was returning **500 for every authenticated request**, including `GET /llm/models`, so the frontend had nothing to render and showed no error.

The API looked healthy under `curl` because the anonymous path short-circuits in auth before it ever touches the connection pool:

| Request | Result |
|---|---|
| `curl /api/llm/models` (no token) | **200**, full model list, 0.44s |
| same endpoint from the browser, signed in | **500** |
| `POST /api/auth/login` | **500 after 30.01s** |
| `GET /api/info/health` (no DB) | **200** |

Every failure was one exception, 13 occurrences in the server log and reproduced live while writing this PR:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached,
connection timed out, timeout 30.00
```

## Root cause: hold time, not pool size

`verify_credentials` and the two `get_optional_user*` wrappers declared the session as a FastAPI dependency:

```python
db: AsyncSession = Depends(get_async_db, scope="function")
```

FastAPI runs dependency teardown **after the path operation function returns**. `scope="function"` narrows that to the endpoint body rather than end-of-response, but the endpoint body is exactly where the expensive work happens — for `/llm/invoke` that is a full agent turn, for the SSE path the entire stream. So one pooled connection was pinned per in-flight request for its whole duration. Fifteen concurrent or slow requests exhausted `pool_size=5 + max_overflow=10`, and the 30s `pool_timeout` then converted a single burst into a cascade, because the frontend's own polling kept adding waiters behind the same queue faster than it drained.

Auth now opens its own short-lived session around the user lookup only, building the detached `ProtectedUser` payload before the session closes.

Separately, the engine was created with **no pool arguments at all**, silently running on SQLAlchemy's defaults. It is now configured explicitly via `DB_SQLA_POOL_SIZE` / `DB_SQLA_POOL_MAX_OVERFLOW` / `DB_SQLA_POOL_TIMEOUT` / `DB_SQLA_POOL_RECYCLE` with `pool_pre_ping`. These are deliberately **new** names rather than reusing `DB_POOL_MIN_SIZE`/`DB_POOL_MAX_SIZE`, which feed `get_store_db`'s psycopg `PoolConfig` and have different min/max semantics — sharing them would let tuning one pool silently retune the other.

`pool_timeout` goes **down** to 5s, not up. Failing fast makes the problem visible in the network tab instead of presenting as a frozen UI.

## Verification

Ran a full instance against a scratch database:

- **60 concurrent authenticated requests** to `/api/llm/models` → **60× 200**, at the *original* pool sizing (`DB_SQLA_POOL_SIZE=5`, `MAX_OVERFLOW=10`, capacity 15). That is 4× the old ceiling, which isolates the session-scope change as what carries the fix rather than the wider pool.
- 25 concurrent at the new default sizing → 25× 200.
- `GET /api/info/health/db` before and after → `checked_out: 0`.
- Unit suite: **643 passed, 2 failed**. Both failures (`test_tool_repo`, `test_tool_service`) are present on the base commit — verified by re-running the suite with `src/` stashed: `2 failed, 638 passed`. No new failures.
- The new pins were checked by rejection: reverting only `services/db.py` fails 3 of them, reverting only `utils/auth.py` fails the other 2, full fix passes 6/6.
- `ruff check` clean; `ruff format --check` reports one pre-existing file (`test_example.py`, unchanged here).

## Observability

Adds `GET /api/info/health/db`:

```json
{"status":"healthy","size":10,"checked_in":1,"checked_out":0,"overflow":-9,
 "max_size":10,"max_overflow":10,"capacity":20,"timeout":5}
```

Pure introspection of the pool object — no query — so it still answers while the pool is exhausted. Diagnosing this originally required reading server logs.

## Note on the replaced test

`tests/unit/utils/test_auth_dependency_scope.py` previously asserted each auth dependency had `scope="function"`. That mechanism is what this PR removes, so the test is rewritten to pin the stronger property: no session dependency at all.

## Deliberately out of scope

Each is real, located, and filed separately rather than bundled into an incident fix:

- `services/db.py:196-205` — `get_store_db()` builds a new psycopg pool with `min_size=5` on **every** call (`workers/tasks.py:301,904`, `services/schedule.py:95,195`). Needs a process-level singleton. Different pool and different exception class, so it cannot produce the error above.
- `routes/v0/info/health.py` — `check_store_health` does `async with store as s:` on the app-wide `app.state.store`, whose `__aexit__` closes the shared pool and permanently breaks the store for that process.
- `services/schedule.py:17` — a sync psycopg2 `SQLAlchemyJobStore` paired with `AsyncIOScheduler` does blocking I/O on the event loop. An amplifier, not a cause.
- `routes/v0/server.py` — bare `Depends(get_async_db)` alongside `Depends(verify_credentials)`. FastAPI's dependency cache key includes the scope, so these resolved as two separate checkouts rather than one; that resolves as a side effect here and should be confirmed after merge.
- **Frontend silent-failure cluster** — why a backend outage read as a config problem: `useModel.tsx:15` gates the models query on a token although the endpoint is auth-optional; `useModelVisibility.ts:46` lets an empty array through the null guard and hides every model; `ChatInput.tsx:183` renders nothing rather than an error; `SelectModel.tsx:132` shows "No model found." for both "backend down" and "filter matched nothing". Also `<Toaster />` is mounted nowhere in `src/`, so all 66 `toast.*` calls currently render nothing.
