### PR TITLE
FROM task/978-organize-backend-environment TO development

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ For all commands, see `backend/Makefile`.
 
 1. **Environment Variables:**
 
+    See the [canonical environment-variable guide](./docs/environment-variables.md) for required values, optional defaults, and provider setup.
+
     Create a `.env` file in the root directory and add your API key(s):
 
     ```bash
@@ -307,6 +309,8 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 ```
 
 #### 1. Environment Setup
+
+See the [canonical environment-variable guide](./docs/environment-variables.md) before creating the deployment file.
 
 Create a `.env.docker` file in the `backend/` directory:
 

--- a/backend/.example.env
+++ b/backend/.example.env
@@ -1,71 +1,62 @@
-#########################################################
-## Application Config
-#########################################################
+# docs/environment-variables.md
+# REQUIRED FOR CURRENT APPLICATION
 APP_ENV=development
-APP_LOG_LEVEL="DEBUG"
-APP_SECRET_KEY=""
-JWT_SECRET_KEY=""
-USER_AGENT="ruska-dev"
-TEST_USER_ID=00000000-0000-0000-0000-000000000000
-
-#########################################################
-## Context Compaction (Message Summarization)
-#########################################################
-# Token threshold to trigger compaction (default: 170000)
-COMPACTION_TOKEN_THRESHOLD=170000
-# Number of recent messages to preserve during compaction (default: 6)
-COMPACTION_RECENT_MESSAGES=6
-
-#########################################################
-## Database Secrets
-#########################################################
+APP_SECRET_KEY=
+JWT_SECRET_KEY=
 POSTGRES_CONNECTION_STRING="postgresql://admin:test1234@localhost:5432/ruska_dev?sslmode=disable"
-
-#########################################################
-## AI Provider Caching
-#########################################################
-# Anthropic Prompt Cache TTL (valid: "5m" or "1h", default: "5m")
-# ANTHROPIC_PROMPT_CACHE_TTL=5m
-
-#########################################################
-## AI Providers (Model Secrets)
-#########################################################
 OPENAI_API_KEY=
-GROQ_API_KEY=
 ANTHROPIC_API_KEY=
-XAI_API_KEY=
-OLLAMA_BASE_URL=
-# AWS Bedrock (requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment)
-# Set this to your preferred AWS region to enable Bedrock models
-# AWS_BEDROCK_REGION=us-east-1
-
-#########################################################
-## Tool (Secretes and Config used by Agent Tools)
-#########################################################
-SEARX_SEARCH_HOST_URL="http://localhost:8080"
 SHELL_EXEC_SERVER_URL="http://localhost:3005/exec"
-TAVILY_API_KEY=
-EXA_API_KEY=
-
-#########################################################
-## Services (Enabled via docker containers)
-#########################################################
-## (Alpha)
-# PRESIDIO_ANALYZE_HOST=http://localhost:5002
-# PRESIDIO_ANONYMIZE_HOST=http://localhost:5001
-# PRESIDIO_API_KEY=
-
-#########################################################
-## Storage (Where images and other files can be stored)
-#########################################################
+SEARX_SEARCH_HOST_URL="http://localhost:8080"
 MINIO_HOST=
 S3_REGION=
 ACCESS_KEY_ID=
 ACCESS_SECRET_KEY=
 BUCKET=ruska_dev
-
-#########################################################
-## Distributed Workers (TaskIQ)
-#########################################################
 REDIS_URL=redis://localhost:6379/0
 DISTRIBUTED_WORKERS=false
+# OPTIONAL
+# APP_LOG_LEVEL=INFO
+# USER_AGENT=ruska-dev
+# TEST_USER_ID=00000000-0000-0000-0000-000000000000
+# COMPACTION_TOKEN_THRESHOLD=170000
+# COMPACTION_RECENT_MESSAGES=6
+# POSTGRES_CONNECTION_STRING_SESSION=
+# DB_POOL_MIN_SIZE=5
+# DB_POOL_MAX_SIZE=20
+# DB_POOL_MAX_IDLE_TIME=300
+# DB_POOL_MAX_LIFETIME=3600
+# DB_SQLA_POOL_SIZE=10
+# DB_SQLA_POOL_MAX_OVERFLOW=10
+# DB_SQLA_POOL_TIMEOUT=5
+# DB_SQLA_POOL_RECYCLE=1800
+# DB_KEEPALIVE_IDLE=60
+# DB_KEEPALIVE_INTERVAL=15
+# DB_KEEPALIVE_COUNT=4
+# CHECKPOINT_MAX_RETRIES=3
+# CHECKPOINT_RETRY_DELAY=1.0
+# CHECKPOINT_MAX_DELAY=30.0
+# CHECKPOINT_JITTER=0.1
+# CHECKPOINT_HEALTH_CHECK_INTERVAL=30
+# CHECKPOINT_USE_RESILIENT=false
+# CHECKPOINT_ENABLE_FALLBACK=false
+# GROQ_API_KEY=
+# XAI_API_KEY=
+# GEMINI_API_KEY=
+# GOOGLE_API_KEY=
+# OLLAMA_BASE_URL=
+# AWS_BEARER_TOKEN_BEDROCK=
+# AWS_BEDROCK_REGION=us-east-1
+# TAVILY_API_KEY=
+# EXA_API_KEY=
+# ARCADE_API_KEY=
+# LANGCONNECT_SERVER_URL=
+# DAYTONA_API_KEY=
+# MCP_SANDBOX_API_KEY=
+# PRESIDIO_ANALYZE_HOST=http://localhost:5002
+# PRESIDIO_ANONYMIZE_HOST=http://localhost:5001
+# PRESIDIO_API_KEY=
+# AIRTABLE_API_KEY=
+# AIRTABLE_BASE_ID=app6sU4AprV9uZze6
+# AIRTABLE_TABLE_ID=Contacts
+# MICROSOFT_TEAMS_WEBHOOK_URL=

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,6 +73,8 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 
 1. **Environment Variables:**
 
