### PR TITLE
FROM feat/980-registry-vm-deploy TO development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/.env*
+/deploy/searxng/settings.yml
+/deploy/orchestra.env
 **/.venv
 **/data/
 **/sandbox/graphs/*

--- a/.oh/tasks/980-registry-vm-deploy/evidence.md
+++ b/.oh/tasks/980-registry-vm-deploy/evidence.md
@@ -1,0 +1,81 @@
+# Evidence — 980-registry-vm-deploy
+
+- **PR**: [#981](https://github.com/mifunedev/orchestra/pull/981) (`mifunedev/orchestra`, base `development`) · **Branch**: `feat/980-registry-vm-deploy`
+- **Audit run**: `audit-20260809T202321Z-2021491` · **Verdict**: `PR-AUDIT-PROMOTABLE`
+
+## What was broken, and what now holds
+
+Orchestra had development-only Docker infrastructure and no production registry Compose entry point. The new `deploy/docker-compose.yml` resolves to API and worker registry services only; the explicitly named database overlay adds private dependency services, while the Ollama service remains profile-gated. The branch is clean and mergeable against the current `development` head, CI is green, and the PR remains intentionally draft-only.
+
+## Proof by gate
+
+| Gate | What was checked | Observed | Result |
+|------|------------------|----------|--------|
+| Task graph | No PRD/task graph was supplied for this deployment request | N/A — acceptance was tracked directly in the issue and PR | N/A |
+| Deployment static validation | YAML parse plus assertions for service sets, no builds, loopback API binding, private dependency ports, profile gating, dependency conditions, image tags, and SearXNG settings | `deployment static validation: PASS` | PASS |
+| Python/config checks | Fernet recipe validation, backend syntax compilation, and diff whitespace check | `Fernet generation recipe: PASS`; `python syntax check: PASS`; `branch diff check: PASS` | PASS |
+| Regression / CI | GitHub Actions workflow for PR head `bfdee05a` | `test-backend success`; `test-frontend success`; `test-e2e skipped` | PASS |
+| PR audit | `pr-acquire.sh` + `pr-classify.sh`, correlated to the run above | `CI PASS`, `mergeable MERGEABLE`, `mergeStateStatus CLEAN`, `evidenceComplete true`, `promotable true` | PASS |
+| VM runtime | Pull/start/health smoke test | Not run from this sandbox per operator instruction not to manage Docker here | N/A |
+
+## Observed output
+
+```text
+$ backend/.venv/bin/python - <<'PY'  # deployment assertions
+...
+PY
+ deployment static validation: PASS
+
+$ backend/.venv/bin/python -m compileall -q backend/src/utils/security.py
+python syntax check: PASS
+
+$ git diff origin/development..HEAD --check
+branch diff check: PASS
+```
+
+```text
+$ gh run view 31334017466 --repo mifunedev/orchestra --json status,conclusion,jobs
+{"conclusion":"success","jobs":[{"conclusion":"success","name":"test-backend","status":"completed"},{"conclusion":"success","name":"test-frontend","status":"completed"},{"conclusion":"skipped","name":"test-e2e","status":"completed"}],"status":"completed"}
+```
+
+```text
+$ git log --format='%h %G? %s' -3
+bfdee05a G Merge origin/development into feat/980-registry-vm-deploy
+23716b1d G fix: document Fernet key generation
+fb31a2ff G fix: clarify overlay secret encoding
+```
+
+```text
+$ .oh/skills/audit/scripts/audit-run.sh pr 981 --repo mifunedev/orchestra --base development -- .oh/skills/audit/scripts/route-driver.sh
+Run: audit-20260809T202321Z-2021491
+Acquisition: pr-acquire.sh exit 0, schema v1 envelope, evidence intact
+Classification: pr-classify.sh exit 0
+CI: PASS
+mergeable: MERGEABLE
+mergeStateStatus: CLEAN
+primary state: draft
+readyForReview: true
+readyToMerge: false
+evidenceComplete: true
+promotable: true
+AUDIT-EVIDENCE: PR-AUDIT-PROMOTABLE
+```
+
+## Acceptance criteria → proof
+
+| Criterion | Proof |
+|-----------|-------|
+| Base Compose contains API and worker only | Static validation assertion and `deploy/docker-compose.yml` |
+| Dependency overlay is explicit and disabled by default | Separate `deploy/docker-compose.database.yml`; base service-set assertion |
+| Ollama is separately opt-in | `profiles: [ollama]` assertion and overlay profile runbook |
+| API is loopback-only and dependencies have no host ports | Static port assertions; `deploy/docker-compose.yml` and `deploy/docker-compose.database.yml` |
+| Production secrets use ignored runtime files/templates | `deploy/.example.env`, `.gitignore`, and tracked SearXNG example without a usable secret |
+| Existing deployment workflows and development compose remain unchanged | Current PR diff has no paths under `.github/workflows/` or `infra/` relative to `origin/development` |
+| Draft PR is delivered against `development` | PR #981 title/base/head and final PR audit |
+
+## Gaps and non-gating findings
+
+- `readyToMerge: false` is expected because the requested completion gate is a draft PR; the PR was not marked ready and was not merged.
+- The repository's E2E job is skipped by workflow configuration.
+- `pre-commit` was unavailable in the current environment (`pre-commit: command not found`); no matching pre-commit hooks target the changed deploy/docs paths.
+- VM pull/start/log/health smoke testing remains an operator-side step because Docker management was explicitly excluded from this sandbox session.

--- a/.oh/tasks/980-registry-vm-deploy/evidence.md
+++ b/.oh/tasks/980-registry-vm-deploy/evidence.md
@@ -1,7 +1,7 @@
 # Evidence — 980-registry-vm-deploy
 
 - **PR**: [#981](https://github.com/mifunedev/orchestra/pull/981) (`mifunedev/orchestra`, base `development`) · **Branch**: `feat/980-registry-vm-deploy`
-- **Audit run**: `audit-20260809T202321Z-2021491` · **Verdict**: `PR-AUDIT-PROMOTABLE`
+- **Audit run**: `audit-20260809T202733Z-2030602` · **Verdict**: `PR-AUDIT-PROMOTABLE`
 
 ## What was broken, and what now holds
 
@@ -14,7 +14,7 @@ Orchestra had development-only Docker infrastructure and no production registry 
 | Task graph | No PRD/task graph was supplied for this deployment request | N/A — acceptance was tracked directly in the issue and PR | N/A |
 | Deployment static validation | YAML parse plus assertions for service sets, no builds, loopback API binding, private dependency ports, profile gating, dependency conditions, image tags, and SearXNG settings | `deployment static validation: PASS` | PASS |
 | Python/config checks | Fernet recipe validation, backend syntax compilation, and diff whitespace check | `Fernet generation recipe: PASS`; `python syntax check: PASS`; `branch diff check: PASS` | PASS |
-| Regression / CI | GitHub Actions workflow for PR head `bfdee05a` | `test-backend success`; `test-frontend success`; `test-e2e skipped` | PASS |
+| Regression / CI | GitHub Actions workflow 31334194103 for PR head `fb0b482f` | `test-backend success`; `test-frontend success`; `test-e2e skipped` | PASS |
 | PR audit | `pr-acquire.sh` + `pr-classify.sh`, correlated to the run above | `CI PASS`, `mergeable MERGEABLE`, `mergeStateStatus CLEAN`, `evidenceComplete true`, `promotable true` | PASS |
 | VM runtime | Pull/start/health smoke test | Not run from this sandbox per operator instruction not to manage Docker here | N/A |
 
@@ -34,12 +34,13 @@ branch diff check: PASS
 ```
 
 ```text
-$ gh run view 31334017466 --repo mifunedev/orchestra --json status,conclusion,jobs
+$ gh run view 31334194103 --repo mifunedev/orchestra --json status,conclusion,jobs
 {"conclusion":"success","jobs":[{"conclusion":"success","name":"test-backend","status":"completed"},{"conclusion":"success","name":"test-frontend","status":"completed"},{"conclusion":"skipped","name":"test-e2e","status":"completed"}],"status":"completed"}
 ```
 
 ```text
-$ git log --format='%h %G? %s' -3
+$ git log --format='%h %G? %s' -4
+fb0b482f G audit: record deployment PR evidence
 bfdee05a G Merge origin/development into feat/980-registry-vm-deploy
 23716b1d G fix: document Fernet key generation
 fb31a2ff G fix: clarify overlay secret encoding
@@ -47,7 +48,7 @@ fb31a2ff G fix: clarify overlay secret encoding
 
 ```text
 $ .oh/skills/audit/scripts/audit-run.sh pr 981 --repo mifunedev/orchestra --base development -- .oh/skills/audit/scripts/route-driver.sh
-Run: audit-20260809T202321Z-2021491
+Run: audit-20260809T202733Z-2030602
 Acquisition: pr-acquire.sh exit 0, schema v1 envelope, evidence intact
 Classification: pr-classify.sh exit 0
 CI: PASS

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: `YYYY.M.D` (date-based, e.g. `2026.2.22`). Multiple releases per day use `-N` suffix (e.g. `2026.2.22-2`).
 
+## 2026.8.9
+
+### Added
+  - task/980-registry-vm-deploy (#980) — add a registry-only production base stack for the GHCR API and worker images, plus an explicit private-database overlay for Postgres/pgvector, Redis, MinIO, SearXNG, and an opt-in Ollama profile. Document VM prerequisites, GHCR authentication, secret handling, migrations, health checks, lifecycle, and backup cautions.
+
 ## 2026.8.7
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Generate signing keys, for example. `APP_SECRET_KEY` is a Fernet key, while
 `JWT_SECRET_KEY` can be any long random signing value:
 
 ```bash
-python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'  # APP_SECRET_KEY
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '\n'                                # APP_SECRET_KEY (Fernet)
 openssl rand -hex 32                                                                         # JWT_SECRET_KEY
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Self-host for free or let us deploy it for you. Your agents, your data, your inf
 
 | Option | Best For | Get Started |
 |--------|----------|-------------|
-| **Community (Free)** | Developers, self-hosting | `docker pull ghcr.io/ruska-ai/orchestra:latest` |
+| **Community (Free)** | Developers, self-hosting | `docker pull ghcr.io/ruska-ai/orchestra-api:latest` |
 | **Managed Cloud** | Teams wanting convenience | [chat.ruska.ai](https://chat.ruska.ai) |
 | **Enterprise** | Organizations needing SSO, compliance, SLA | [Contact Us](https://ruska.ai/enterprise) |
 
@@ -58,10 +58,11 @@ This project includes tools for running shell commands and Docker container oper
 
 ## 🐳 Docker Deployment (GHCR)
 
-We publish the backend image to GitHub Container Registry (GHCR). For the full Docker/Docker Compose deployment guide (env setup, services, migrations, troubleshooting), jump to [Docker Deployment details](#-docker-deployment-ghcr--docker-compose).
+We publish separate API and worker images to GitHub Container Registry (GHCR). For the full Docker/Docker Compose deployment guide (env setup, services, migrations, troubleshooting), jump to [Docker Deployment details](#-docker-deployment-ghcr--docker-compose).
 
 ```bash
-docker pull ghcr.io/ruska-ai/orchestra:latest
+docker pull ghcr.io/ruska-ai/orchestra-api:latest
+docker pull ghcr.io/ruska-ai/orchestra-worker:latest
 ```
 
 ## 📋 Prerequisites
@@ -107,7 +108,7 @@ For all commands, see `backend/Makefile`.
 
     ```bash
     cd <project-root>
-    docker compose up postgres
+    docker compose -f infra/docker-compose.yml up postgres
     ```
 
 ### Dockerized Dev Stack
@@ -288,248 +289,198 @@ We partner with you to deploy Orchestra inside your infrastructure. [Contact us]
 
 ## 🐳 Docker Deployment (GHCR / Docker Compose)
 
-This section covers deploying the Orchestra backend using Docker. For local development, see the sections above.
+This section covers the production registry deployment. For local development, use
+`infra/docker-compose.yml`; it is intentionally separate from the production files.
+The production files are self-contained under `deploy/` and never build images.
 
-### 📋 Prerequisites
+### 📋 VM prerequisites
 
--   [Docker](https://docs.docker.com/engine/install/) installed
--   [Docker Compose](https://docs.docker.com/compose/install/) installed
--   Access to AI provider API keys (OpenAI, Anthropic, etc.)
+Use a supported Linux VM with:
 
-### 🚀 Quick Start
+- [Docker Engine](https://docs.docker.com/engine/install/) and the Compose v2 plugin
+- At least 2 vCPUs, 4 GB RAM, and persistent disk sized for Postgres, MinIO, and logs
+- A firewall that permits SSH and your TLS reverse proxy, but not database, Redis,
+  MinIO, SearXNG, or Ollama ports
+- A DNS name and TLS termination in front of the API if it will be internet-facing
 
-#### Using Pre-built Image
+### 🔐 GHCR and environment setup
 
-Pull the latest image from GitHub Container Registry:
-
-```bash
-docker pull ghcr.io/ruska-ai/orchestra:latest
-```
-
-#### 1. Environment Setup
-
-Create a `.env.docker` file in the `backend/` directory:
+The images are private registry images in some deployments. Authenticate on the VM
+with a GitHub token that has `read:packages` (do not put the token in a committed file):
 
 ```bash
-cd backend
-cp .example.env .env.docker
+export GHCR_USERNAME=your-github-user
+read -rsp 'GHCR token: ' GHCR_TOKEN; echo
+echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+unset GHCR_TOKEN
 ```
 
-Update the following values for Docker networking:
+Create the ignored runtime env file from the tracked production template. Replace
+all `replace-with-*` values, use URL-safe database credentials when the overlay will
+construct a connection URL, and never commit the copied file:
 
 ```bash
-# Database - use container name instead of localhost
-POSTGRES_CONNECTION_STRING="postgresql://admin:test1234@postgres:5432/orchestra?sslmode=disable"
-
-# Tools - use container names for internal services
-SEARX_SEARCH_HOST_URL="http://search_engine:8080"
+cp deploy/.example.env deploy/orchestra.env
+chmod 600 deploy/orchestra.env
+# Edit deploy/orchestra.env with strong keys, service URLs, and at least one model provider key.
 ```
 
-#### 2. Start Services
-
-From the project root directory:
+Generate signing keys, for example. `APP_SECRET_KEY` is a Fernet key, while
+`JWT_SECRET_KEY` can be any long random signing value:
 
 ```bash
-# Start database and backend
-docker compose up postgres orchestra
-
-# Or start all services
-docker compose up
+python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'  # APP_SECRET_KEY
+openssl rand -hex 32                                                                         # JWT_SECRET_KEY
 ```
 
-#### 3. Verify Deployment
+### 🚀 Base-only deployment (external dependencies)
 
-The API will be available at `http://localhost:8000`
-
--   API Docs: `http://localhost:8000/docs`
--   Health Check: `http://localhost:8000/health`
-
-### 🧩 Docker Compose Services
-
-| Service         | Port      | Description                        |
-| --------------- | --------- | ---------------------------------- |
-| `orchestra`     | 8000      | Backend API                        |
-| `postgres`      | 5432      | PostgreSQL with pgvector           |
-| `minio`         | 9000/9001 | S3-compatible file storage         |
-| `search_engine` | 8080      | SearXNG search engine              |
-| `ollama`        | 11434     | Local LLM inference (requires GPU) |
-| `redis`         | 6379      | Redis message broker (for workers) |
-| `worker`        | -         | TaskIQ worker (no exposed port)    |
-
-### 🧱 Docker Compose Example
-
-```yaml
-services:
-    # PGVector
-    postgres:
-        image: pgvector/pgvector:pg16
-        container_name: postgres
-        environment:
-            POSTGRES_USER: admin
-            POSTGRES_PASSWORD: test1234
-            POSTGRES_DB: postgres
-        ports:
-            - "5432:5432"
-
-    # Server (use pre-built image or build locally)
-    orchestra:
-        image: ghcr.io/ruska-ai/orchestra:latest
-        container_name: orchestra
-        env_file: .env.docker
-        ports:
-            - "8000:8000"
-        depends_on:
-            - postgres
-```
-
-### 🏗️ Build Commands
-
-#### Build with Script (Recommended)
-
-The build script copies the Docker deployment README into the image and handles tagging:
+The base stack contains only the registry API and worker images. It does not start
+Postgres, Redis, MinIO, SearXNG, or Ollama, so all dependency URLs can point to
+managed or separately operated services. `ORCHESTRA_IMAGE_TAG` defaults to `latest` and the
+API binds only to loopback; put a reverse proxy in front of it when remote access is
+needed.
 
 ```bash
-# From project root
+cd /path/to/orchestra
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml up -d
+
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml ps
+curl --fail "http://$(docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml port api 8000)/api/info/health"
+```
+
+For a release tag, set `ORCHESTRA_IMAGE_TAG=your-tag` in the runtime environment.
+Production startup runs migrations automatically. If you need a separate migration
+step, use the entrypoint override below before routing traffic:
+
+```bash
+# Production startup runs Alembic automatically. To run it explicitly without
+# starting the API entrypoint, override the image entrypoint:
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml run --rm --no-deps --entrypoint python api \
+  -m alembic upgrade head
+```
+
+### 🧩 Explicit database overlay
+
+The database overlay is opt-in. It adds private-network-only Postgres with pgvector,
+Redis, MinIO, and SearXNG, and overrides API/worker URLs and dependency ordering to
+use the Compose service names. It also runs an idempotent MinIO bucket initializer.
+It does not load merely because it is next to the base file; always pass both files explicitly:
+
+```bash
+mkdir -p deploy/searxng
+cp deploy/searxng/settings.example.yml deploy/searxng/settings.yml
+sed -i "s/REPLACE_WITH_A_RANDOM_SECRET/$(openssl rand -hex 32)/" \
+  deploy/searxng/settings.yml
+chmod 600 deploy/searxng/settings.yml
+
+# Replace the overlay credentials in deploy/orchestra.env first. The template includes
+# ORCHESTRA_POSTGRES_PASSWORD, ORCHESTRA_REDIS_PASSWORD,
+# ORCHESTRA_MINIO_ROOT_USER, and ORCHESTRA_MINIO_ROOT_PASSWORD.
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml up -d
+
+# Production startup runs Alembic automatically. To run it explicitly:
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  run --rm --no-deps --entrypoint python api -m alembic upgrade head
+```
+
+Dependency ports are not published to the VM host. SearXNG has API and JSON enabled
+but is reachable only by the API and worker on the private Compose network. The
+tracked `settings.example.yml` is non-debug and contains no usable secret; generate
+and keep the ignored `deploy/searxng/settings.yml` on the VM.
+
+### 🦙 Optional Ollama profile
+
+Ollama is in the database overlay but has its own `ollama` profile. Enabling the
+database overlay alone does not require a GPU or download a model. To use local
+inference, set `ORCHESTRA_OLLAMA_BASE_URL=http://ollama:11434` in
+`deploy/orchestra.env`, then start the profile:
+
+```bash
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  --profile ollama up -d
+
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  exec ollama ollama pull llama3.2
+```
+
+The profile uses the standard `ollama serve` command and persists models in the
+`ollama_data` volume. Configure a suitable CPU/GPU VM separately; model downloads
+are intentionally an explicit operator action. For production updates, set an
+immutable `ORCHESTRA_IMAGE_TAG` and pull before recreating the API and worker:
+`docker compose ... pull api worker` followed by `docker compose ... up -d --pull always`.
+
+### ✅ Health checks and lifecycle
+
+Inspect health and logs with the same file list used to start the stack:
+
+```bash
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml ps
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml logs --tail=100 api worker
+```
+
+Use `docker compose stop` for a temporary pause and `docker compose start` to resume.
+Use `docker compose down` to remove containers and the network while retaining named
+volumes. Do not use `down -v` unless you intentionally want to destroy application
+data. Back up Postgres (including pgvector data), MinIO buckets, and the runtime
+SearXNG settings before VM replacement or any volume cleanup; test restores before
+calling a backup usable.
+
+### 🛠️ Custom image builds (development)
+
+The production deployment consumes the tagged GHCR images and never builds on the VM.
+For local development or a custom image, use the existing build script or Dockerfile:
+
+```bash
 bash backend/scripts/build.sh
-
-# Or with custom tag
-bash backend/scripts/build.sh v1.0.0
-```
-
-#### Build with Docker Compose
-
-```bash
-docker compose build orchestra
-```
-
-#### Manual Build
-
-```bash
-# Copy README first, then build (Dockerfile lives in infra/)
+# Or build a local API image directly:
 cp infra/README.md backend/README.md
 docker build -t orchestra:local -f infra/backend.Dockerfile backend
 ```
 
-### ⚙️ Environment Variables
+The Dockerized development stack remains `infra/docker-compose.yml`; it is separate
+from the production files under `deploy/`.
 
-#### Application Config
+### ⚙️ Environment reference
 
-| Variable         | Description                          | Default       |
-| ---------------- | ------------------------------------ | ------------- |
-| `APP_ENV`        | Environment (development/production) | `development` |
-| `APP_LOG_LEVEL`  | Logging level                        | `DEBUG`       |
-| `APP_SECRET_KEY` | Application secret key               | -             |
-| `JWT_SECRET_KEY` | JWT signing key                      | -             |
-| `USER_AGENT`     | User agent string for requests       | `ruska-dev`    |
-| `TEST_USER_ID`   | Test user UUID                       | -             |
+The tracked `deploy/.example.env` is the production-oriented starting point. The
+[canonical environment-variable guide](./docs/environment-variables.md) remains the
+source of truth for provider and application settings.
 
-#### Database
-
-| Variable                     | Description                  | Default |
-| ---------------------------- | ---------------------------- | ------- |
-| `POSTGRES_CONNECTION_STRING` | PostgreSQL connection string | -       |
-
-#### AI Providers (at least one required)
-
-| Variable            | Description       | Default |
-| ------------------- | ----------------- | ------- |
-| `OPENAI_API_KEY`    | OpenAI API key    | -       |
-| `GROQ_API_KEY`      | Groq API key      | -       |
-| `ANTHROPIC_API_KEY` | Anthropic API key | -       |
-| `XAI_API_KEY`       | xAI API key       | -       |
-| `OLLAMA_BASE_URL`   | Ollama server URL | -       |
-
-#### Tool Config
-
-| Variable                | Description              | Default                      |
-| ----------------------- | ------------------------ | ---------------------------- |
-| `SEARX_SEARCH_HOST_URL` | SearXNG search endpoint  | `http://localhost:8080`      |
-| `TAVILY_API_KEY`        | Tavily search API key    | -                            |
-
-#### Distributed Workers (Optional)
-
-| Variable              | Description                    | Default |
-| --------------------- | ------------------------------ | ------- |
-| `REDIS_URL`           | Redis connection for task queue | -       |
-| `DISTRIBUTED_WORKERS` | Enable distributed worker mode | `false` |
-
-> **Note**: When enabled, run the worker process separately: `make dev.worker`
-
-#### Storage
-
-| Variable            | Description       | Default    |
-| ------------------- | ----------------- | ---------- |
-| `MINIO_HOST`        | MinIO/S3 host URL | -          |
-| `S3_REGION`         | S3 region         | -          |
-| `ACCESS_KEY_ID`     | S3 access key     | -          |
-| `ACCESS_SECRET_KEY` | S3 secret key     | -          |
-| `BUCKET`            | S3 bucket name    | `enso_dev` |
-
-### 🗄️ Database Migrations
-
-Run migrations inside the container:
-
-```bash
-# Using docker compose exec
-docker compose exec orchestra alembic upgrade head
-
-# Or run migrations before starting
-docker compose run --rm orchestra alembic upgrade head
-```
-
-### 🚢 Production Considerations
-
-#### Security
-
--   Generate strong values for `APP_SECRET_KEY` and `JWT_SECRET_KEY`
--   Use SSL/TLS termination (nginx, traefik, etc.)
--   Restrict database access to internal networks
--   Never expose `.env` files
-
-#### Performance
-
--   Configure appropriate resource limits in `docker-compose.yml`
--   Use a reverse proxy for load balancing
--   Enable PostgreSQL connection pooling for high traffic
-
-#### Dockerfile Features
-
-The Dockerfile uses a multi-stage build:
-
-1. **Builder Stage**: Installs dependencies, compiles Python to bytecode (`.pyc`)
-2. **Runtime Stage**: Ships only compiled bytecode for smaller image size
-
-> **Note**: Migration files (`.py`) are preserved since Alembic requires source files.
+| Variable | Production role |
+|----------|-----------------|
+| `APP_ENV` | Set to `production` to run startup migrations |
+| `APP_SECRET_KEY` | Fernet key for encrypted application values |
+| `JWT_SECRET_KEY` | JWT signing key |
+| `POSTGRES_CONNECTION_STRING` | External PostgreSQL URL in base-only mode |
+| `REDIS_URL` | External Redis URL in base-only mode |
+| `MINIO_HOST` / `ACCESS_KEY_ID` / `ACCESS_SECRET_KEY` / `BUCKET` | External S3-compatible storage in base-only mode |
+| `SEARX_SEARCH_HOST_URL` | External SearXNG URL in base-only mode |
+| `DISTRIBUTED_WORKERS` | Enabled by the production API/worker stack |
+| `ORCHESTRA_*` | Credentials and service settings for the explicit dependency overlay |
 
 ### 🧰 Troubleshooting
 
-#### Container won't start
-
 ```bash
-# Check logs
-docker compose logs orchestra
+# Inspect the production services and recent logs
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml ps
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml logs --tail=100 api worker
 
-# Verify environment file exists
-ls -la backend/.env.docker
+# Verify the loopback health endpoint
+curl --fail "http://$(docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml port api 8000)/api/info/health"
 ```
 
-#### Database connection failed
-
-```bash
-# Ensure postgres is running
-docker compose ps postgres
-
-# Check postgres logs
-docker compose logs postgres
-```
-
-#### Port already in use
-
-```bash
-# Check what's using the port
-lsof -i :8000
-
-# Or change the port mapping in docker-compose.yml
-ports:
-  - "8001:8000"  # Map to different host port
-```
+For application configuration details, see the [environment-variable guide](./docs/environment-variables.md).

--- a/deploy/.example.env
+++ b/deploy/.example.env
@@ -39,8 +39,8 @@ XAI_API_KEY=
 AWS_BEARER_TOKEN_BEDROCK=
 AWS_BEDROCK_REGION=us-east-1
 
-# Database overlay credentials. Use URL-safe characters in the Postgres password
-# because the overlay builds a PostgreSQL URL from it.
+# Database overlay credentials. Use URL-safe characters in the Postgres and Redis
+# passwords because the overlay embeds them in service URLs.
 ORCHESTRA_POSTGRES_USER=orchestra
 ORCHESTRA_POSTGRES_PASSWORD=replace-with-url-safe-password
 ORCHESTRA_POSTGRES_DB=orchestra

--- a/deploy/.example.env
+++ b/deploy/.example.env
@@ -1,0 +1,55 @@
+# Production runtime template for deploy/docker-compose.yml.
+# Copy to deploy/orchestra.env, replace every replace-with-* value, and chmod 600.
+# Never commit the copied file. Values in this file are intentionally placeholders.
+
+# Registry and ingress
+ORCHESTRA_IMAGE_TAG=latest
+ORCHESTRA_API_PORT=8000
+ORCHESTRA_APP_ENV=production
+ORCHESTRA_APP_LOG_LEVEL=INFO
+
+# Application signing keys. APP_SECRET_KEY must be a Fernet key; JWT_SECRET_KEY
+# may be generated with: openssl rand -hex 32.
+APP_SECRET_KEY=replace-with-a-fernet-key
+JWT_SECRET_KEY=replace-with-a-random-32-byte-hex-secret
+
+# Base-only mode: replace these with externally managed service URLs.
+# The database-overlay compose file overrides these with Docker service names.
+POSTGRES_CONNECTION_STRING=postgresql://orchestra:replace-with-url-safe-password@db.example.invalid:5432/orchestra
+POSTGRES_CONNECTION_STRING_SESSION=
+REDIS_URL=redis://:replace-with-redis-password@redis.example.invalid:6379/0
+MINIO_HOST=minio.example.invalid:9000
+S3_REGION=us-east-2
+ACCESS_KEY_ID=replace-with-s3-access-key
+ACCESS_SECRET_KEY=replace-with-s3-secret-key
+BUCKET=orchestra
+SEARX_SEARCH_HOST_URL=http://search.example.invalid:8080
+OLLAMA_BASE_URL=
+# Configure this only when an external sandbox service is available.
+SHELL_EXEC_SERVER_URL=
+DISTRIBUTED_WORKERS=true
+
+# Configure at least one model provider.
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GROQ_API_KEY=
+GOOGLE_API_KEY=
+GEMINI_API_KEY=
+XAI_API_KEY=
+AWS_BEARER_TOKEN_BEDROCK=
+AWS_BEDROCK_REGION=us-east-1
+
+# Database overlay credentials. Use URL-safe characters in the Postgres password
+# because the overlay builds a PostgreSQL URL from it.
+ORCHESTRA_POSTGRES_USER=orchestra
+ORCHESTRA_POSTGRES_PASSWORD=replace-with-url-safe-password
+ORCHESTRA_POSTGRES_DB=orchestra
+ORCHESTRA_REDIS_PASSWORD=replace-with-redis-password
+ORCHESTRA_MINIO_ROOT_USER=replace-with-minio-user
+ORCHESTRA_MINIO_ROOT_PASSWORD=replace-with-a-long-minio-password
+ORCHESTRA_MINIO_BUCKET=orchestra
+ORCHESTRA_S3_REGION=us-east-2
+
+# Leave empty unless the Ollama profile is enabled:
+# ORCHESTRA_OLLAMA_BASE_URL=http://ollama:11434
+ORCHESTRA_OLLAMA_BASE_URL=

--- a/deploy/.example.env
+++ b/deploy/.example.env
@@ -8,8 +8,9 @@ ORCHESTRA_API_PORT=8000
 ORCHESTRA_APP_ENV=production
 ORCHESTRA_APP_LOG_LEVEL=INFO
 
-# Application signing keys. APP_SECRET_KEY must be a Fernet key; JWT_SECRET_KEY
-# may be generated with: openssl rand -hex 32.
+# Application signing keys. APP_SECRET_KEY must be a Fernet key; generate it with:
+# openssl rand -base64 32 | tr '+/' '-_' | tr -d '\n'
+# JWT_SECRET_KEY may be generated with: openssl rand -hex 32.
 APP_SECRET_KEY=replace-with-a-fernet-key
 JWT_SECRET_KEY=replace-with-a-random-32-byte-hex-secret
 

--- a/deploy/docker-compose.database.yml
+++ b/deploy/docker-compose.database.yml
@@ -1,0 +1,157 @@
+name: orchestra-production
+
+services:
+  api:
+    environment:
+      POSTGRES_CONNECTION_STRING: ${ORCHESTRA_POSTGRES_CONNECTION_STRING:-postgresql://${ORCHESTRA_POSTGRES_USER:-orchestra}:${ORCHESTRA_POSTGRES_PASSWORD}@postgres:5432/${ORCHESTRA_POSTGRES_DB:-orchestra}}
+      POSTGRES_CONNECTION_STRING_SESSION: ${ORCHESTRA_POSTGRES_CONNECTION_STRING_SESSION:-postgresql://${ORCHESTRA_POSTGRES_USER:-orchestra}:${ORCHESTRA_POSTGRES_PASSWORD}@postgres:5432/${ORCHESTRA_POSTGRES_DB:-orchestra}}
+      REDIS_URL: ${ORCHESTRA_REDIS_URL:-redis://:${ORCHESTRA_REDIS_PASSWORD}@redis:6379/0}
+      MINIO_HOST: minio:9000
+      S3_REGION: ${ORCHESTRA_S3_REGION:-us-east-1}
+      ACCESS_KEY_ID: ${ORCHESTRA_MINIO_ROOT_USER:?ORCHESTRA_MINIO_ROOT_USER must be set}
+      ACCESS_SECRET_KEY: ${ORCHESTRA_MINIO_ROOT_PASSWORD:?ORCHESTRA_MINIO_ROOT_PASSWORD must be set}
+      BUCKET: ${ORCHESTRA_MINIO_BUCKET:-orchestra}
+      SEARX_SEARCH_HOST_URL: http://search_engine:8080
+      OLLAMA_BASE_URL: ${ORCHESTRA_OLLAMA_BASE_URL:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio_init:
+        condition: service_completed_successfully
+      search_engine:
+        condition: service_healthy
+
+  worker:
+    environment:
+      POSTGRES_CONNECTION_STRING: ${ORCHESTRA_POSTGRES_CONNECTION_STRING:-postgresql://${ORCHESTRA_POSTGRES_USER:-orchestra}:${ORCHESTRA_POSTGRES_PASSWORD}@postgres:5432/${ORCHESTRA_POSTGRES_DB:-orchestra}}
+      POSTGRES_CONNECTION_STRING_SESSION: ${ORCHESTRA_POSTGRES_CONNECTION_STRING_SESSION:-postgresql://${ORCHESTRA_POSTGRES_USER:-orchestra}:${ORCHESTRA_POSTGRES_PASSWORD}@postgres:5432/${ORCHESTRA_POSTGRES_DB:-orchestra}}
+      REDIS_URL: ${ORCHESTRA_REDIS_URL:-redis://:${ORCHESTRA_REDIS_PASSWORD}@redis:6379/0}
+      MINIO_HOST: minio:9000
+      S3_REGION: ${ORCHESTRA_S3_REGION:-us-east-1}
+      ACCESS_KEY_ID: ${ORCHESTRA_MINIO_ROOT_USER:?ORCHESTRA_MINIO_ROOT_USER must be set}
+      ACCESS_SECRET_KEY: ${ORCHESTRA_MINIO_ROOT_PASSWORD:?ORCHESTRA_MINIO_ROOT_PASSWORD must be set}
+      BUCKET: ${ORCHESTRA_MINIO_BUCKET:-orchestra}
+      SEARX_SEARCH_HOST_URL: http://search_engine:8080
+      OLLAMA_BASE_URL: ${ORCHESTRA_OLLAMA_BASE_URL:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio_init:
+        condition: service_completed_successfully
+      search_engine:
+        condition: service_healthy
+
+  postgres:
+    image: pgvector/pgvector:0.8.6-pg16-bookworm
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${ORCHESTRA_POSTGRES_USER:-orchestra}
+      POSTGRES_PASSWORD: ${ORCHESTRA_POSTGRES_PASSWORD:?ORCHESTRA_POSTGRES_PASSWORD must be set}
+      POSTGRES_DB: ${ORCHESTRA_POSTGRES_DB:-orchestra}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  redis:
+    image: redis:7.4.10-alpine3.21
+    restart: unless-stopped
+    environment:
+      REDIS_PASSWORD: ${ORCHESTRA_REDIS_PASSWORD:?ORCHESTRA_REDIS_PASSWORD must be set}
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${ORCHESTRA_REDIS_PASSWORD:?ORCHESTRA_REDIS_PASSWORD must be set}"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${ORCHESTRA_MINIO_ROOT_USER:?ORCHESTRA_MINIO_ROOT_USER must be set}
+      MINIO_ROOT_PASSWORD: ${ORCHESTRA_MINIO_ROOT_PASSWORD:?ORCHESTRA_MINIO_ROOT_PASSWORD must be set}
+    command: ["server", "/data", "--console-address", ":9001"]
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+
+  minio_init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${ORCHESTRA_MINIO_ROOT_USER:?ORCHESTRA_MINIO_ROOT_USER must be set}
+      MINIO_ROOT_PASSWORD: ${ORCHESTRA_MINIO_ROOT_PASSWORD:?ORCHESTRA_MINIO_ROOT_PASSWORD must be set}
+      ORCHESTRA_MINIO_BUCKET: ${ORCHESTRA_MINIO_BUCKET:-orchestra}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        mc alias set orchestra http://minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD"
+        && mc mb --ignore-existing "orchestra/$$ORCHESTRA_MINIO_BUCKET"
+
+  search_engine:
+    image: searxng/searxng:2026.8.5-1689cb1b5
+    restart: unless-stopped
+    environment:
+      SEARXNG_SETTINGS_PATH: /etc/searxng/settings.yml
+    volumes:
+      - searxng_cache:/var/cache/searxng
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=5).read()
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  ollama:
+    image: ollama/ollama:0.32.6
+    profiles: ["ollama"]
+    restart: unless-stopped
+    command: ["serve"]
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 15s
+
+volumes:
+  postgres_data:
+  redis_data:
+  minio_data:
+  searxng_cache:
+  ollama_data:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,86 @@
+name: orchestra-production
+
+services:
+  api:
+    image: ghcr.io/ruska-ai/orchestra-api:${ORCHESTRA_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    init: true
+    env_file:
+      - ./orchestra.env
+    environment:
+      APP_ENV: ${ORCHESTRA_APP_ENV:-production}
+      APP_LOG_LEVEL: ${ORCHESTRA_APP_LOG_LEVEL:-INFO}
+      APP_VERSION: ${ORCHESTRA_IMAGE_TAG:-latest}
+      APP_SECRET_KEY: ${APP_SECRET_KEY:?APP_SECRET_KEY must be set}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set}
+      POSTGRES_CONNECTION_STRING: ${POSTGRES_CONNECTION_STRING:?POSTGRES_CONNECTION_STRING must be set}
+      REDIS_URL: ${REDIS_URL:?REDIS_URL must be set}
+      MINIO_HOST: ${MINIO_HOST:-}
+      S3_REGION: ${S3_REGION:-us-east-2}
+      ACCESS_KEY_ID: ${ACCESS_KEY_ID:-}
+      ACCESS_SECRET_KEY: ${ACCESS_SECRET_KEY:-}
+      BUCKET: ${BUCKET:-orchestra}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      SEARX_SEARCH_HOST_URL: ${SEARX_SEARCH_HOST_URL:-}
+      DISTRIBUTED_WORKERS: "true"
+    ports:
+      - "127.0.0.1:${ORCHESTRA_API_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.urlopen('http://127.0.0.1:8000/api/info/health', timeout=5).read()
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  worker:
+    image: ghcr.io/ruska-ai/orchestra-worker:${ORCHESTRA_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    init: true
+    env_file:
+      - ./orchestra.env
+    environment:
+      APP_ENV: ${ORCHESTRA_APP_ENV:-production}
+      APP_LOG_LEVEL: ${ORCHESTRA_APP_LOG_LEVEL:-INFO}
+      APP_VERSION: ${ORCHESTRA_IMAGE_TAG:-latest}
+      APP_SECRET_KEY: ${APP_SECRET_KEY:?APP_SECRET_KEY must be set}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set}
+      POSTGRES_CONNECTION_STRING: ${POSTGRES_CONNECTION_STRING:?POSTGRES_CONNECTION_STRING must be set}
+      REDIS_URL: ${REDIS_URL:?REDIS_URL must be set}
+      MINIO_HOST: ${MINIO_HOST:-}
+      S3_REGION: ${S3_REGION:-us-east-2}
+      ACCESS_KEY_ID: ${ACCESS_KEY_ID:-}
+      ACCESS_SECRET_KEY: ${ACCESS_SECRET_KEY:-}
+      BUCKET: ${BUCKET:-orchestra}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      SEARX_SEARCH_HOST_URL: ${SEARX_SEARCH_HOST_URL:-}
+      DISTRIBUTED_WORKERS: "true"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - |
+          import os
+          import sys
+
+          found = False
+          for pid in os.listdir('/proc'):
+              if not pid.isdigit():
+                  continue
+              try:
+                  found = 'taskiq' in open('/proc/' + pid + '/cmdline', 'rb').read().decode(errors='ignore')
+              except OSError:
+                  continue
+              if found:
+                  break
+          sys.exit(not found)
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/deploy/searxng/settings.example.yml
+++ b/deploy/searxng/settings.example.yml
@@ -1,0 +1,30 @@
+# Copy this file to settings.yml and replace the placeholder secret before starting SearXNG.
+use_default_settings: true
+
+server:
+  bind_address: 0.0.0.0
+  limiter: true
+  public_instance: false
+  api: true
+  secret_key: "REPLACE_WITH_A_RANDOM_SECRET"
+
+# Keep production diagnostics disabled. The API and JSON format are intentionally enabled
+# for Orchestra's search integration; the service has no published host port in Compose.
+general:
+  debug: false
+
+search:
+  default_lang: en
+  formats:
+    - html
+    - json
+
+engines:
+  - name: wikipedia
+    disabled: true
+  - name: wikipedia (en)
+    disabled: true
+  - name: wikidata
+    disabled: false
+  - name: startpage
+    disabled: false

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -9,16 +9,99 @@ This guide covers environment configuration for self-hosting Orchestra with vari
 
 ## Prerequisites
 
-- Docker and Docker Compose
-- PostgreSQL database
-- (Optional) S3-compatible storage (MinIO)
+For a VM deployment, use Linux with Docker Engine and the Compose v2 plugin, at least
+2 vCPUs and 4 GB RAM, persistent disk for Postgres and MinIO, SSH access, and a DNS
+name with TLS termination. Keep database, Redis, MinIO, SearXNG, and Ollama ports on
+the private Docker network; publish only the loopback-bound API or a reverse proxy.
+
+## Production Docker deployment
+
+The registry-only base stack is `deploy/docker-compose.yml`. It runs only the GHCR
+API and worker images and expects externally managed dependency URLs. Set
+`ORCHESTRA_IMAGE_TAG` to deploy a release tag; it defaults to `latest`. Authenticate
+to GHCR with a token that has `read:packages` before pulling private images:
+
+```bash
+export GHCR_USERNAME=your-github-user
+read -rsp 'GHCR token: ' GHCR_TOKEN; echo
+echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+unset GHCR_TOKEN
+```
+
+Create the ignored runtime file from the tracked production template. Replace all
+`replace-with-*` values, use URL-safe database credentials when the overlay will
+construct a connection URL, and never commit the copied file or provider credentials.
+
+```bash
+cp deploy/.example.env deploy/orchestra.env
+chmod 600 deploy/orchestra.env
+# Edit it with strong signing keys, service URLs, and at least one provider key, then:
+# APP_SECRET_KEY: python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+# JWT_SECRET_KEY: openssl rand -hex 32
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml up -d
+curl --fail "http://$(docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml port api 8000)/api/info/health"
+```
+
+The database stack is an explicit overlay, never an implicit `COMPOSE_FILE`:
+
+```bash
+mkdir -p deploy/searxng
+cp deploy/searxng/settings.example.yml deploy/searxng/settings.yml
+sed -i "s/REPLACE_WITH_A_RANDOM_SECRET/$(openssl rand -hex 32)/" \
+  deploy/searxng/settings.yml
+chmod 600 deploy/searxng/settings.yml
+
+# Replace the overlay credentials from deploy/.example.env in deploy/orchestra.env.
+# The overlay constructs its internal URLs from those ORCHESTRA_* values.
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml up -d
+```
+
+The overlay provides private Postgres with pgvector, Redis, MinIO, and SearXNG with
+persistent named volumes, healthchecks, credentials from environment variables, and
+service-name URLs for API/worker dependencies. An idempotent MinIO initializer creates
+the configured bucket. The tracked SearXNG example enables API/JSON and disables
+debug; the generated `deploy/searxng/settings.yml` is ignored. Production startup
+runs migrations automatically; to run them explicitly without the API entrypoint:
+
+```bash
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  run --rm --no-deps --entrypoint python api -m alembic upgrade head
+```
+
+Ollama is separately gated behind the `ollama` profile, so enabling the database
+overlay does not require GPU support or model downloads. To use local inference, set
+`ORCHESTRA_OLLAMA_BASE_URL=http://ollama:11434` in `deploy/orchestra.env`, then start
+standard `ollama serve` with its persistent volume:
+
+```bash
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  --profile ollama up -d
+# Pull models explicitly when desired:
+docker compose --env-file deploy/orchestra.env \
+  -f deploy/docker-compose.yml -f deploy/docker-compose.database.yml \
+  exec ollama ollama pull llama3.2
+```
+
+For production updates, set an immutable `ORCHESTRA_IMAGE_TAG`, run
+`docker compose ... pull api worker`, then recreate with `docker compose ... up -d --pull always`.
+Check service health and logs with `docker compose ... ps` and `docker compose ...
+logs`. Use `stop`/`start` for pauses and `down` to remove containers while retaining
+named volumes. Avoid `down -v` unless destroying data. Back up and test restores for
+Postgres, MinIO, and runtime settings before VM replacement or volume cleanup.
 
 ## Environment Configuration
 
-Orchestra uses environment variables to configure AI providers. Copy the example environment file and configure your providers:
+Orchestra uses environment variables to configure AI providers. For general
+application development, copy the tracked template to a user-local ignored file:
 
 ```bash
-cp backend/.example.env ~/.env/orchestra/.env.backend
+mkdir -p ~/.config/orchestra
+cp backend/.example.env ~/.config/orchestra/.env
 ```
 
 ### AI Provider Configuration
@@ -171,9 +254,10 @@ make dev
 
 ### Production with Docker
 
-```bash
-docker compose up -d
-```
+Use the production commands in [Production Docker deployment](#production-docker-deployment)
+above. Do not use `docker compose up -d` without explicitly naming the production
+files, and do not use `infra/docker-compose.yml` for a VM deployment; that file is
+the development stack.
 
 ## Verifying Configuration
 

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -36,7 +36,7 @@ construct a connection URL, and never commit the copied file or provider credent
 cp deploy/.example.env deploy/orchestra.env
 chmod 600 deploy/orchestra.env
 # Edit it with strong signing keys, service URLs, and at least one provider key, then:
-# APP_SECRET_KEY: python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+# APP_SECRET_KEY: openssl rand -base64 32 | tr '+/' '-_' | tr -d '\n'
 # JWT_SECRET_KEY: openssl rand -hex 32
 docker compose --env-file deploy/orchestra.env \
   -f deploy/docker-compose.yml up -d


### PR DESCRIPTION
## Summary

- Add a registry-only production Compose base for the GHCR API and worker images.
- Add an explicitly opt-in private dependency overlay for Postgres/pgvector, Redis, MinIO, SearXNG, and profile-gated Ollama.
- Add `deploy/.example.env`, secure SearXNG settings generation, an idempotent MinIO bucket initializer, and VM deployment documentation.

## Deployment behavior

- Base mode starts only `api` and `worker`; dependencies remain externally managed.
- The database overlay is loaded only with both Compose files explicitly named.
- Ollama is not started unless `--profile ollama` is selected.
- API host exposure is loopback-only; dependency services publish no host ports.
- Existing `.github/workflows/deploy-docker.yml`, `.github/workflows/deploy-vm.yml`, and `infra/docker-compose.yml` are unchanged.

## Validation

- Static Compose/YAML assertions: PASS (base service set, overlay/profile service set, no build directives, loopback API binding, private dependency ports, health/dependency conditions, tagged images).
- SearXNG settings template parse and production flags: PASS.
- Python syntax check: PASS.
- `git diff --check`: PASS.
- VM pull/start/health smoke test: not run from this sandbox; the deployment runbook contains the operator commands.
- `pre-commit`: unavailable in the current environment (`pre-commit: command not found`).

Reviewer evidence will be recorded at [`.oh/tasks/980-registry-vm-deploy/evidence.md`](.oh/tasks/980-registry-vm-deploy/evidence.md) after the focused PR audit.

Closes #980
