### PR TITLE
fix: render hydrated assistant messages with content blocks

### DIFF
--- a/frontend/src/components/lists/ChatMessages.tsx
+++ b/frontend/src/components/lists/ChatMessages.tsx
@@ -197,6 +197,11 @@ export const Message = memo(
 		}
 
 		const isSubagent = !!message.agent_name;
+		const content = formatContent(message.content);
+
+		// Nothing renderable — e.g. a reasoning-only block list, or an assistant
+		// turn that carried only tool calls. Skip the bubble entirely.
+		if (!content) return null;
 
 		return (
 			<div className="group px-3 md:px-5">
@@ -209,14 +214,12 @@ export const Message = memo(
 						</div>
 					)}
 					<div className="bg-transparent text-foreground-500 px-3 rounded-lg rounded-bl-sm">
-						<MarkdownCard
-							content={formatContent(message.content) || "Invalid message"}
-						/>
+						<MarkdownCard content={content} />
 					</div>
 				</div>
 				<div className="flex justify-start opacity-100 transition-opacity duration-200 mt-1 px-3">
 					<div className="flex gap-1">
-						<CopyTextButton text={formatContent(message.content)} />
+						<CopyTextButton text={content} />
 
 						<div className="flex items-center gap-2">
 							<button className="text-sm text-muted-foreground">

