### PR TITLE
fix: stop /health/store re-entering the app-wide store singleton (#958)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.8.7
+
+### Fixed
+  - fix/958-store-health-reentry — stop `GET /api/info/health/store` from entering the application-wide store as an async context manager. `get_store` returns `req.app.state.store`, the single `AsyncPostgresStore` created once in the lifespan, so the handler's `async with store as s:` ran `__aenter__`/`__aexit__` on a singleton whose lifecycle it does not own — a diagnostic endpoint manipulating the resource it measures. The handler now awaits `store.asearch(...)` on the injected instance directly, inside the same 5s `asyncio.timeout`; the response body, the timeout→503 branch, and the `"connection"`/`"closed"`→503 mapping are all unchanged. Correcting the issue as filed: this was **latent, not an active outage**. On the pinned `langgraph-checkpoint-postgres` 3.1.0, `AsyncPostgresStore.__aenter__` is a bare `return self` and `__aexit__` only stops a TTL sweeper task that is never started (the store-level `ttl=` is never configured, so `_ttl_sweeper_task` is always `None`); the pool is closed solely by `from_conn_string`'s own `async with`, which unwinds at lifespan exit. The reported pool exhaustion therefore does not reproduce today — but a future `ttl=` config, or a langgraph version whose `__aexit__` releases resources, would have degraded the process-wide store silently. The endpoint had **zero tests**, which is how the pattern survived; `backend/tests/integration/test_health_store.py` adds five, covering the happy path, both 503 branches, the 500 fallback, and — the one that pins the fix — a store double that is a perfectly valid context manager and simply *counts* entries, so the pre-fix handler fails on `aenter_calls == 1` rather than on an incidental error. All five fail against the pre-fix handler. Scoped deliberately to the health probe: `services/assistant.py:227,294` and `services/prompt/__init__.py:168` re-enter the same singleton and are left for a follow-up.
+
 ## 2026.8.6
 
 ### Changed

--- a/backend/src/routes/v0/info/health.py
+++ b/backend/src/routes/v0/info/health.py
@@ -52,19 +52,25 @@ async def check_db_pool_health():
 async def check_store_health(
     store: AsyncPostgresStore = Depends(get_store),
 ):
-    """Check if the AsyncPostgresStore connection is healthy"""
+    """Check if the AsyncPostgresStore connection is healthy.
+
+    Reads the injected store without entering it as a context manager. The store
+    is the application-wide singleton created once in the lifespan
+    (`main.py`) and handed out by `get_store`, so this probe does not own its
+    lifecycle -- `async with store` here would run the singleton's
+    `__aenter__`/`__aexit__` on every poll of a diagnostic endpoint.
+    """
     try:
         # Test basic store operation with timeout
         async with asyncio.timeout(5.0):  # 5 second timeout
-            async with store as s:
-                # Try a simple search operation
-                await s.asearch(("health_check",), limit=1)
-                return {
-                    "status": "healthy",
-                    "store_type": type(store).__name__,
-                    "test_operation": "search",
-                    "message": "Store connection is working",
-                }
+            # Try a simple search operation
+            await store.asearch(("health_check",), limit=1)
+            return {
+                "status": "healthy",
+                "store_type": type(store).__name__,
+                "test_operation": "search",
+                "message": "Store connection is working",
+            }
     except asyncio.TimeoutError:
         logger.error("Store health check timed out")
         raise HTTPException(status_code=503, detail="Store connection timeout - service unavailable")

--- a/backend/tests/integration/test_health_store.py
+++ b/backend/tests/integration/test_health_store.py
@@ -1,0 +1,178 @@
+"""Integration tests for `GET /api/info/health/store`.
+
+The endpoint used to do `async with store as s:` on the value returned by
+`get_store`, which is the application-wide singleton (`req.app.state.store`,
+set once in the lifespan). Entering and exiting a context manager the handler
+does not own is the defect tracked by issue #958, so the tests below pin the
+call shape, not just the status code.
+
+Note on how the store is injected here: routes are registered on `api_app` and
+copied into `app` by reference (`main.py:126`), so every route's
+`dependency_overrides_provider` is `api_app`, not `app`. Setting
+`app.dependency_overrides[get_store]` alone does NOT reach this handler -- the
+real `get_store` runs and reads `req.app.state.store`. `app.state.store` is
+therefore the load-bearing assignment; the overrides are set on both apps as
+well so these tests keep working if the routing is ever restructured.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import Request
+from httpx import AsyncClient
+from langgraph.store.memory import InMemoryStore
+from main import api_app, app
+from src.services.db import get_store
+
+
+class RecordingStore(InMemoryStore):
+    """A fully valid async context manager that counts entries and exits.
+
+    Deliberately does NOT raise on `__aenter__`. That makes the assertion
+    semantic rather than incidental: the handler is free to enter it, so the
+    test fails against the pre-fix code on the counter itself ("you entered the
+    singleton") instead of on an unrelated `TypeError` from a double that simply
+    is not enterable.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.aenter_calls = 0
+        self.aexit_calls = 0
+
+    async def __aenter__(self) -> "RecordingStore":
+        self.aenter_calls += 1
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.aexit_calls += 1
+
+
+class FailingSearchStore(InMemoryStore):
+    """`asearch` raises a generic error -- the 500 fallback path."""
+
+    async def asearch(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+
+class BrokenLinkStore(InMemoryStore):
+    """`asearch` raises the message the "connection"/"closed" 503 branch matches."""
+
+    async def asearch(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("the connection is closed")
+
+
+class TimingOutStore(InMemoryStore):
+    """`asearch` times out, exercising the `except asyncio.TimeoutError` branch."""
+
+    async def asearch(self, *args: Any, **kwargs: Any) -> Any:
+        raise asyncio.TimeoutError()
+
+
+@pytest.fixture
+def override_store():
+    """Swap in a store double, restoring `app.state.store` afterwards.
+
+    The `async_client` fixture clears `app.dependency_overrides` on teardown but
+    does not reset `app.state.store`, so a double left there would leak onto the
+    module-level `app` for every later test in the session.
+    """
+    sentinel = object()
+    previous = getattr(app.state, "store", sentinel)
+
+    def _apply(store: InMemoryStore) -> InMemoryStore:
+        def override_get_store(req: Request) -> InMemoryStore:
+            return store
+
+        app.dependency_overrides[get_store] = override_get_store
+        api_app.dependency_overrides[get_store] = override_get_store
+        app.state.store = store
+        return store
+
+    yield _apply
+
+    api_app.dependency_overrides.pop(get_store, None)
+    if previous is sentinel:
+        delattr(app.state, "store")
+    else:
+        app.state.store = previous
+
+
+@pytest.mark.asyncio
+async def test_store_health_reports_healthy(async_client: AsyncClient, test_store: InMemoryStore):
+    """Happy path: the probe answers 200 with the documented body."""
+    response = await async_client.get("/api/info/health/store")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["test_operation"] == "search"
+    assert body["message"] == "Store connection is working"
+    # `store_type` reflects whatever store was injected -- the in-memory double
+    # here, `AsyncPostgresStore` in production.
+    assert body["store_type"] == type(test_store).__name__
+
+
+@pytest.mark.asyncio
+async def test_store_health_does_not_enter_store_context(async_client: AsyncClient, override_store):
+    """Regression for #958: the probe must not re-enter the injected singleton.
+
+    This is the test that pins the fix. `RecordingStore` is a perfectly usable
+    async context manager, so the pre-fix handler enters it happily and still
+    returns 200 -- the failure it produces is `aenter_calls == 1`, which names
+    the actual defect. Post-fix both counters stay at zero.
+
+    Scope of the guard: it proves the handler does not enter *the instance it
+    was given*. It would not catch a handler that opened a fresh store from the
+    `get_store_db()` factory instead.
+    """
+    store = override_store(RecordingStore())
+
+    response = await async_client.get("/api/info/health/store")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "healthy"
+    assert store.aenter_calls == 0, "handler entered the app-wide singleton's context manager"
+    assert store.aexit_calls == 0, "handler exited the app-wide singleton's context manager"
+
+
+@pytest.mark.asyncio
+async def test_store_health_maps_search_failure_to_500(async_client: AsyncClient, override_store):
+    """A generic store failure surfaces as a 500 with the message passed through."""
+    override_store(FailingSearchStore())
+
+    response = await async_client.get("/api/info/health/store")
+
+    assert response.status_code == 500
+    assert "boom" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_store_health_maps_closed_connection_to_503(async_client: AsyncClient, override_store):
+    """FR-4: the "connection"/"closed" branch must keep mapping to 503, not 500.
+
+    Pins the branch the PRD explicitly forbids deleting as newly-dead code.
+    """
+    override_store(BrokenLinkStore())
+
+    response = await async_client.get("/api/info/health/store")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Store connection is closed - service unavailable"
+
+
+@pytest.mark.asyncio
+async def test_store_health_maps_timeout_to_503(async_client: AsyncClient, override_store):
+    """FR-2: a timed-out store operation is a 503, not a 500.
+
+    Exercises the `except asyncio.TimeoutError` branch. The literal 5.0s budget
+    is not asserted -- doing so would cost five seconds of suite time for a
+    constant.
+    """
+    override_store(TimingOutStore())
+
+    response = await async_client.get("/api/info/health/store")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Store connection timeout - service unavailable"


### PR DESCRIPTION
Fixes #958.

## What

`GET /api/info/health/store` entered the **application-wide singleton** store as an async context manager. `store` comes from `Depends(get_store)` → `req.app.state.store` (`backend/src/services/db.py:93-94`) — the single `AsyncPostgresStore` created once in the lifespan (`backend/main.py:89-102`). The handler did `async with store as s:`, running `__aenter__`/`__aexit__` on a resource whose lifecycle it does not own.

The probe meant to answer *"is the backend healthy?"* was manipulating the thing it measures.

It now awaits `store.asearch(("health_check",), limit=1)` on the injected instance directly, inside the same `async with asyncio.timeout(5.0)`.

**Nothing observable changes.** Response body byte-identical (`store_type` already read `type(store).__name__`, not `s`), the `asyncio.TimeoutError` → 503 branch untouched, and the `"connection"`/`"closed"` → 503 mapping deliberately **kept** — it guards genuine connection failures and is orthogonal to this fix, so it is not newly-dead code.

## Correcting the issue as filed

#958 says this "closes the app-wide pool permanently." **It does not** — verified against the installed package, not inferred:

- `AsyncPostgresStore.__aenter__` is a bare `return self` — `langgraph/store/postgres/aio.py:392-393`
- `__aexit__` only signals a TTL sweeper task — `aio.py:395-406`
- `_ttl_sweeper_task` is initialised to `None` (`aio.py:160`) and only ever assigned inside `start_ttl_sweeper` (`aio.py:354`), which this codebase **never calls**
- `get_store_db` (`backend/src/services/db.py:194-217`) passes no store-level `ttl=` to `from_conn_string`
- the pool is closed solely by `from_conn_string`'s own `async with`, which unwinds when the lifespan generator exits

(The `ttl=` arguments that *do* appear — `services/memory.py:15`, `repos/tool_repo.py:257` — are per-item expiries on `aput()`, a different thing from the store-level `TTLConfig` that starts the sweeper.)

So this is a **latent footgun, not an active outage**. A future `ttl=` config, or a langgraph release whose `__aexit__` releases resources, would have degraded the process-wide store silently — with no test to catch it. Pinned version is `langgraph-checkpoint-postgres` 3.1.0 (`backend/uv.lock:2069`).

## ⚠️ Scope: this is 1 of 3 re-entry sites

The plan asserted `health.py` was the only place the singleton gets re-entered. **Adversarial review found that claim to be false**, and it's worth flagging rather than quietly shipping:

| Site | Route | Auth |
|---|---|---|
| `routes/v0/info/health.py` | `GET /api/info/health/store` | public — **fixed here** |
| `services/assistant.py:227` (`search_public`) | `GET /assistants/public` | **unauthenticated** — not fixed |
| `services/assistant.py:294` (`_postgres_search`) | `POST /assistants/search` | authenticated — not fixed |
| `services/prompt/__init__.py:168` (`_postgres_search`) | prompt service paths | — not fixed |

The chain: `routes/v0/assistant.py` injects `store: AsyncPostgresStore = Depends(get_store)` (`:54`, `:59`, `:133`, …) → `AssistantService(store=store)` / `ServiceContext(..., store=store)` → `contexts/service.py:36-39` → `self.store = store` (`services/assistant.py:20`). At `assistant.py:224-227` an `isinstance(self.store, InMemoryStore)` guard sends the **production** `AsyncPostgresStore` into exactly the `async with` branch.

Those files were named in this task's out-of-scope list, so this PR leaves them alone rather than silently widening. **They want a follow-up issue** — `GET /assistants/public` is unauthenticated and takes more traffic than a diagnostic endpoint. Happy to file it or fold it in, reviewer's call.

## Tests

The endpoint had **zero** tests — which is how the pattern survived. `backend/tests/integration/test_health_store.py` adds five:

1. happy path → 200, full body asserted
2. **the one that pins the fix** — `RecordingStore` is a fully valid async context manager that simply *counts* `__aenter__`/`__aexit__`. The pre-fix handler enters it happily and still returns 200; the failure is `aenter_calls == 1` with the message `handler entered the app-wide singleton's context manager`. That names the actual defect instead of failing on an incidental "object is not a context manager" error.
3. generic `asearch` failure → 500 (fallback path)
4. `"connection"`/`"closed"` error → **503** — pins FR-4 so the branch can't be dropped as dead
5. `asyncio.TimeoutError` → **503**

**All five fail against the pre-fix handler, all five pass with it.** Verified by stashing the change and re-running.

One caveat worth knowing for future test authors, discovered while writing these: `app.dependency_overrides[get_store]` is **inert for this route**. Routes are registered on `api_app` and copied into `app` by reference (`main.py:126`), so each route's `dependency_overrides_provider` is `api_app` — the real `get_store` runs and reads `req.app.state.store`. Probed directly: with the override returning a sentinel string, the handler still served `app.state.store`. The fixture sets both apps and restores `app.state.store` on teardown.

## Verification

```
uvx ruff check backend/src/routes/v0/info/health.py backend/tests/integration/test_health_store.py  → All checks passed
uv run pytest                                                                                       → 797 passed, 2 skipped, 0 failed
```

Manual, against my own backend on `:8001` (port 8000 serves a different checkout):

```
$ curl -s localhost:8001/api/info/health/store
{"status":"healthy","store_type":"AsyncPostgresStore","test_operation":"search","message":"Store connection is working"}

$ for i in $(seq 1 20); do curl -so /dev/null -w "%{http_code} " localhost:8001/api/info/health/store; done
200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200

$ curl -s -X POST localhost:8001/api/auth/login -H 'Content-Type: application/json' -d '{"email":"admin@example.com","password":"test1234"}'
→ 200, token returned; /health/db shows checked_out 0
```

## Two things to flag

- **`make lint` is red on `development`, independently of this PR.** One pre-existing `E501` at `backend/tests/unit/controllers/test_llm_context_files.py:30` (121 > 120), and `ruff format --check` would also rewrite a fenced python block in `backend/tests/README.md`. Confirmed by stashing this branch's changes and running against a clean tree. Running `make format` as the contributor docs instruct auto-fixes both and would have put unrelated churn in this diff, so they're left alone — worth a separate cleanup. `.github/workflows/test.yml` runs no ruff step, so nothing is gated.
- **`CONTRIBUTING.md` says PRs target `main`**, which contradicts `origin/HEAD → origin/development`. This PR follows `development`; one of the two should be corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store health-check reliability by preventing unnecessary connection lifecycle interruptions.
  * Preserved existing timeout behavior and response mappings.
  * Health checks now consistently report successful, unavailable, and failed store states with the appropriate status codes.

* **Tests**
  * Added coverage for healthy responses, timeouts, unavailable connections, and unexpected store errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->