+    See the [canonical environment-variable guide](../docs/environment-variables.md) for required values, optional defaults, and provider setup.
+
     Create a `.env` file in the root directory and add your API key(s):
 
     ```bash
@@ -236,6 +238,8 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 
 #### 1. Environment Setup
 
+See the [canonical environment-variable guide](../docs/environment-variables.md) before creating the deployment file.
+
 Create a `.env.docker` file in the `backend/` directory:
 
 ```bash
@@ -337,6 +341,8 @@ docker build -t orchestra:local -f infra/backend.Dockerfile backend
 ```
 
 ### ⚙️ Environment Variables
+
+See the [canonical environment-variable guide](../docs/environment-variables.md). The table below is retained as a quick reference.
 
 #### Application Config
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,134 @@
+# Environment variables
+
+This is the canonical environment-variable reference for Orchestra. The
+tracked template is `backend/.example.env` and follows one order:
+
+1. values required by the current API/worker stack are active at the top;
+2. code-default tuning, alternate integrations, and test-only values are
+   commented in the bottom `OPTIONAL` section.
+
+Copy the template to the configured user-local file:
+
+```bash
+mkdir -p ~/.config/orchestra
+cp backend/.example.env ~/.config/orchestra/.env
+```
+
+For tests, copy it to `~/.config/orchestra/.env.test` and use
+`ENV_FILE=~/.config/orchestra/.env.test make -C backend test`. Docker Compose
+loads `~/.config/orchestra/.env` and overrides service-only hostnames such as
+Postgres, Redis, and SearXNG inside `infra/docker-compose.yml`.
+
+## Required configuration
+
+### Application and database
+
+| Variable | Configuration |
+|---|---|
+| `APP_ENV` | Current environment name; use `development` locally and `production` in a deployed service. |
+| `APP_SECRET_KEY` | Fernet key for encrypted user/provider settings. Generate a URL-safe 32-byte key with `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`. |
+| `JWT_SECRET_KEY` | Long random signing key for API tokens. Generate with `openssl rand -hex 32`. |
+| `POSTGRES_CONNECTION_STRING` | Required Postgres URL. Local Compose uses `postgresql://admin:test1234@postgres:5432/lg_template_dev`; host-run development can use the `localhost` URL in the template. |
+
+Never use the insecure code fallback for either application secret in a
+shared or deployed environment.
+
+### Agent execution
+
+At least one model provider must be configured for agent execution. The
+current template keeps the two primary providers active so the requirement is
+visible; fill one or both:
+
+| Variable | Configuration |
+|---|---|
+| `OPENAI_API_KEY` | API key from <https://platform.openai.com/api-keys>. |
+| `ANTHROPIC_API_KEY` | API key from <https://console.anthropic.com/settings/keys>. |
+
+### Current tool and service dependencies
+
+| Variable | Configuration |
+|---|---|
+| `SHELL_EXEC_SERVER_URL` | Shell-execution service origin, normally `http://localhost:3005/exec` for the current local stack. |
+| `SEARX_SEARCH_HOST_URL` | SearXNG origin, normally `http://localhost:8080` locally and `http://search_engine:8080` in Compose. |
+| `MINIO_HOST` | MinIO endpoint when using the current local storage service; leave blank only when using an HTTPS S3 endpoint. |
+| `S3_REGION` | Region used by the storage client. |
+| `ACCESS_KEY_ID` | S3/MinIO access key. |
+| `ACCESS_SECRET_KEY` | S3/MinIO secret key. |
+| `BUCKET` | Current object-storage bucket name. Create it before using upload routes. |
+| `REDIS_URL` | Redis URL used by cache, abort, and TaskIQ paths. |
+| `DISTRIBUTED_WORKERS` | Current worker-mode flag. Keep it explicit; Compose sets it to `true` for the app/worker pair. |
+
+For a local Docker stack, use the credentials configured in
+`infra/docker-compose.yml` for MinIO and the service hostnames documented in
+that file. Do not commit real credentials.
+
+## Optional configuration
+
+These values have safe code defaults or enable an alternate integration. Keep
+them commented unless the deployment has an explicit reason to override the
+default.
+
+### Defaulted runtime and database tuning
+
+```dotenv
+# APP_LOG_LEVEL=INFO
+# USER_AGENT=ruska-dev
+# COMPACTION_TOKEN_THRESHOLD=170000
+# COMPACTION_RECENT_MESSAGES=6
+# POSTGRES_CONNECTION_STRING_SESSION=
+# DB_POOL_MIN_SIZE=5
+# DB_POOL_MAX_SIZE=20
+# DB_POOL_MAX_IDLE_TIME=300
+# DB_POOL_MAX_LIFETIME=3600
+# DB_SQLA_POOL_SIZE=10
+# DB_SQLA_POOL_MAX_OVERFLOW=10
+# DB_SQLA_POOL_TIMEOUT=5
+# DB_SQLA_POOL_RECYCLE=1800
+# DB_KEEPALIVE_IDLE=60
+# DB_KEEPALIVE_INTERVAL=15
+# DB_KEEPALIVE_COUNT=4
+# CHECKPOINT_MAX_RETRIES=3
+# CHECKPOINT_RETRY_DELAY=1.0
+# CHECKPOINT_MAX_DELAY=30.0
+# CHECKPOINT_JITTER=0.1
+# CHECKPOINT_HEALTH_CHECK_INTERVAL=30
+# CHECKPOINT_USE_RESILIENT=false
+# CHECKPOINT_ENABLE_FALLBACK=false
+```
+
+### Optional providers and integrations
+
+```dotenv
+# GROQ_API_KEY=
+# XAI_API_KEY=
+# GEMINI_API_KEY=
+# GOOGLE_API_KEY=
+# OLLAMA_BASE_URL=
+# AWS_BEARER_TOKEN_BEDROCK=
+# AWS_BEDROCK_REGION=us-east-1
+# TAVILY_API_KEY=
+# EXA_API_KEY=
+# ARCADE_API_KEY=
+# LANGCONNECT_SERVER_URL=
+# DAYTONA_API_KEY=
+# MCP_SANDBOX_API_KEY=
+# PRESIDIO_ANALYZE_HOST=http://localhost:5002
+# PRESIDIO_ANONYMIZE_HOST=http://localhost:5001
+# PRESIDIO_API_KEY=
+# AIRTABLE_API_KEY=
+# AIRTABLE_BASE_ID=app6sU4AprV9uZze6
+# AIRTABLE_TABLE_ID=Contacts
+# MICROSOFT_TEAMS_WEBHOOK_URL=
+# TEST_USER_ID=00000000-0000-0000-0000-000000000000
+```
+
+Search works with the current SearXNG service; add Tavily or Exa only when
+needed. Airtable and Teams are best-effort integrations. Storage credentials
+are active because the current API exposes storage routes; use the optional
+provider values only when switching the backing service.
+
+## Secret handling
+
+Keep real values under `~/.config/orchestra/` or the deployment secret store.
+Never commit `.env` files, provider keys, database passwords, MinIO credentials,
+or application signing keys.