--- a/frontend/src/embed/EmbedWidget.tsx
+++ b/frontend/src/embed/EmbedWidget.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
+import { formatContent } from "@/lib/utils/format";
 
 interface Message {
 	role: "user" | "assistant";
@@ -12,21 +13,6 @@ interface EmbedWidgetProps {
 }
 
 const STORAGE_KEY_PREFIX = "orchestra_embed_thread_";
-
-/** Extract text from AIMessageChunk content (string or content-block array). */
-function extractTextContent(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (Array.isArray(content)) {
-		return content
-			.filter(
-				(b: Record<string, unknown>) =>
-					b?.type === "text" && typeof b?.text === "string",
-			)
-			.map((b: Record<string, unknown>) => b.text)
-			.join("");
-	}
-	return "";
-}
 
 export function EmbedWidget({ agentId, apiBase, token }: EmbedWidgetProps) {
 	const [open, setOpen] = useState(false);
@@ -166,7 +152,7 @@ export function EmbedWidget({ agentId, apiBase, token }: EmbedWidgetProps) {
 						if (eventType === "messages" && Array.isArray(payload)) {
 							const msgDict = payload[0];
 							if (msgDict && msgDict.content !== undefined) {
-								const text = extractTextContent(msgDict.content);
+								const text = formatContent(msgDict.content);
 								if (text) {
 									setMessages((prev) => {
 										const copy = [...prev];

--- a/frontend/src/hooks/useChat.test.tsx
+++ b/frontend/src/hooks/useChat.test.tsx
@@ -38,7 +38,21 @@ vi.mock("@/context/AgentContext", () => ({
 }));
 
 vi.mock("@/lib/utils/format", () => ({
-	formatContent: (content: unknown) => content ?? "",
+	formatContent: (content: unknown) => {
+		if (typeof content === "string") return content;
+		if (!content) return "";
+		if (Array.isArray(content)) {
+			return content
+				.filter(
+					(b: any) =>
+						(b?.type === "text" || b?.type == null) &&
+						typeof b?.text === "string",
+				)
+				.map((b: any) => b.text)
+				.join("");
+		}
+		return "";
+	},
 	formatMessages: (messages: unknown[]) => messages,
 	formatMultimodalPayload: (...args: unknown[]) =>
 		mockFormatMultimodalPayload(...args),

--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatMessages } from "./format";
+import { formatContent, formatMessages } from "./format";
 
 describe("formatMessages", () => {
 	describe("Tool Call Normalization", () => {
@@ -847,5 +847,134 @@ describe("formatMessages", () => {
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual(messages[0]);
 		});
+	});
+});
+
+describe("formatContent", () => {
+	it("passes plain strings through", () => {
+		expect(formatContent("Hello world")).toBe("Hello world");
+	});
+
+	it("returns an empty string for empty content", () => {
+		expect(formatContent("")).toBe("");
+		expect(formatContent(null)).toBe("");
+		expect(formatContent(undefined)).toBe("");
+	});
+
+	it("never returns undefined for a non-array object", () => {
+		expect(formatContent({ text: "nope" })).toBe("");
+	});
+
+	describe("content-block arrays", () => {
+		// Regression: OpenAI reasoning models route through the Responses API,
+		// which persists a reasoning block ahead of the answer. Reading only
+		// content[0].text yielded undefined and rendered "Invalid message"
+		// whenever a thread was re-hydrated from the sidebar.
+		it("extracts text when a reasoning block comes first", () => {
+			const content = [
+				{ type: "reasoning", id: "rs_123", summary: [] },
+				{ type: "text", text: "The real answer", annotations: [] },
+			];
+
+			expect(formatContent(content)).toBe("The real answer");
+		});
+
+		it("extracts text when an Anthropic thinking block comes first", () => {
+			const content = [
+				{ type: "thinking", thinking: "hmm...", signature: "sig" },
+				{ type: "text", text: "Hi" },
+			];
+
+			expect(formatContent(content)).toBe("Hi");
+		});
+
+		it("joins every text block rather than only the first", () => {
+			const content = [
+				{ type: "text", text: "a" },
+				{ type: "text", text: "b" },
+			];
+
+			expect(formatContent(content)).toBe("ab");
+		});
+
+		it("returns an empty string for reasoning-only content", () => {
+			const content = [{ type: "reasoning", id: "rs_123", summary: [] }];
+
+			expect(formatContent(content)).toBe("");
+		});
+
+		it("returns an empty string for tool_use-only content", () => {
+			const content = [
+				{ type: "tool_use", id: "call_1", name: "search", input: {} },
+			];
+
+			expect(formatContent(content)).toBe("");
+		});
+
+		it("still accepts untyped blocks for backwards compatibility", () => {
+			expect(formatContent([{ text: "legacy" }])).toBe("legacy");
+		});
+
+		it("ignores blocks whose text is not a string", () => {
+			const content = [
+				{ type: "text", text: null },
+				{ type: "text", text: "ok" },
+			];
+
+			expect(formatContent(content)).toBe("ok");
+		});
+	});
+});
+
+describe("formatMessages with Responses API content blocks", () => {
+	it("emits the assistant text message alongside its tool calls", () => {
+		const messages = [
+			{
+				id: "msg-blocks",
+				type: "ai",
+				content: [
+					{ type: "reasoning", id: "rs_1", summary: [] },
+					{ type: "text", text: "Let me look that up.", annotations: [] },
+				],
+				tool_calls: [
+					{ id: "call_1", name: "web_search", args: { query: "aegra" } },
+				],
+			},
+		];
+
+		const result = formatMessages(messages);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].role).toBe("assistant");
+		expect(result[0].type).toBe("assistant");
+		expect(formatContent(result[0].content)).toBe("Let me look that up.");
+		expect(result[1].type).toBe("tool_input");
+		expect(result[1].tool_call_id).toBe("call_1");
+	});
+
+	it("keeps block content on a hydrated assistant message without tool calls", () => {
+		const messages = [
+			{
+				id: "msg-final",
+				type: "ai",
+				content: [
+					{ type: "reasoning", id: "rs_2", summary: [] },
+					{
+						type: "text",
+						text: "Here are the streaming examples.",
+						annotations: [],
+					},
+				],
+				tool_calls: [],
+			},
+		];
+
+		const result = formatMessages(messages);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].role).toBe("assistant");
+		expect(formatContent(result[0].content)).toBe(
+			"Here are the streaming examples.",
+		);
 	});
 });

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -334,12 +334,32 @@ export async function formatMultimodalPayload(
 	return [{ role: "user", content: content }];
 }
 
-export function formatContent(content: any) {
+/**
+ * Extract renderable text from message content.
+ *
+ * Content arrives in two shapes: a plain string (Chat Completions, and the
+ * flattened form the streaming handler stores), or a list of content blocks
+ * (OpenAI Responses API, Anthropic extended thinking). Block lists may lead
+ * with a non-text block — `reasoning`, `thinking`, `tool_use` — and may split
+ * a single answer across several text blocks, so join every text block rather
+ * than reading only the first one.
+ */
+export function formatContent(content: any): string {
 	if (typeof content === "string") {
 		return content;
 	}
 	if (!content) return "";
-	return content[0]?.text;
+	if (Array.isArray(content)) {
+		return content
+			.filter(
+				(block: any) =>
+					(block?.type === "text" || block?.type == null) &&
+					typeof block?.text === "string",
+			)
+			.map((block: any) => block.text)
+			.join("");
+	}
+	return "";
 }
 
 export function isEmpty(str: string) {


### PR DESCRIPTION
## Problem

Selecting a thread from the sidebar renders the final assistant response as the literal text **"Invalid message"**. The same conversation renders correctly while it is streaming in a new chat.


## Root cause

The streaming and hydration paths deliver different `content` shapes:

- **Streaming (works)** — `StreamMessageHandler.messageCreate` (`frontend/src/lib/utils/message.ts:122`) stores the **flattened string** produced by `formatContent`. Reasoning-only chunks are falsy and get skipped, so only text lands in history.
- **Hydration (broken)** — `useLoadThreadEffect` → `POST /threads/search` → `formatMessages` (`frontend/src/hooks/useThread.ts:106`). The backend returns a raw LangChain `model_dump()` and `formatMessages` leaves `content` untouched.

Since #961, OpenAI reasoning models are routed through the Responses API (`backend/src/utils/reasoning.py:161`, `use_responses_api = True`), so a persisted assistant message's `content` is a **block array** that leads with a reasoning block:

```jsonc
[{"type": "reasoning", "summary": [...], "id": "rs_..."},
 {"type": "text", "text": "The real answer…", "annotations": []}]
```

`formatContent` (`frontend/src/lib/utils/format.ts:337`) only ever read `content[0]?.text` → `undefined` → `ChatMessages.tsx:213` fell back to `"Invalid message"`.

## Changes

- **`lib/utils/format.ts`** — `formatContent` joins **every** text block instead of reading the first one, and always returns a `string`. This also unbreaks Anthropic extended-thinking content, answers split across multiple text blocks, and the `undefined` that `CopyTextButton` was being handed.
- **`components/lists/ChatMessages.tsx`** — dropped the `"Invalid message"` placeholder. An assistant turn with no renderable text now renders nothing rather than fake body text. Hoisted the three repeated `formatContent` calls into one.
- **`embed/EmbedWidget.tsx`** — deleted the duplicate local `extractTextContent` in favor of the shared helper.
- **Tests** — new `formatContent` suite (reasoning-first, thinking-first, multi-block join, reasoning-only, untyped-block back-compat, non-array) plus Responses-API `formatMessages` cases; realigned the `formatContent` mock in `useChat.test.tsx` so the streaming tests stay honest.

Sidebar previews (`app-sidebar.tsx:82`) and thread search (`ThreadSearchModal.tsx:121`) call the same helper, so they are fixed too.

**No backend change.** The persisted shape is legitimate LangChain output; the frontend is the layer that must handle it.

## Verification

```
npm run test      → 398 passed | 3 skipped
npx tsc --noEmit  → clean
npm run lint      → 0 errors (3 pre-existing warnings in untouched files)
```

End-to-end via `agent-browser` against a running stack:

1. Logged in and selected *"Provide some streaming examples of using aegra"* from the sidebar — the exact thread in the bug report (`/thread/66f680d2-…`, `openai:gpt-5.6-luna`).
2. The full markdown answer now renders; **zero** occurrences of "Invalid message" in the accessibility snapshot.
3. Two other hydrated threads reload correctly; no new console errors.

## Follow-ups (not in this PR)

- Reasoning/thinking blocks are still discarded rather than shown — there is no reasoning UI component today.
- `useThread.ts:106` reads only `checkpoints[0]`, and `backend/src/services/checkpoint.py:51-69` can return only `__start__` input messages for that checkpoint — a separate history-truncation risk.
- `POST /threads/search` has `@cache(expire=15)` (`backend/src/routes/v0/thread.py:40`), which can serve a stale checkpoint right after a run finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant message formatting across chat and embedded experiences.
  * Text from multiple content blocks is now combined consistently.
  * Reasoning-only, tool-call-only, empty, or unsupported content no longer displays as unintended fallback text.
  * Markdown rendering and copy actions now use the same formatted message content.
* **Reliability**
  * Improved handling of streamed assistant responses and varied content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->