--- a/infra/README.md
+++ b/infra/README.md
@@ -72,6 +72,8 @@ docker pull ghcr.io/ruska-ai/orchestra:latest
 
 ### 1. Environment Setup
 
+See the [canonical environment-variable guide](../docs/environment-variables.md) before creating the deployment file.
+
 Create a `.env.docker` file in the `backend/` directory:
 
 ```bash
@@ -175,6 +177,8 @@ docker build -t orchestra:local -f infra/backend.Dockerfile backend
 ```
 
 ## ⚙️ Environment Variables
+
+See the [canonical environment-variable guide](../docs/environment-variables.md). The table below is retained as a quick reference.
 
 ### Application Config
 


### PR DESCRIPTION
Closes #978

Organizes the backend environment template into active required values first and commented optional defaults/integrations last. Adds the canonical environment-variable guide and links the existing setup docs.

Verification:
- Template ordering and git diff checks pass.
- Full backend tests require the unavailable local Postgres service at localhost:5432; no assertion failure was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centralized environment-variable reference covering required settings, optional configuration, integrations, storage, workers, and secret handling.
  * Linked the reference guide from local development, Docker setup, and environment-variable documentation.
  * Clarified the example environment file by separating required settings from optional configuration.
  * Expanded the documented configuration options for databases, AI providers, tools, services, and runtime tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->